### PR TITLE
[PPSC-602] fix(security): armisignore size limit and go-git CVE remediation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Post PR comment
         uses: actions/github-script@v8
         with:
+          retries: 3
           script: |
             const fs = require('fs');
             const summary = fs.readFileSync('coverage/coverage.txt', 'utf8');

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/distribution/reference v0.6.0
-	github.com/go-git/go-git/v5 v5.17.0
+	github.com/go-git/go-git/v5 v5.17.2
 	github.com/mattn/go-runewidth v0.0.21
 	github.com/muesli/termenv v0.16.0
 	github.com/schollz/progressbar/v3 v3.19.0

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66D
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.8.0 h1:I8hjc3LbBlXTtVuFNJuwYuMiHvQJDq1AT6u4DwDzZG0=
 github.com/go-git/go-billy/v5 v5.8.0/go.mod h1:RpvI/rw4Vr5QA+Z60c6d6LXH0rYJo0uD5SqfmrrheCY=
-github.com/go-git/go-git/v5 v5.17.0 h1:AbyI4xf+7DsjINHMu35quAh4wJygKBKBuXVjV/pxesM=
-github.com/go-git/go-git/v5 v5.17.0/go.mod h1:f82C4YiLx+Lhi8eHxltLeGC5uBTXSFa6PC5WW9o4SjI=
+github.com/go-git/go-git/v5 v5.17.2 h1:B+nkdlxdYrvyFK4GPXVU8w1U+YkbsgciIR7f2sZJ104=
+github.com/go-git/go-git/v5 v5.17.2/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/scan/repo/ignore.go
+++ b/internal/scan/repo/ignore.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,8 +33,8 @@ func LoadIgnorePatterns(repoRoot string) (*IgnoreMatcher, error) {
 		}
 
 		if !info.IsDir() && info.Name() == ".armisignore" {
-			if info.Size() > maxIgnoreFileSize {
-				return fmt.Errorf(".armisignore file too large (%d bytes, max %d): %s", info.Size(), maxIgnoreFileSize, path)
+			if info.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf(".armisignore is a symlink (rejected): %s", path)
 			}
 			patterns, err := loadIgnoreFile(path, repoRoot)
 			if err != nil {
@@ -57,9 +58,20 @@ func LoadIgnorePatterns(repoRoot string) (*IgnoreMatcher, error) {
 }
 
 func loadIgnoreFile(ignoreFilePath, repoRoot string) ([]gitignore.Pattern, error) {
-	data, err := os.ReadFile(ignoreFilePath) // #nosec G304 - ignore file path is constructed internally
+	f, err := os.Open(ignoreFilePath) // #nosec G304 - ignore file path is constructed internally
 	if err != nil {
 		return nil, err
+	}
+	defer f.Close() //nolint:errcheck // read-only file
+
+	// Read up to maxIgnoreFileSize+1 to detect files exceeding the limit.
+	limited := io.LimitReader(f, maxIgnoreFileSize+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxIgnoreFileSize {
+		return nil, fmt.Errorf(".armisignore file too large (max %d bytes): %s", maxIgnoreFileSize, ignoreFilePath)
 	}
 
 	ignoreDir := filepath.Dir(ignoreFilePath)

--- a/internal/scan/repo/ignore.go
+++ b/internal/scan/repo/ignore.go
@@ -1,12 +1,16 @@
 package repo
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 )
+
+// maxIgnoreFileSize is the maximum allowed size for a .armisignore file (1 MB).
+const maxIgnoreFileSize = 1 << 20
 
 // IgnoreMatcher matches files against ignore patterns.
 type IgnoreMatcher struct {
@@ -28,6 +32,9 @@ func LoadIgnorePatterns(repoRoot string) (*IgnoreMatcher, error) {
 		}
 
 		if !info.IsDir() && info.Name() == ".armisignore" {
+			if info.Size() > maxIgnoreFileSize {
+				return fmt.Errorf(".armisignore file too large (%d bytes, max %d): %s", info.Size(), maxIgnoreFileSize, path)
+			}
 			patterns, err := loadIgnoreFile(path, repoRoot)
 			if err != nil {
 				return err

--- a/internal/scan/repo/ignore_test.go
+++ b/internal/scan/repo/ignore_test.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -95,5 +96,27 @@ func TestLoadIgnorePatternsNested(t *testing.T) {
 
 	if !matcher.Match("subdir/test.tmp", false) {
 		t.Error("Expected nested pattern to match")
+	}
+}
+
+func TestLoadIgnorePatternsOversizedFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	oversized := make([]byte, maxIgnoreFileSize+1)
+	for i := range oversized {
+		oversized[i] = 'a'
+	}
+
+	ignoreFile := filepath.Join(tmpDir, ".armisignore")
+	if err := os.WriteFile(ignoreFile, oversized, 0600); err != nil {
+		t.Fatalf("Failed to create oversized ignore file: %v", err)
+	}
+
+	_, err := LoadIgnorePatterns(tmpDir)
+	if err == nil {
+		t.Fatal("expected error for oversized .armisignore file")
+	}
+	if !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("expected 'too large' error, got: %v", err)
 	}
 }

--- a/internal/scan/repo/ignore_test.go
+++ b/internal/scan/repo/ignore_test.go
@@ -99,6 +99,30 @@ func TestLoadIgnorePatternsNested(t *testing.T) {
 	}
 }
 
+func TestLoadIgnorePatternsSymlinkRejected(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a real file that the symlink will point to.
+	realFile := filepath.Join(tmpDir, "real-ignore")
+	if err := os.WriteFile(realFile, []byte("*.log\n"), 0600); err != nil {
+		t.Fatalf("Failed to create real ignore file: %v", err)
+	}
+
+	// Create a symlink named .armisignore pointing to the real file.
+	symlinkPath := filepath.Join(tmpDir, ".armisignore")
+	if err := os.Symlink(realFile, symlinkPath); err != nil {
+		t.Skipf("Symlink creation not supported: %v", err)
+	}
+
+	_, err := LoadIgnorePatterns(tmpDir)
+	if err == nil {
+		t.Fatal("expected error for symlinked .armisignore file")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected 'symlink' error, got: %v", err)
+	}
+}
+
 func TestLoadIgnorePatternsOversizedFile(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Related Issue

* [PPSC-602](https://armis-security.atlassian.net/browse/PPSC-602)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

After merging PR #135 (security code scanning remediations), GitHub Code Scanning reported 21 new/pre-existing open alerts. Triage revealed:
- 6 were duplicates of previously dismissed alerts (line shifts or overlapping CWEs)
- 13 were false positives (standard CLI patterns, hardcoded paths, read-only ops)
- 2 were true positives requiring fixes

## Solution

**Alert triage (19 of 21 dismissed via GitHub API):**
- 6 duplicates re-dismissed with cross-references to original dismissals
- 13 false positives dismissed with detailed justification comments

**Code fixes for 2 true positives:**
- **CWE-770** (`internal/scan/repo/ignore.go`): Added 1MB size check before `os.ReadFile` on `.armisignore` files to prevent memory exhaustion from maliciously large ignore files
- **CVE-2026-34165** (`go.mod`): Upgraded `go-git/go-git/v5` from v5.17.0 to v5.17.2

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

- `go test ./internal/scan/repo/... -run Ignore` — all 4 tests pass including new oversized file test
- Verified open alert count dropped from 21 to 2 (these 2 will auto-close when this PR merges)

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-602]: https://armis-security.atlassian.net/browse/PPSC-602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ