### PR TITLE
[PPSC-711] fix(ci): upgrade cosign-installer to v4 to fix release pip…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,9 +70,7 @@ jobs:
         uses: anchore/sbom-action/download-syft@v0.24.0
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
-        with:
-          cosign-release: "v2.6.3"
+        uses: sigstore/cosign-installer@v4
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7


### PR DESCRIPTION
…eline

The v3 action's hardcoded bootstrap binary (v2.5.2) was delisted from GitHub releases, causing a 404 during the cosign install step. Upgrading to v4 uses an updated bootstrap and installs the action's tested default cosign version.

## Related Issue

<!-- Link to Jira ticket or GitHub issue. Delete the one you don't use. -->

* [PPSC-XXXX](https://your-jira.atlassian.net/browse/PPSC-XXXX)
* Fixes #XXX

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Refactoring (no functional changes)
* [ ] Performance improvement

## Problem

<!-- What problem does this PR solve? Why is this change needed? -->

## Solution

<!-- How does this PR solve the problem? What approach did you take? -->

## Testing

### Automated Tests

* [ ] Unit tests added/updated
* [ ] Integration tests added/updated
* [ ] All tests passing locally

### Manual Testing

<!-- How did you verify this works? Steps to reproduce -->

## Reviewer Notes

<!-- Anything specific reviewers should focus on? -->
<!-- Any trade-offs, technical debt, or follow-up work? -->

## Checklist

* [ ] Code follows project style guidelines
* [ ] Pre-commit hooks pass
* [ ] Self-review performed
* [ ] Documentation updated (if needed)
* [ ] Breaking changes documented (if applicable)
* [ ] No new warnings generated

## Screenshots (if applicable)

<!-- Add screenshots to help explain visual changes -->
