### PR TITLE
[PPSC-678] fix: graceful degradation when result fetching fails

### DIFF
--- a/cmd/armis-cli/main.go
+++ b/cmd/armis-cli/main.go
@@ -32,6 +32,13 @@ func main() {
 			cmd.PrintUpdateNotification()
 			os.Exit(findingsErr.ExitCode)
 		}
+		// Handle incomplete results (scan succeeded but results couldn't be fetched)
+		var incompleteErr *output.ErrResultsIncomplete
+		if errors.As(err, &incompleteErr) {
+			cli.PrintWarning(incompleteErr.Error())
+			cmd.PrintUpdateNotification()
+			os.Exit(2)
+		}
 		// Handle user cancellation (Ctrl+C) cleanly without printing error
 		if errors.Is(err, cmd.ErrScanCancelled) {
 			cmd.PrintUpdateNotification()

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -183,7 +183,7 @@ func NewClient(baseURL string, authProvider AuthHeaderProvider, debug bool, uplo
 		RetryMax:     3,
 		RetryWaitMin: 1 * time.Second,
 		RetryWaitMax: 10 * time.Second,
-		Timeout:      60 * time.Second,
+		Timeout:      180 * time.Second,
 	})
 
 	uploadHTTPClient := httpclient.NewClient(httpclient.Config{

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -183,7 +183,7 @@ func NewClient(baseURL string, authProvider AuthHeaderProvider, debug bool, uplo
 		RetryMax:     3,
 		RetryWaitMin: 1 * time.Second,
 		RetryWaitMax: 10 * time.Second,
-		Timeout:      180 * time.Second,
+		Timeout:      60 * time.Second,
 	})
 
 	uploadHTTPClient := httpclient.NewClient(httpclient.Config{

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -19,6 +19,17 @@ import (
 	"github.com/ArmisSecurity/armis-cli/internal/model"
 )
 
+// APIError represents an HTTP API error with a status code, allowing callers
+// to distinguish retryable (5xx, timeout) from permanent (4xx) errors.
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API error (status %d): %s", e.StatusCode, e.Body)
+}
+
 // DownloadTimeout is the default timeout for downloading files from pre-signed URLs.
 const DownloadTimeout = 5 * time.Minute
 
@@ -536,7 +547,7 @@ func (c *Client) FetchNormalizedResults(ctx context.Context, tenantID, scanID st
 
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, MaxAPIResponseSize))
-		return nil, fmt.Errorf("fetch results failed with status %d: %s", resp.StatusCode, string(bodyBytes))
+		return nil, &APIError{StatusCode: resp.StatusCode, Body: string(bodyBytes)}
 	}
 
 	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, MaxAPIResponseSize))

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -25,6 +25,17 @@ func (e *ErrFindingsExceeded) Error() string {
 	return "findings exceeded threshold"
 }
 
+// ErrResultsIncomplete indicates the scan completed on the server but the CLI
+// failed to retrieve results. This should result in a non-zero exit code so
+// CI pipelines do not silently pass when results are unavailable.
+type ErrResultsIncomplete struct {
+	ScanID string
+}
+
+func (e *ErrResultsIncomplete) Error() string {
+	return fmt.Sprintf("scan completed but results could not be retrieved (scan ID: %s)", e.ScanID)
+}
+
 // FormatOptions contains options for formatting scan results.
 type FormatOptions struct {
 	GroupBy          string

--- a/internal/scan/image/image.go
+++ b/internal/scan/image/image.go
@@ -38,6 +38,7 @@ type Scanner struct {
 	timeout               time.Duration
 	includeNonExploitable bool
 	pollInterval          time.Duration
+	fetchRetryInterval    time.Duration
 	sbomVEXOpts           *scan.SBOMVEXOptions
 	pullPolicy            string // "always", "missing", "never"
 }
@@ -53,12 +54,19 @@ func NewScanner(client *api.Client, noProgress bool, tenantID string, pageLimit 
 		timeout:               timeout,
 		includeNonExploitable: includeNonExploitable,
 		pollInterval:          5 * time.Second,
+		fetchRetryInterval:    10 * time.Second,
 	}
 }
 
 // WithPollInterval sets a custom poll interval for the scanner (used for testing).
 func (s *Scanner) WithPollInterval(d time.Duration) *Scanner {
 	s.pollInterval = d
+	return s
+}
+
+// WithFetchRetryInterval sets a custom retry interval for result fetching (used for testing).
+func (s *Scanner) WithFetchRetryInterval(d time.Duration) *Scanner {
+	s.fetchRetryInterval = d
 	return s
 }
 
@@ -175,9 +183,22 @@ func (s *Scanner) ScanTarball(ctx context.Context, tarballPath string) (*model.S
 		styles.MutedText.Render("Scan completed in"),
 		styles.Duration.Render(scan.FormatElapsed(elapsed)))
 
-	findings, err := s.client.FetchAllNormalizedResults(ctx, s.tenantID, scanID, s.pageLimit)
+	var findings []model.NormalizedFinding
+	const maxFetchRetries = 5
+	for attempt := 1; attempt <= maxFetchRetries; attempt++ {
+		findings, err = s.client.FetchAllNormalizedResults(ctx, s.tenantID, scanID, s.pageLimit)
+		if err == nil {
+			break
+		}
+		if attempt < maxFetchRetries {
+			time.Sleep(s.fetchRetryInterval)
+		}
+	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch results: %w", err)
+		cli.PrintWarningf("Failed to retrieve results after %d attempts: %v", maxFetchRetries, err)
+		cli.PrintWarningf("Scan completed successfully. Results are available with scan ID: %s", scanID)
+		result := buildScanResult(scanID, nil, s.client.IsDebug(), s.includeNonExploitable)
+		return result, nil
 	}
 
 	// Handle SBOM/VEX downloads if requested

--- a/internal/scan/image/image.go
+++ b/internal/scan/image/image.go
@@ -4,6 +4,7 @@ package image
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -183,6 +184,9 @@ func (s *Scanner) ScanTarball(ctx context.Context, tarballPath string) (*model.S
 		styles.MutedText.Render("Scan completed in"),
 		styles.Duration.Render(scan.FormatElapsed(elapsed)))
 
+	fetchSpinner := progress.NewSpinnerWithContext(ctx, "Retrieving results...", s.noProgress)
+	fetchSpinner.Start()
+
 	var findings []model.NormalizedFinding
 	const maxFetchRetries = 5
 	for attempt := 1; attempt <= maxFetchRetries; attempt++ {
@@ -190,15 +194,19 @@ func (s *Scanner) ScanTarball(ctx context.Context, tarballPath string) (*model.S
 		if err == nil {
 			break
 		}
+		if !isRetryableError(err) {
+			break
+		}
 		if attempt < maxFetchRetries {
+			fetchSpinner.Update(fmt.Sprintf("Retrieving results (retry %d/%d)...", attempt, maxFetchRetries-1))
 			time.Sleep(s.fetchRetryInterval)
 		}
 	}
+	fetchSpinner.Stop()
 	if err != nil {
-		cli.PrintWarningf("Failed to retrieve results after %d attempts: %v", maxFetchRetries, err)
+		cli.PrintWarningf("Failed to retrieve results: %v", err)
 		cli.PrintWarningf("Scan completed successfully. Results are available with scan ID: %s", scanID)
-		result := buildScanResult(scanID, nil, s.client.IsDebug(), s.includeNonExploitable)
-		return result, nil
+		return nil, &output.ErrResultsIncomplete{ScanID: scanID}
 	}
 
 	// Handle SBOM/VEX downloads if requested
@@ -322,6 +330,16 @@ func determinePullBehavior(policy string, localExists bool) (shouldPull bool, er
 	default:
 		return false, fmt.Errorf("invalid pull policy %q: must be 'always', 'missing', or 'never'", policy)
 	}
+}
+
+// isRetryableError returns true for transient errors (timeouts, network errors,
+// 5xx server errors) and false for permanent errors (4xx, decode failures).
+func isRetryableError(err error) bool {
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode >= 500
+	}
+	return errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err)
 }
 
 func buildScanResult(scanID string, normalizedFindings []model.NormalizedFinding, debug bool, includeNonExploitable bool) *model.ScanResult {

--- a/internal/scan/image/image_test.go
+++ b/internal/scan/image/image_test.go
@@ -742,14 +742,19 @@ func TestScanTarball(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewClient failed: %v", err)
 		}
-		scanner := NewScanner(apiClient, true, "tenant-456", 100, false, 1*time.Minute, false).WithPollInterval(10 * time.Millisecond)
+		scanner := NewScanner(apiClient, true, "tenant-456", 100, false, 1*time.Minute, false).
+			WithPollInterval(10 * time.Millisecond).
+			WithFetchRetryInterval(10 * time.Millisecond)
 
-		_, err = scanner.ScanTarball(context.Background(), tarballPath)
-		if err == nil {
-			t.Error("expected error on fetch results failure")
+		result, err := scanner.ScanTarball(context.Background(), tarballPath)
+		if err != nil {
+			t.Errorf("expected graceful degradation, got error: %v", err)
 		}
-		if !strings.Contains(err.Error(), "failed to fetch results") {
-			t.Errorf("unexpected error message: %v", err)
+		if result == nil {
+			t.Fatal("expected non-nil result on fetch failure with graceful degradation")
+		}
+		if len(result.Findings) != 0 {
+			t.Errorf("expected zero findings on fetch failure, got %d", len(result.Findings))
 		}
 	})
 

--- a/internal/scan/image/image_test.go
+++ b/internal/scan/image/image_test.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"github.com/ArmisSecurity/armis-cli/internal/api"
 	"github.com/ArmisSecurity/armis-cli/internal/httpclient"
 	"github.com/ArmisSecurity/armis-cli/internal/model"
+	"github.com/ArmisSecurity/armis-cli/internal/output"
 	"github.com/ArmisSecurity/armis-cli/internal/scan/testhelpers"
 	"github.com/ArmisSecurity/armis-cli/internal/testutil"
 )
@@ -746,15 +748,13 @@ func TestScanTarball(t *testing.T) {
 			WithPollInterval(10 * time.Millisecond).
 			WithFetchRetryInterval(10 * time.Millisecond)
 
-		result, err := scanner.ScanTarball(context.Background(), tarballPath)
-		if err != nil {
-			t.Errorf("expected graceful degradation, got error: %v", err)
+		_, err = scanner.ScanTarball(context.Background(), tarballPath)
+		if err == nil {
+			t.Fatal("expected ErrResultsIncomplete error")
 		}
-		if result == nil {
-			t.Fatal("expected non-nil result on fetch failure with graceful degradation")
-		}
-		if len(result.Findings) != 0 {
-			t.Errorf("expected zero findings on fetch failure, got %d", len(result.Findings))
+		var incompleteErr *output.ErrResultsIncomplete
+		if !errors.As(err, &incompleteErr) {
+			t.Errorf("expected ErrResultsIncomplete, got: %T: %v", err, err)
 		}
 	})
 

--- a/internal/scan/repo/repo.go
+++ b/internal/scan/repo/repo.go
@@ -234,6 +234,9 @@ func (s *Scanner) Scan(ctx context.Context, path string) (*model.ScanResult, err
 		if err == nil {
 			break
 		}
+		if !isRetryableError(err) {
+			break
+		}
 		if attempt < maxFetchRetries {
 			fetchSpinner.Update(fmt.Sprintf("Retrieving results (retry %d/%d)...", attempt, maxFetchRetries-1))
 			time.Sleep(s.fetchRetryInterval)
@@ -241,10 +244,9 @@ func (s *Scanner) Scan(ctx context.Context, path string) (*model.ScanResult, err
 	}
 	if err != nil {
 		fetchSpinner.Stop()
-		cli.PrintWarningf("Failed to retrieve results after %d attempts: %v", maxFetchRetries, err)
+		cli.PrintWarningf("Failed to retrieve results: %v", err)
 		cli.PrintWarningf("Scan completed successfully. Results are available with scan ID: %s", scanID)
-		result := buildScanResult(scanID, nil, s.client.IsDebug(), s.includeNonExploitable)
-		return result, nil
+		return nil, &output.ErrResultsIncomplete{ScanID: scanID}
 	}
 
 	fetchSpinner.Stop()
@@ -594,6 +596,17 @@ func isTestFile(name string) bool {
 	}
 
 	return false
+}
+
+// isRetryableError returns true for transient errors (timeouts, network errors,
+// 5xx server errors) and false for permanent errors (4xx, decode failures).
+func isRetryableError(err error) bool {
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode >= 500
+	}
+	// Timeout and network errors are retryable
+	return errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err)
 }
 
 func buildScanResult(scanID string, normalizedFindings []model.NormalizedFinding, debug bool, includeNonExploitable bool) *model.ScanResult {

--- a/internal/scan/repo/repo.go
+++ b/internal/scan/repo/repo.go
@@ -37,6 +37,7 @@ type Scanner struct {
 	timeout               time.Duration
 	includeNonExploitable bool
 	pollInterval          time.Duration
+	fetchRetryInterval    time.Duration
 	includeFiles          *FileList
 	sbomVEXOpts           *scan.SBOMVEXOptions
 }
@@ -52,12 +53,19 @@ func NewScanner(client *api.Client, noProgress bool, tenantID string, pageLimit 
 		timeout:               timeout,
 		includeNonExploitable: includeNonExploitable,
 		pollInterval:          5 * time.Second,
+		fetchRetryInterval:    10 * time.Second,
 	}
 }
 
 // WithPollInterval sets a custom poll interval for the scanner (used for testing).
 func (s *Scanner) WithPollInterval(d time.Duration) *Scanner {
 	s.pollInterval = d
+	return s
+}
+
+// WithFetchRetryInterval sets a custom retry interval for result fetching (used for testing).
+func (s *Scanner) WithFetchRetryInterval(d time.Duration) *Scanner {
+	s.fetchRetryInterval = d
 	return s
 }
 
@@ -219,9 +227,24 @@ func (s *Scanner) Scan(ctx context.Context, path string) (*model.ScanResult, err
 	fetchSpinner.Start()
 	defer fetchSpinner.Stop()
 
-	findings, err := s.client.FetchAllNormalizedResults(ctx, s.tenantID, scanID, s.pageLimit)
+	var findings []model.NormalizedFinding
+	const maxFetchRetries = 5
+	for attempt := 1; attempt <= maxFetchRetries; attempt++ {
+		findings, err = s.client.FetchAllNormalizedResults(ctx, s.tenantID, scanID, s.pageLimit)
+		if err == nil {
+			break
+		}
+		if attempt < maxFetchRetries {
+			fetchSpinner.Update(fmt.Sprintf("Retrieving results (retry %d/%d)...", attempt, maxFetchRetries-1))
+			time.Sleep(s.fetchRetryInterval)
+		}
+	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch results: %w", err)
+		fetchSpinner.Stop()
+		cli.PrintWarningf("Failed to retrieve results after %d attempts: %v", maxFetchRetries, err)
+		cli.PrintWarningf("Scan completed successfully. Results are available with scan ID: %s", scanID)
+		result := buildScanResult(scanID, nil, s.client.IsDebug(), s.includeNonExploitable)
+		return result, nil
 	}
 
 	fetchSpinner.Stop()

--- a/internal/scan/repo/repo_test.go
+++ b/internal/scan/repo/repo_test.go
@@ -23,13 +23,14 @@ import (
 	"github.com/ArmisSecurity/armis-cli/internal/testutil"
 )
 
+const testScanID = "scan-123"
 const testSQLInjectionDescription = "SQL Injection vulnerability"
 
 func TestBuildScanResult(t *testing.T) {
 	t.Run("empty findings", func(t *testing.T) {
-		result := buildScanResult("scan-123", []model.NormalizedFinding{}, false, true)
+		result := buildScanResult(testScanID, []model.NormalizedFinding{}, false, true)
 
-		if result.ScanID != "scan-123" {
+		if result.ScanID != testScanID {
 			t.Errorf("ScanID = %s, want scan-123", result.ScanID)
 		}
 		if result.Status != "completed" {
@@ -1312,7 +1313,7 @@ func TestScan(t *testing.T) {
 			case strings.Contains(r.URL.Path, "/api/v1/ingest/tar"):
 				// StartIngest
 				response := model.IngestUploadResponse{
-					ScanID:       "scan-123",
+					ScanID:       testScanID,
 					ArtifactType: "repo",
 					TenantID:     "tenant-456",
 					Filename:     "test-repo.tar.gz",
@@ -1325,7 +1326,7 @@ func TestScan(t *testing.T) {
 				response := model.IngestStatusResponse{
 					Data: []model.IngestStatusData{
 						{
-							ScanID:     "scan-123",
+							ScanID:     testScanID,
 							ScanStatus: "completed",
 						},
 					},
@@ -1339,7 +1340,7 @@ func TestScan(t *testing.T) {
 						TenantID: "tenant-456",
 						ScanResults: []model.ScanResultData{
 							{
-								ScanID: "scan-123",
+								ScanID: testScanID,
 								Findings: []model.NormalizedFinding{
 									{
 										NormalizedTask: model.NormalizedTask{
@@ -1384,7 +1385,7 @@ func TestScan(t *testing.T) {
 		}
 
 		// Verify result
-		if result.ScanID != "scan-123" {
+		if result.ScanID != testScanID {
 			t.Errorf("ScanID = %s, want scan-123", result.ScanID)
 		}
 		if result.Status != "completed" {
@@ -1472,7 +1473,7 @@ func TestScan(t *testing.T) {
 		server := testutil.NewTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 			// Delay to ensure context cancellation takes effect
 			time.Sleep(100 * time.Millisecond)
-			testutil.JSONResponse(t, w, http.StatusOK, model.IngestUploadResponse{ScanID: "scan-123"})
+			testutil.JSONResponse(t, w, http.StatusOK, model.IngestUploadResponse{ScanID: testScanID})
 		})
 
 		httpClient := httpclient.NewClient(httpclient.Config{Timeout: 5 * time.Second})
@@ -1500,11 +1501,11 @@ func TestScan(t *testing.T) {
 		server := testutil.NewTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 			switch {
 			case strings.Contains(r.URL.Path, "/api/v1/ingest/tar"):
-				response := model.IngestUploadResponse{ScanID: "scan-123"}
+				response := model.IngestUploadResponse{ScanID: testScanID}
 				testutil.JSONResponse(t, w, http.StatusOK, response)
 			case strings.Contains(r.URL.Path, "/api/v1/ingest/status"):
 				response := model.IngestStatusResponse{
-					Data: []model.IngestStatusData{{ScanID: "scan-123", ScanStatus: "completed"}},
+					Data: []model.IngestStatusData{{ScanID: testScanID, ScanStatus: "completed"}},
 				}
 				testutil.JSONResponse(t, w, http.StatusOK, response)
 			case strings.Contains(r.URL.Path, "/api/v1/ingest/normalized-results"):
@@ -1529,7 +1530,7 @@ func TestScan(t *testing.T) {
 		if !errors.As(err, &incompleteErr) {
 			t.Errorf("expected ErrResultsIncomplete, got: %T: %v", err, err)
 		}
-		if incompleteErr.ScanID != "scan-123" {
+		if incompleteErr.ScanID != testScanID {
 			t.Errorf("ScanID = %s, want scan-123", incompleteErr.ScanID)
 		}
 	})

--- a/internal/scan/repo/repo_test.go
+++ b/internal/scan/repo/repo_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ArmisSecurity/armis-cli/internal/api"
 	"github.com/ArmisSecurity/armis-cli/internal/httpclient"
 	"github.com/ArmisSecurity/armis-cli/internal/model"
+	"github.com/ArmisSecurity/armis-cli/internal/output"
 	"github.com/ArmisSecurity/armis-cli/internal/scan/testhelpers"
 	"github.com/ArmisSecurity/armis-cli/internal/testutil"
 )
@@ -1487,6 +1488,49 @@ func TestScan(t *testing.T) {
 		_, err = scanner.Scan(ctx, tmpDir)
 		if err == nil {
 			t.Error("expected error when context is cancelled")
+		}
+	})
+
+	t.Run("returns ErrResultsIncomplete on fetch failure", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main"), 0600); err != nil {
+			t.Fatalf("failed to create main.go: %v", err)
+		}
+
+		server := testutil.NewTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.Contains(r.URL.Path, "/api/v1/ingest/tar"):
+				response := model.IngestUploadResponse{ScanID: "scan-123"}
+				testutil.JSONResponse(t, w, http.StatusOK, response)
+			case strings.Contains(r.URL.Path, "/api/v1/ingest/status"):
+				response := model.IngestStatusResponse{
+					Data: []model.IngestStatusData{{ScanID: "scan-123", ScanStatus: "completed"}},
+				}
+				testutil.JSONResponse(t, w, http.StatusOK, response)
+			case strings.Contains(r.URL.Path, "/api/v1/ingest/normalized-results"):
+				testutil.ErrorResponse(w, http.StatusInternalServerError, "Failed to fetch results")
+			}
+		})
+
+		httpClient := httpclient.NewClient(httpclient.Config{Timeout: 5 * time.Second, RetryMax: 1, RetryWaitMin: 10 * time.Millisecond, RetryWaitMax: 50 * time.Millisecond})
+		apiClient, err := api.NewClient(server.URL, testutil.NewTestAuthProvider("token123"), false, 1*time.Minute, api.WithHTTPClient(httpClient))
+		if err != nil {
+			t.Fatalf("NewClient failed: %v", err)
+		}
+		scanner := NewScanner(apiClient, true, "tenant-456", 100, true, 1*time.Minute, false).
+			WithPollInterval(10 * time.Millisecond).
+			WithFetchRetryInterval(10 * time.Millisecond)
+
+		_, err = scanner.Scan(context.Background(), tmpDir)
+		if err == nil {
+			t.Fatal("expected ErrResultsIncomplete error")
+		}
+		var incompleteErr *output.ErrResultsIncomplete
+		if !errors.As(err, &incompleteErr) {
+			t.Errorf("expected ErrResultsIncomplete, got: %T: %v", err, err)
+		}
+		if incompleteErr.ScanID != "scan-123" {
+			t.Errorf("ScanID = %s, want scan-123", incompleteErr.ScanID)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Instead of failing the entire scan when normalized result retrieval times out, retry up to 5 times with 10s intervals (transient errors only)
- If all retries fail, exit with code 2 (not 0) and print scan ID so users can retrieve results later
- Applied to both repo and image scan paths

## Problem
The CLI reported "scan failed" (exit 1) when the `/api/v1/ingest/normalized-results` HTTP request timed out, even though the scan completed successfully on the server. The scan ID was lost in the error, leaving users with no way to retrieve their results. In CI, this was indistinguishable from an actual scan failure.

This is distinct from slow scans (e.g., due to Cerebras LLM latency in the AI verifier). Slow server-side processing is handled correctly by the polling loop in `WaitForIngest`, which polls every 5s for up to 60 minutes. The failure only occurred in the result-fetching phase *after* the scan was already marked `COMPLETED`.

## Solution
1. **Retry with error discrimination**: Retry result fetching up to 5 times with 10s intervals, but only for transient errors (5xx, timeouts, network errors). Permanent errors (4xx, decode failures) fail immediately. Each attempt also has 3 internal HTTP retries with 60s timeout, giving ~15 min total window for transient issues.

2. **Non-zero exit code**: On total failure, return `ErrResultsIncomplete` (exit code 2) instead of nil (exit 0). CI pipelines will not silently pass when results are unavailable. Exit codes: 0 = success, 1 = findings exceeded `--fail-on` threshold, 2 = results incomplete, 130 = cancelled.

3. **User feedback**: Print warnings with the scan ID so users can retrieve results later. Both repo and image scans show retry progress via spinner.

## Changes
- `internal/api/client.go`: Added `APIError` type for structured HTTP status code checks
- `internal/output/output.go`: Added `ErrResultsIncomplete` error type
- `cmd/armis-cli/main.go`: Handle `ErrResultsIncomplete` with exit code 2
- `internal/scan/repo/repo.go`: Retry loop with error discrimination and graceful degradation
- `internal/scan/image/image.go`: Same retry logic + spinner feedback (was missing)
- Tests updated for both repo and image scanners

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go test ./internal/scan/repo/...` passes (new test for ErrResultsIncomplete)
- [x] `go test ./internal/scan/image/...` passes (updated test)
- [x] `go test ./internal/api/...` passes
- [x] `go test ./internal/output/...` passes
- [x] Security scan — no new findings
- [ ] Manual test: run a scan against MooseProd and verify exit code 2 on timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)