### PR TITLE
[PPSC-719] fix(security): upgrade go-git to v5.18.0 (CVE-2026-41506)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/distribution/reference v0.6.0
-	github.com/go-git/go-git/v5 v5.17.2
+	github.com/go-git/go-git/v5 v5.18.0
 	github.com/mattn/go-runewidth v0.0.21
 	github.com/muesli/termenv v0.16.0
 	github.com/schollz/progressbar/v3 v3.19.0

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66D
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.8.0 h1:I8hjc3LbBlXTtVuFNJuwYuMiHvQJDq1AT6u4DwDzZG0=
 github.com/go-git/go-billy/v5 v5.8.0/go.mod h1:RpvI/rw4Vr5QA+Z60c6d6LXH0rYJo0uD5SqfmrrheCY=
-github.com/go-git/go-git/v5 v5.17.2 h1:B+nkdlxdYrvyFK4GPXVU8w1U+YkbsgciIR7f2sZJ104=
-github.com/go-git/go-git/v5 v5.17.2/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
+github.com/go-git/go-git/v5 v5.18.0 h1:O831KI+0PR51hM2kep6T8k+w0/LIAD490gvqMCvL5hM=
+github.com/go-git/go-git/v5 v5.18.0/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=


### PR DESCRIPTION
## Related Issue

* [PPSC-719](https://armis-security.atlassian.net/browse/PPSC-719)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

go-git v5.17.2 has CVE-2026-41506 (GHSA-3xc5-wrhm-f963): credential leak via cross-host redirect in smart HTTP transport. Additionally, 13 false positive code scanning alerts were cluttering the security dashboard despite having proper mitigations already in place.

## Solution

- Upgraded `github.com/go-git/go-git/v5` from v5.17.2 to v5.18.0 (patched version)
- Dismissed 13 false positive alerts via GitHub API with explanatory comments documenting the existing mitigations (CWE-522 x5, CWE-562 x1, CWE-770 x3, CWE-426 x2, CWE-73 x1, CWE-22 x1)

Note: The vulnerability is in go-git's HTTP transport layer which we don't use (only `plumbing/format/gitignore` is imported), but upgrading is best practice.

## Testing

### Automated Tests

* [ ] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

- `go build ./...` passes
- `go test ./internal/scan/repo/...` passes (exercises the gitignore package from go-git)
- Verified 13 alerts dismissed and only 1 remains (alert #1141, auto-resolves on next scan after merge)

## Reviewer Notes

This is a minimal dependency bump (go.mod + go.sum only). The 13 dismissed alerts each have a detailed comment explaining why the existing code mitigations make them false positives. See the [code scanning alerts page](https://github.com/ArmisSecurity/armis-cli/security/code-scanning) for the dismissal comments.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-719]: https://armis-security.atlassian.net/browse/PPSC-719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ