### PR TITLE
[PPSC-697] feat: agent discovery

### DIFF
--- a/internal/agentdetect/agent.go
+++ b/internal/agentdetect/agent.go
@@ -1,0 +1,46 @@
+package agentdetect
+
+// AgentName is a typed string for agent identifiers.
+type AgentName string
+
+const (
+	AgentClaudeCode        AgentName = "ClaudeCode"
+	AgentWindsurf          AgentName = "Windsurf"
+	AgentGoogleAntigravity AgentName = "GoogleAntigravity"
+	AgentGitHubCopilot     AgentName = "GitHubCopilot"
+	AgentCursor            AgentName = "Cursor"
+	AgentCline             AgentName = "Cline"
+	AgentRooCode           AgentName = "RooCode"
+	AgentAider             AgentName = "Aider"
+	AgentDevin             AgentName = "Devin"
+	AgentOpenHands         AgentName = "OpenHands"
+	AgentAmazonQ           AgentName = "AmazonQ"
+	AgentJunie             AgentName = "Junie"
+)
+
+// AgentDetector detects the presence of a coding agent for a given user home directory.
+// resolvedHome is the symlink-resolved, canonical path for homeDir (resolved once by Scanner).
+type AgentDetector interface {
+	Name() AgentName
+	Detect(resolvedHome, homeDir string, platform Platform) bool
+	CheckMCP(resolvedHome, homeDir string, platform Platform) bool
+	DetectVersion(resolvedHome, homeDir string, platform Platform) string
+}
+
+// Registry returns all registered agent detectors.
+func Registry() []AgentDetector {
+	return []AgentDetector{
+		&claudeCodeDetector{},
+		&windsurfDetector{},
+		&antigravityDetector{},
+		&copilotDetector{},
+		&cursorDetector{},
+		&clineDetector{},
+		&rooCodeDetector{},
+		&aiderDetector{},
+		&devinDetector{},
+		&openHandsDetector{},
+		&amazonQDetector{},
+		&junieDetector{},
+	}
+}

--- a/internal/agentdetect/agent.go
+++ b/internal/agentdetect/agent.go
@@ -16,6 +16,9 @@ const (
 	AgentOpenHands         AgentName = "OpenHands"
 	AgentAmazonQ           AgentName = "AmazonQ"
 	AgentJunie             AgentName = "Junie"
+	AgentZed               AgentName = "Zed"
+	AgentContinue          AgentName = "Continue"
+	AgentGeminiCLI         AgentName = "GeminiCLI"
 )
 
 // AgentDetector detects the presence of a coding agent for a given user home directory.
@@ -42,5 +45,8 @@ func Registry() []AgentDetector {
 		&openHandsDetector{},
 		&amazonQDetector{},
 		&junieDetector{},
+		&zedDetector{},
+		&continueDetector{},
+		&geminiCLIDetector{},
 	}
 }

--- a/internal/agentdetect/agentdetect.go
+++ b/internal/agentdetect/agentdetect.go
@@ -3,6 +3,7 @@ package agentdetect
 
 import (
 	"fmt"
+	"os"
 )
 
 // DetectedAgent represents a single detected agent for a specific user.
@@ -58,6 +59,7 @@ func (s *Scanner) Scan() (*ScanResult, error) {
 	for _, user := range users {
 		resolvedHome, err := resolvePath(user.HomeDir)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping user %s: %v\n", user.Username, err)
 			continue
 		}
 

--- a/internal/agentdetect/agentdetect.go
+++ b/internal/agentdetect/agentdetect.go
@@ -1,0 +1,83 @@
+// Package agentdetect detects AI coding agents installed on the system.
+package agentdetect
+
+import (
+	"fmt"
+)
+
+// DetectedAgent represents a single detected agent for a specific user.
+type DetectedAgent struct {
+	Name         string `json:"name"`
+	MCPInstalled bool   `json:"mcp_installed"`
+	Version      string `json:"version,omitempty"`
+	User         string `json:"user"`
+}
+
+// UserResult groups detected agents by user.
+type UserResult struct {
+	User   string
+	Agents []DetectedAgent
+}
+
+// ScanResult is the aggregate result of scanning all user profiles.
+type ScanResult struct {
+	Users []UserResult
+}
+
+// FlatResults returns all DetectedAgent entries in a flat slice (for JSON output).
+func (r *ScanResult) FlatResults() []DetectedAgent {
+	var results []DetectedAgent
+	for _, u := range r.Users {
+		results = append(results, u.Agents...)
+	}
+	return results
+}
+
+// Scanner performs agent detection across user profiles.
+type Scanner struct {
+	platform  Platform
+	detectors []AgentDetector
+}
+
+// NewScanner creates a Scanner with the given platform and all registered detectors.
+func NewScanner(platform Platform) *Scanner {
+	return &Scanner{
+		platform:  platform,
+		detectors: Registry(),
+	}
+}
+
+// Scan performs agent detection across all accessible user profiles.
+func (s *Scanner) Scan() (*ScanResult, error) {
+	users, err := s.platform.UserHomeDirs()
+	if err != nil {
+		return nil, fmt.Errorf("enumerating user profiles: %w", err)
+	}
+
+	result := &ScanResult{}
+	for _, user := range users {
+		resolvedHome, err := resolvePath(user.HomeDir)
+		if err != nil {
+			continue
+		}
+
+		userResult := UserResult{User: user.Username}
+		for _, detector := range s.detectors {
+			if !detector.Detect(resolvedHome, user.HomeDir, s.platform) {
+				continue
+			}
+			agent := DetectedAgent{
+				Name:         string(detector.Name()),
+				MCPInstalled: detector.CheckMCP(resolvedHome, user.HomeDir, s.platform),
+				Version:      detector.DetectVersion(resolvedHome, user.HomeDir, s.platform),
+				User:         user.Username,
+			}
+			userResult.Agents = append(userResult.Agents, agent)
+		}
+		if len(userResult.Agents) > 0 {
+			result.Users = append(result.Users, userResult)
+		}
+	}
+
+	return result, nil
+}

--- a/internal/agentdetect/agentdetect_test.go
+++ b/internal/agentdetect/agentdetect_test.go
@@ -1,0 +1,235 @@
+package agentdetect
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func mustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o750); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// resolvedTempDir returns a temp directory with symlinks resolved.
+// On macOS, t.TempDir() returns /var/folders/... which is a symlink to /private/var/folders/...
+func resolvedTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%s): %v", dir, err)
+	}
+	return resolved
+}
+
+func TestScanner_Scan(t *testing.T) {
+	home := t.TempDir()
+	mustMkdirAll(t, filepath.Join(home, ".claude"))
+	mustMkdirAll(t, filepath.Join(home, ".cursor"))
+
+	p := &mockPlatform{
+		users:           []UserHome{{Username: "alice", HomeDir: home}},
+		vsCodeExtDir:    filepath.Join(home, ".vscode", "extensions"),
+		vsCodeConfigDir: filepath.Join(home, ".config", "Code", "User"),
+	}
+
+	scanner := NewScanner(p)
+	result, err := scanner.Scan()
+	if err != nil {
+		t.Fatalf("Scan() error: %v", err)
+	}
+
+	if len(result.Users) != 1 {
+		t.Fatalf("expected 1 user, got %d", len(result.Users))
+	}
+	if result.Users[0].User != "alice" {
+		t.Errorf("expected user alice, got %s", result.Users[0].User)
+	}
+
+	agentNames := make(map[string]bool)
+	for _, a := range result.Users[0].Agents {
+		agentNames[a.Name] = true
+	}
+	if !agentNames["ClaudeCode"] {
+		t.Error("expected ClaudeCode to be detected")
+	}
+	if !agentNames["Cursor"] {
+		t.Error("expected Cursor to be detected")
+	}
+}
+
+func TestScanner_Scan_NoAgents(t *testing.T) {
+	home := t.TempDir()
+	p := &mockPlatform{
+		users:        []UserHome{{Username: "bob", HomeDir: home}},
+		vsCodeExtDir: filepath.Join(home, ".vscode", "extensions"),
+	}
+	scanner := NewScanner(p)
+	result, err := scanner.Scan()
+	if err != nil {
+		t.Fatalf("Scan() error: %v", err)
+	}
+	if len(result.Users) != 0 {
+		t.Errorf("expected 0 users with agents, got %d", len(result.Users))
+	}
+}
+
+func TestScanner_Scan_MultipleUsers(t *testing.T) {
+	home1 := t.TempDir()
+	home2 := t.TempDir()
+	mustMkdirAll(t, filepath.Join(home1, ".claude"))
+	mustMkdirAll(t, filepath.Join(home2, ".cursor"))
+
+	p := &mockPlatform{
+		users: []UserHome{
+			{Username: "alice", HomeDir: home1},
+			{Username: "bob", HomeDir: home2},
+		},
+		vsCodeExtDir:    "/nonexistent",
+		vsCodeConfigDir: "/nonexistent",
+	}
+
+	scanner := NewScanner(p)
+	result, err := scanner.Scan()
+	if err != nil {
+		t.Fatalf("Scan() error: %v", err)
+	}
+	if len(result.Users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(result.Users))
+	}
+}
+
+func TestScanResult_FlatResults(t *testing.T) {
+	result := &ScanResult{
+		Users: []UserResult{
+			{
+				User: "alice",
+				Agents: []DetectedAgent{
+					{Name: "ClaudeCode", User: "alice"},
+					{Name: "Cursor", User: "alice"},
+				},
+			},
+			{
+				User: "bob",
+				Agents: []DetectedAgent{
+					{Name: "Copilot", User: "bob"},
+				},
+			},
+		},
+	}
+	flat := result.FlatResults()
+	if len(flat) != 3 {
+		t.Errorf("expected 3 flat results, got %d", len(flat))
+	}
+}
+
+func TestFormatPlain(t *testing.T) {
+	result := &ScanResult{
+		Users: []UserResult{
+			{
+				User: "John",
+				Agents: []DetectedAgent{
+					{Name: "ClaudeCode", MCPInstalled: true, User: "John"},
+					{Name: "Cursor", MCPInstalled: false, User: "John"},
+				},
+			},
+			{
+				User: "Jack",
+				Agents: []DetectedAgent{
+					{Name: "Copilot", MCPInstalled: false, User: "Jack"},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := FormatPlain(result, &buf); err != nil {
+		t.Fatalf("FormatPlain() error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "user: John") {
+		t.Error("expected 'user: John' in output")
+	}
+	if !strings.Contains(output, "ClaudeCode(MCP:true), Cursor(MCP:false)") {
+		t.Errorf("unexpected agent line, got:\n%s", output)
+	}
+	if !strings.Contains(output, "user: Jack") {
+		t.Error("expected 'user: Jack' in output")
+	}
+	if !strings.Contains(output, "Copilot(MCP:false)") {
+		t.Error("expected 'Copilot(MCP:false)' in output")
+	}
+}
+
+func TestFormatPlain_Empty(t *testing.T) {
+	result := &ScanResult{}
+	var buf bytes.Buffer
+	if err := FormatPlain(result, &buf); err != nil {
+		t.Fatalf("FormatPlain() error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output, got %q", buf.String())
+	}
+}
+
+func TestFormatJSON(t *testing.T) {
+	result := &ScanResult{
+		Users: []UserResult{
+			{
+				User: "John",
+				Agents: []DetectedAgent{
+					{Name: "ClaudeCode", MCPInstalled: true, User: "John"},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := FormatJSON(result, &buf); err != nil {
+		t.Fatalf("FormatJSON() error: %v", err)
+	}
+
+	var agents []DetectedAgent
+	if err := json.Unmarshal(buf.Bytes(), &agents); err != nil {
+		t.Fatalf("invalid JSON output: %v", err)
+	}
+	if len(agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(agents))
+	}
+	if agents[0].Name != "ClaudeCode" {
+		t.Errorf("expected ClaudeCode, got %s", agents[0].Name)
+	}
+	if !agents[0].MCPInstalled {
+		t.Error("expected MCPInstalled to be true")
+	}
+}
+
+func TestFormatJSON_Empty(t *testing.T) {
+	result := &ScanResult{}
+	var buf bytes.Buffer
+	if err := FormatJSON(result, &buf); err != nil {
+		t.Fatalf("FormatJSON() error: %v", err)
+	}
+
+	var agents []DetectedAgent
+	if err := json.Unmarshal(buf.Bytes(), &agents); err != nil {
+		t.Fatalf("invalid JSON output: %v", err)
+	}
+	if len(agents) != 0 {
+		t.Errorf("expected empty array, got %d agents", len(agents))
+	}
+}

--- a/internal/agentdetect/agentdetect_test.go
+++ b/internal/agentdetect/agentdetect_test.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ArmisSecurity/armis-cli/internal/cli"
+	"github.com/ArmisSecurity/armis-cli/internal/output"
 )
 
 func mustMkdirAll(t *testing.T, path string) {
@@ -137,6 +140,9 @@ func TestScanResult_FlatResults(t *testing.T) {
 }
 
 func TestFormatPlain(t *testing.T) {
+	cli.InitColors(cli.ColorModeNever)
+	output.SyncColors()
+
 	result := &ScanResult{
 		Users: []UserResult{
 			{
@@ -176,6 +182,9 @@ func TestFormatPlain(t *testing.T) {
 }
 
 func TestFormatPlain_Empty(t *testing.T) {
+	cli.InitColors(cli.ColorModeNever)
+	output.SyncColors()
+
 	result := &ScanResult{}
 	var buf bytes.Buffer
 	if err := FormatPlain(result, &buf); err != nil {

--- a/internal/agentdetect/detector.go
+++ b/internal/agentdetect/detector.go
@@ -204,7 +204,7 @@ func (d *copilotDetector) Detect(resolvedHome, homeDir string, platform Platform
 
 func (d *copilotDetector) CheckMCP(resolvedHome, homeDir string, platform Platform) bool {
 	mcpPath := filepath.Join(platform.VSCodeUserConfigDir(homeDir), "mcp.json")
-	return HasArmisMCP(resolvedHome, mcpPath)
+	return HasArmisMCP(resolvedHome, mcpPath) || HasArmisMCPInVSCodeFormat(resolvedHome, mcpPath)
 }
 
 func (d *copilotDetector) DetectVersion(resolvedHome, homeDir string, platform Platform) string {
@@ -245,8 +245,10 @@ func (d *clineDetector) Detect(resolvedHome, homeDir string, platform Platform) 
 	return hasExtensionPrefix(resolvedHome, platform.VSCodeExtensionsDir(homeDir), "saoudrizwan.claude-dev")
 }
 
-func (d *clineDetector) CheckMCP(resolvedHome, homeDir string, _ Platform) bool {
-	return HasArmisMCP(resolvedHome, filepath.Join(homeDir, ".cline", "mcp_settings.json"))
+func (d *clineDetector) CheckMCP(resolvedHome, homeDir string, platform Platform) bool {
+	vsCodePath := filepath.Join(platform.VSCodeUserConfigDir(homeDir), "globalStorage",
+		"saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json")
+	return HasArmisMCP(resolvedHome, vsCodePath)
 }
 
 func (d *clineDetector) DetectVersion(resolvedHome, homeDir string, platform Platform) string {

--- a/internal/agentdetect/detector.go
+++ b/internal/agentdetect/detector.go
@@ -19,12 +19,25 @@ func resolvePath(path string) (string, error) {
 
 // isUnderDir checks that target (after symlink resolution) is strictly under resolvedBase.
 // Returns false if the target cannot be resolved (e.g. does not exist).
+// Uses filepath.Rel instead of string prefix to handle case-insensitive paths on Windows.
 func isUnderDir(resolvedBase, target string) bool {
 	resolved, err := resolvePath(target)
 	if err != nil {
 		return false
 	}
-	return strings.HasPrefix(resolved, resolvedBase+string(filepath.Separator))
+
+	baseVol := filepath.VolumeName(resolvedBase)
+	resolvedVol := filepath.VolumeName(resolved)
+	if baseVol != "" && resolvedVol != "" && strings.EqualFold(baseVol, resolvedVol) {
+		resolved = baseVol + strings.TrimPrefix(resolved, resolvedVol)
+	}
+
+	rel, err := filepath.Rel(resolvedBase, resolved)
+	if err != nil {
+		return false
+	}
+
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // dirExists returns true if path exists, is a directory, and resolves under resolvedHome.

--- a/internal/agentdetect/detector.go
+++ b/internal/agentdetect/detector.go
@@ -1,0 +1,372 @@
+package agentdetect
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// resolvePath resolves symlinks and cleans the result.
+// Returns an error if the path does not exist or cannot be resolved.
+func resolvePath(path string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(resolved), nil
+}
+
+// isUnderDir checks that target (after symlink resolution) is strictly under resolvedBase.
+// Returns false if the target cannot be resolved (e.g. does not exist).
+func isUnderDir(resolvedBase, target string) bool {
+	resolved, err := resolvePath(target)
+	if err != nil {
+		return false
+	}
+	return strings.HasPrefix(resolved, resolvedBase+string(filepath.Separator))
+}
+
+// dirExists returns true if path exists, is a directory, and resolves under resolvedHome.
+func dirExists(resolvedHome, path string) bool {
+	if !isUnderDir(resolvedHome, path) {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// fileExists returns true if path exists, is a regular file, and resolves under resolvedHome.
+func fileExists(resolvedHome, path string) bool {
+	if !isUnderDir(resolvedHome, path) {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// hasExtensionPrefix checks if any subdirectory in extDir starts with the given prefix.
+// extDir must resolve under resolvedHome.
+func hasExtensionPrefix(resolvedHome, extDir, prefix string) bool {
+	if !isUnderDir(resolvedHome, extDir) {
+		return false
+	}
+	entries, err := os.ReadDir(extDir)
+	if err != nil {
+		return false
+	}
+	lower := strings.ToLower(prefix)
+	for _, entry := range entries {
+		if entry.IsDir() && strings.HasPrefix(strings.ToLower(entry.Name()), lower) {
+			return true
+		}
+	}
+	return false
+}
+
+// findExtensionVersion looks for a package.json in an extension directory matching the prefix
+// and extracts the version field. extDir must resolve under resolvedHome.
+func findExtensionVersion(resolvedHome, extDir, prefix string) string {
+	if !isUnderDir(resolvedHome, extDir) {
+		return ""
+	}
+	entries, err := os.ReadDir(extDir)
+	if err != nil {
+		return ""
+	}
+	lower := strings.ToLower(prefix)
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(strings.ToLower(entry.Name()), lower) {
+			continue
+		}
+		pkgPath := filepath.Join(extDir, entry.Name(), "package.json")
+		if !isUnderDir(resolvedHome, pkgPath) {
+			continue
+		}
+		return readVersionFromPackageJSON(pkgPath)
+	}
+	return ""
+}
+
+func readVersionFromPackageJSON(path string) string {
+	data, err := os.ReadFile(path) //nolint:gosec // path validated by caller via isUnderDir
+	if err != nil {
+		return ""
+	}
+	var pkg struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return ""
+	}
+	return pkg.Version
+}
+
+// hasJetBrainsPlugin checks JetBrains plugin directories for a plugin matching the prefix.
+func hasJetBrainsPlugin(resolvedHome string, platform Platform, homeDir, prefix string) bool {
+	for _, pluginDir := range platform.JetBrainsPluginDirs(homeDir) {
+		if hasExtensionPrefix(resolvedHome, pluginDir, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Claude Code ---
+
+type claudeCodeDetector struct{}
+
+func (d *claudeCodeDetector) Name() AgentName { return AgentClaudeCode }
+
+func (d *claudeCodeDetector) Detect(resolvedHome, homeDir string, _ Platform) bool {
+	return dirExists(resolvedHome, filepath.Join(homeDir, ".claude")) ||
+		fileExists(resolvedHome, filepath.Join(homeDir, ".claude.json"))
+}
+
+func (d *claudeCodeDetector) CheckMCP(resolvedHome, homeDir string, _ Platform) bool {
+	return HasArmisMCPInClaudeSettings(resolvedHome, filepath.Join(homeDir, ".claude", "settings.json"))
+}
+
+func (d *claudeCodeDetector) DetectVersion(_, _ string, _ Platform) string {
+	return ""
+}
+
+// --- Windsurf ---
+
+type windsurfDetector struct{}
+
+func (d *windsurfDetector) Name() AgentName { return AgentWindsurf }
+
+func (d *windsurfDetector) Detect(resolvedHome, homeDir string, platform Platform) bool {
+	if dirExists(resolvedHome, filepath.Join(homeDir, ".windsurf")) {
+		return true
+	}
+	if hasExtensionPrefix(resolvedHome, platform.VSCodeExtensionsDir(homeDir), "codeium.windsurf") {
+		return true
+	}
+	return hasJetBrainsPlugin(resolvedHome, platform, homeDir, "windsurf")
+}
+
+func (d *windsurfDetector) CheckMCP(resolvedHome, homeDir string, _ Platform) bool {
+	return HasArmisMCP(resolvedHome, filepath.Join(homeDir, ".codeium", "windsurf", "mcp_config.json"))
+}
+
+func (d *windsurfDetector) DetectVersion(resolvedHome, homeDir string, platform Platform) string {
+	return findExtensionVersion(resolvedHome, platform.VSCodeExtensionsDir(homeDir), "codeium.windsurf")
+}
+
+// --- Google Antigravity ---
+
+type antigravityDetector struct{}
+
+func (d *antigravityDetector) Name() AgentName { return AgentGoogleAntigravity }
+
+func (d *antigravityDetector) Detect(resolvedHome, homeDir string, _ Platform) bool {
+	return dirExists(resolvedHome, filepath.Join(homeDir, ".gemini", "antigravity"))
+}
+
+func (d *antigravityDetector) CheckMCP(resolvedHome, homeDir string, _ Platform) bool {
+	return HasArmisMCP(resolvedHome, filepath.Join(homeDir, ".gemini", "antigravity", "mcp_config.json"))
+}
+
+func (d *antigravityDetector) DetectVersion(_, _ string, _ Platform) string {
+	return ""
+}
+
+// --- GitHub Copilot ---
+
+type copilotDetector struct{}
+
+func (d *copilotDetector) Name() AgentName { return AgentGitHubCopilot }
+
+func (d *copilotDetector) Detect(resolvedHome, homeDir string, platform Platform) bool {
+	if hasExtensionPrefix(resolvedHome, platform.VSCodeExtensionsDir(homeDir), "github.copilot") {
+		return true
+	}
+	if hasJetBrainsPlugin(resolvedHome, platform, homeDir, "github-copilot") {
+		return true
+	}
+	return dirExists(resolvedHome, filepath.Join(homeDir, ".config", "github-copilot"))
+}
+
+func (d *copilotDetector) CheckMCP(resolvedHome, homeDir string, platform Platform) bool {
+	mcpPath := filepath.Join(platform.VSCodeUserConfigDir(homeDir), "mcp.json")
+	return HasArmisMCP(resolvedHome, mcpPath)
+}
+
+func (d *copilotDetector) DetectVersion(resolvedHome, homeDir string, platform Platform) string {
+	return findExtensionVersion(resolvedHome, platform.VSCodeExtensionsDir(homeDir), "github.copilot")
+}
+
+// --- Cursor ---
+
+type cursorDetector struct{}
+
+func (d *cursorDetector) Name() AgentName { return AgentCursor }
+
+func (d *cursorDetector) Detect(resolvedHome, homeDir string, platform Platform) bool {
+	if dirExists(resolvedHome, filepath.Join(homeDir, ".cursor")) {
+		return true
+	}
+	return platform.CursorAppExists(homeDir)
+}
+
+func (d *cursorDetector) CheckMCP(resolvedHome, homeDir string, _ Platform) bool {
+	return HasArmisMCP(resolvedHome, filepath.Join(homeDir, ".cursor", "mcp.json"))
+}
+
+func (d *cursorDetector) DetectVersion(_, _ string, _ Platform) string {
+	return ""
+}
+
+// --- Cline ---
+
+type clineDetector struct{}
+
+func (d *clineDetector) Name() AgentName { return AgentCline }
+
+func (d *clineDetector) Detect(resolvedHome, homeDir string, platform Platform) bool {
+	if dirExists(resolvedHome, filepath.Join(homeDir, ".cline")) {
+		return true
+	}
+	return hasExtensionPrefix(resolvedHome, platform.VSCodeExtensionsDir(homeDir), "saoudrizwan.claude-dev")
+}
+
+func (d *clineDetector) CheckMCP(resolvedHome, homeDir string, _ Platform) bool {
+	return HasArmisMCP(resolvedHome, filepath.Join(homeDir, ".cline", "mcp_settings.json"))
+}
+
+func (d *clineDetector) DetectVersion(resolvedHome, homeDir string, platform Platform) string {
+	return findExtensionVersion(resolvedHome, platform.VSCodeExtensionsDir(homeDir), "saoudrizwan.claude-dev")
+}
+
+// --- Roo Code ---
+
+type rooCodeDetector struct{}
+
+func (d *rooCodeDetector) Name() AgentName { return AgentRooCode }
+
+func (d *rooCodeDetector) Detect(resolvedHome, homeDir string, platform Platform) bool {
+	if dirExists(resolvedHome, filepath.Join(homeDir, ".roo-cline")) {
+		return true
+	}
+	return hasExtensionPrefix(resolvedHome, platform.VSCodeExtensionsDir(homeDir), "rooveterinaryinc.roo-cline")
+}
+
+func (d *rooCodeDetector) CheckMCP(resolvedHome, homeDir string, _ Platform) bool {
+	return HasArmisMCP(resolvedHome, filepath.Join(homeDir, ".roo-cline", "mcp_settings.json"))
+}
+
+func (d *rooCodeDetector) DetectVersion(resolvedHome, homeDir string, platform Platform) string {
+	return findExtensionVersion(resolvedHome, platform.VSCodeExtensionsDir(homeDir), "rooveterinaryinc.roo-cline")
+}
+
+// --- Aider ---
+
+type aiderDetector struct{}
+
+func (d *aiderDetector) Name() AgentName { return AgentAider }
+
+func (d *aiderDetector) Detect(resolvedHome, homeDir string, _ Platform) bool {
+	if dirExists(resolvedHome, filepath.Join(homeDir, ".aider")) {
+		return true
+	}
+	return fileExists(resolvedHome, filepath.Join(homeDir, ".aider.conf.yml"))
+}
+
+func (d *aiderDetector) CheckMCP(_, _ string, _ Platform) bool {
+	return false
+}
+
+func (d *aiderDetector) DetectVersion(_, _ string, _ Platform) string {
+	return ""
+}
+
+// --- Devin ---
+
+type devinDetector struct{}
+
+func (d *devinDetector) Name() AgentName { return AgentDevin }
+
+func (d *devinDetector) Detect(resolvedHome, homeDir string, _ Platform) bool {
+	return dirExists(resolvedHome, filepath.Join(homeDir, ".devin"))
+}
+
+func (d *devinDetector) CheckMCP(_, _ string, _ Platform) bool {
+	return false
+}
+
+func (d *devinDetector) DetectVersion(_, _ string, _ Platform) string {
+	return ""
+}
+
+// --- OpenHands ---
+
+type openHandsDetector struct{}
+
+func (d *openHandsDetector) Name() AgentName { return AgentOpenHands }
+
+func (d *openHandsDetector) Detect(resolvedHome, homeDir string, _ Platform) bool {
+	return dirExists(resolvedHome, filepath.Join(homeDir, ".openhands"))
+}
+
+func (d *openHandsDetector) CheckMCP(_, _ string, _ Platform) bool {
+	return false
+}
+
+func (d *openHandsDetector) DetectVersion(_, _ string, _ Platform) string {
+	return ""
+}
+
+// --- Amazon Q ---
+
+type amazonQDetector struct{}
+
+func (d *amazonQDetector) Name() AgentName { return AgentAmazonQ }
+
+func (d *amazonQDetector) Detect(resolvedHome, homeDir string, platform Platform) bool {
+	if dirExists(resolvedHome, filepath.Join(homeDir, ".aws", "amazonq")) {
+		return true
+	}
+	if hasExtensionPrefix(resolvedHome, platform.VSCodeExtensionsDir(homeDir), "amazonwebservices.amazon-q-vscode") {
+		return true
+	}
+	return hasJetBrainsPlugin(resolvedHome, platform, homeDir, "amazon-q")
+}
+
+func (d *amazonQDetector) CheckMCP(_, _ string, _ Platform) bool {
+	return false
+}
+
+func (d *amazonQDetector) DetectVersion(resolvedHome, homeDir string, platform Platform) string {
+	return findExtensionVersion(resolvedHome, platform.VSCodeExtensionsDir(homeDir), "amazonwebservices.amazon-q-vscode")
+}
+
+// --- Junie ---
+
+type junieDetector struct{}
+
+func (d *junieDetector) Name() AgentName { return AgentJunie }
+
+func (d *junieDetector) Detect(resolvedHome, homeDir string, platform Platform) bool {
+	if dirExists(resolvedHome, filepath.Join(homeDir, ".junie")) {
+		return true
+	}
+	if hasJetBrainsPlugin(resolvedHome, platform, homeDir, "junie") {
+		return true
+	}
+	for _, binPath := range platform.JunieBinaryPaths(homeDir) {
+		if _, err := os.Stat(binPath); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *junieDetector) CheckMCP(resolvedHome, homeDir string, _ Platform) bool {
+	return HasArmisMCP(resolvedHome, filepath.Join(homeDir, ".junie", "mcp", "mcp.json"))
+}
+
+func (d *junieDetector) DetectVersion(_, _ string, _ Platform) string {
+	return ""
+}

--- a/internal/agentdetect/detector.go
+++ b/internal/agentdetect/detector.go
@@ -334,8 +334,8 @@ func (d *amazonQDetector) Detect(resolvedHome, homeDir string, platform Platform
 	return hasJetBrainsPlugin(resolvedHome, platform, homeDir, "amazon-q")
 }
 
-func (d *amazonQDetector) CheckMCP(_, _ string, _ Platform) bool {
-	return false
+func (d *amazonQDetector) CheckMCP(resolvedHome, homeDir string, _ Platform) bool {
+	return HasArmisMCP(resolvedHome, filepath.Join(homeDir, ".aws", "amazonq", "mcp.json"))
 }
 
 func (d *amazonQDetector) DetectVersion(resolvedHome, homeDir string, platform Platform) string {
@@ -368,5 +368,80 @@ func (d *junieDetector) CheckMCP(resolvedHome, homeDir string, _ Platform) bool 
 }
 
 func (d *junieDetector) DetectVersion(_, _ string, _ Platform) string {
+	return ""
+}
+
+// --- Zed ---
+
+type zedDetector struct{}
+
+func (d *zedDetector) Name() AgentName { return AgentZed }
+
+func (d *zedDetector) Detect(resolvedHome, homeDir string, platform Platform) bool {
+	zedDir := platform.ZedConfigDir(homeDir)
+	if zedDir == "" {
+		return false
+	}
+	return dirExists(resolvedHome, zedDir)
+}
+
+func (d *zedDetector) CheckMCP(resolvedHome, homeDir string, platform Platform) bool {
+	zedDir := platform.ZedConfigDir(homeDir)
+	if zedDir == "" {
+		return false
+	}
+	return HasArmisMCPInZedSettings(resolvedHome, filepath.Join(zedDir, "settings.json"))
+}
+
+func (d *zedDetector) DetectVersion(_, _ string, _ Platform) string {
+	return ""
+}
+
+// --- Continue ---
+
+type continueDetector struct{}
+
+func (d *continueDetector) Name() AgentName { return AgentContinue }
+
+func (d *continueDetector) Detect(resolvedHome, homeDir string, _ Platform) bool {
+	return dirExists(resolvedHome, filepath.Join(homeDir, ".continue"))
+}
+
+func (d *continueDetector) CheckMCP(resolvedHome, homeDir string, _ Platform) bool {
+	mcpDir := filepath.Join(homeDir, ".continue", "mcpServers")
+	if !isUnderDir(resolvedHome, mcpDir) {
+		return false
+	}
+	entries, err := os.ReadDir(mcpDir)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if strings.Contains(strings.ToLower(entry.Name()), "armis") {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *continueDetector) DetectVersion(_, _ string, _ Platform) string {
+	return ""
+}
+
+// --- Gemini CLI ---
+
+type geminiCLIDetector struct{}
+
+func (d *geminiCLIDetector) Name() AgentName { return AgentGeminiCLI }
+
+func (d *geminiCLIDetector) Detect(resolvedHome, homeDir string, _ Platform) bool {
+	return fileExists(resolvedHome, filepath.Join(homeDir, ".gemini", "settings.json"))
+}
+
+func (d *geminiCLIDetector) CheckMCP(resolvedHome, homeDir string, _ Platform) bool {
+	return HasArmisMCP(resolvedHome, filepath.Join(homeDir, ".gemini", "settings.json"))
+}
+
+func (d *geminiCLIDetector) DetectVersion(_, _ string, _ Platform) string {
 	return ""
 }

--- a/internal/agentdetect/detector.go
+++ b/internal/agentdetect/detector.go
@@ -430,7 +430,10 @@ func (d *continueDetector) CheckMCP(resolvedHome, homeDir string, _ Platform) bo
 		return false
 	}
 	for _, entry := range entries {
-		if strings.Contains(strings.ToLower(entry.Name()), "armis") {
+		if entry.IsDir() || !strings.HasSuffix(strings.ToLower(entry.Name()), ".json") {
+			continue
+		}
+		if HasArmisMCP(resolvedHome, filepath.Join(mcpDir, entry.Name())) {
 			return true
 		}
 	}

--- a/internal/agentdetect/detector_test.go
+++ b/internal/agentdetect/detector_test.go
@@ -17,14 +17,14 @@ type mockPlatform struct {
 	isRoot            bool
 }
 
-func (m *mockPlatform) UserHomeDirs() ([]UserHome, error) { return m.users, nil }
-func (m *mockPlatform) VSCodeExtensionsDir(_ string) string { return m.vsCodeExtDir }
+func (m *mockPlatform) UserHomeDirs() ([]UserHome, error)     { return m.users, nil }
+func (m *mockPlatform) VSCodeExtensionsDir(_ string) string   { return m.vsCodeExtDir }
 func (m *mockPlatform) JetBrainsPluginDirs(_ string) []string { return m.jetBrainsPlugDirs }
-func (m *mockPlatform) VSCodeUserConfigDir(_ string) string { return m.vsCodeConfigDir }
-func (m *mockPlatform) CursorAppExists(_ string) bool { return m.cursorAppExists }
-func (m *mockPlatform) JunieBinaryPaths(_ string) []string { return m.junieBinPaths }
-func (m *mockPlatform) ZedConfigDir(_ string) string { return m.zedConfigDir }
-func (m *mockPlatform) IsRoot() bool { return m.isRoot }
+func (m *mockPlatform) VSCodeUserConfigDir(_ string) string   { return m.vsCodeConfigDir }
+func (m *mockPlatform) CursorAppExists(_ string) bool         { return m.cursorAppExists }
+func (m *mockPlatform) JunieBinaryPaths(_ string) []string    { return m.junieBinPaths }
+func (m *mockPlatform) ZedConfigDir(_ string) string          { return m.zedConfigDir }
+func (m *mockPlatform) IsRoot() bool                          { return m.isRoot }
 
 func newMockPlatform(homeDir string) *mockPlatform {
 	return &mockPlatform{

--- a/internal/agentdetect/detector_test.go
+++ b/internal/agentdetect/detector_test.go
@@ -13,6 +13,7 @@ type mockPlatform struct {
 	vsCodeConfigDir   string
 	cursorAppExists   bool
 	junieBinPaths     []string
+	zedConfigDir      string
 	isRoot            bool
 }
 
@@ -22,6 +23,7 @@ func (m *mockPlatform) JetBrainsPluginDirs(_ string) []string { return m.jetBrai
 func (m *mockPlatform) VSCodeUserConfigDir(_ string) string { return m.vsCodeConfigDir }
 func (m *mockPlatform) CursorAppExists(_ string) bool { return m.cursorAppExists }
 func (m *mockPlatform) JunieBinaryPaths(_ string) []string { return m.junieBinPaths }
+func (m *mockPlatform) ZedConfigDir(_ string) string { return m.zedConfigDir }
 func (m *mockPlatform) IsRoot() bool { return m.isRoot }
 
 func newMockPlatform(homeDir string) *mockPlatform {
@@ -721,6 +723,179 @@ func TestJunieDetector_CheckMCP(t *testing.T) {
 	}
 }
 
+func TestAmazonQDetector_CheckMCP(t *testing.T) {
+	d := &amazonQDetector{}
+	home := resolvedTempDir(t)
+	mcpDir := filepath.Join(home, ".aws", "amazonq")
+	mustMkdirAll(t, mcpDir)
+	mustWriteFile(t, filepath.Join(mcpDir, "mcp.json"),
+		`{"mcpServers":{"armis-appsec":{"command":"python3"}}}`)
+	p := newMockPlatform(home)
+	if !d.CheckMCP(home, home, p) {
+		t.Error("CheckMCP() should return true when armis MCP is configured")
+	}
+}
+
+// --- Zed Detector ---
+
+func TestZedDetector_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, home string, p *mockPlatform)
+		expected bool
+	}{
+		{
+			name: "zed config dir exists",
+			setup: func(t *testing.T, home string, p *mockPlatform) {
+				zedDir := filepath.Join(home, "zed-config")
+				mustMkdirAll(t, zedDir)
+				p.zedConfigDir = zedDir
+			},
+			expected: true,
+		},
+		{
+			name: "zed not supported on platform",
+			setup: func(_ *testing.T, _ string, p *mockPlatform) {
+				p.zedConfigDir = ""
+			},
+			expected: false,
+		},
+		{
+			name:     "nothing exists",
+			setup:    func(_ *testing.T, _ string, _ *mockPlatform) {},
+			expected: false,
+		},
+	}
+
+	d := &zedDetector{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := resolvedTempDir(t)
+			p := newMockPlatform(home)
+			tt.setup(t, home, p)
+			if got := d.Detect(home, home, p); got != tt.expected {
+				t.Errorf("Detect() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestZedDetector_CheckMCP(t *testing.T) {
+	d := &zedDetector{}
+	home := resolvedTempDir(t)
+	zedDir := filepath.Join(home, "zed-config")
+	mustMkdirAll(t, zedDir)
+	mustWriteFile(t, filepath.Join(zedDir, "settings.json"),
+		`{"context_servers":{"armis-appsec-mcp":{"command":{"path":"python3"}}}}`)
+	p := newMockPlatform(home)
+	p.zedConfigDir = zedDir
+	if !d.CheckMCP(home, home, p) {
+		t.Error("CheckMCP() should return true when armis MCP is in context_servers")
+	}
+}
+
+// --- Continue Detector ---
+
+func TestContinueDetector_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, home string)
+		expected bool
+	}{
+		{
+			name: "continue dir exists",
+			setup: func(t *testing.T, home string) {
+				mustMkdirAll(t, filepath.Join(home, ".continue"))
+			},
+			expected: true,
+		},
+		{
+			name:     "nothing exists",
+			setup:    func(_ *testing.T, _ string) {},
+			expected: false,
+		},
+	}
+
+	d := &continueDetector{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := resolvedTempDir(t)
+			tt.setup(t, home)
+			p := newMockPlatform(home)
+			if got := d.Detect(home, home, p); got != tt.expected {
+				t.Errorf("Detect() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestContinueDetector_CheckMCP(t *testing.T) {
+	d := &continueDetector{}
+	home := resolvedTempDir(t)
+	mcpDir := filepath.Join(home, ".continue", "mcpServers")
+	mustMkdirAll(t, mcpDir)
+	mustWriteFile(t, filepath.Join(mcpDir, "armis-appsec.json"), `{"command":"python3"}`)
+	p := newMockPlatform(home)
+	if !d.CheckMCP(home, home, p) {
+		t.Error("CheckMCP() should return true when armis MCP file exists in mcpServers dir")
+	}
+}
+
+// --- Gemini CLI Detector ---
+
+func TestGeminiCLIDetector_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, home string)
+		expected bool
+	}{
+		{
+			name: "gemini settings.json exists",
+			setup: func(t *testing.T, home string) {
+				mustMkdirAll(t, filepath.Join(home, ".gemini"))
+				mustWriteFile(t, filepath.Join(home, ".gemini", "settings.json"), "{}")
+			},
+			expected: true,
+		},
+		{
+			name: "gemini dir exists but no settings.json",
+			setup: func(t *testing.T, home string) {
+				mustMkdirAll(t, filepath.Join(home, ".gemini"))
+			},
+			expected: false,
+		},
+		{
+			name:     "nothing exists",
+			setup:    func(_ *testing.T, _ string) {},
+			expected: false,
+		},
+	}
+
+	d := &geminiCLIDetector{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := resolvedTempDir(t)
+			tt.setup(t, home)
+			p := newMockPlatform(home)
+			if got := d.Detect(home, home, p); got != tt.expected {
+				t.Errorf("Detect() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGeminiCLIDetector_CheckMCP(t *testing.T) {
+	d := &geminiCLIDetector{}
+	home := resolvedTempDir(t)
+	mustMkdirAll(t, filepath.Join(home, ".gemini"))
+	mustWriteFile(t, filepath.Join(home, ".gemini", "settings.json"),
+		`{"mcpServers":{"armis-appsec-mcp":{"command":"npx"}}}`)
+	p := newMockPlatform(home)
+	if !d.CheckMCP(home, home, p) {
+		t.Error("CheckMCP() should return true when armis MCP is configured")
+	}
+}
+
 func TestRegistryReturnsAllAgents(t *testing.T) {
 	registry := Registry()
 	expected := map[AgentName]bool{
@@ -736,6 +911,9 @@ func TestRegistryReturnsAllAgents(t *testing.T) {
 		AgentOpenHands:         false,
 		AgentAmazonQ:           false,
 		AgentJunie:             false,
+		AgentZed:               false,
+		AgentContinue:          false,
+		AgentGeminiCLI:         false,
 	}
 	for _, d := range registry {
 		expected[d.Name()] = true

--- a/internal/agentdetect/detector_test.go
+++ b/internal/agentdetect/detector_test.go
@@ -1,0 +1,847 @@
+package agentdetect
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type mockPlatform struct {
+	users             []UserHome
+	vsCodeExtDir      string
+	jetBrainsPlugDirs []string
+	vsCodeConfigDir   string
+	cursorAppExists   bool
+	junieBinPaths     []string
+	isRoot            bool
+}
+
+func (m *mockPlatform) UserHomeDirs() ([]UserHome, error) { return m.users, nil }
+func (m *mockPlatform) VSCodeExtensionsDir(_ string) string { return m.vsCodeExtDir }
+func (m *mockPlatform) JetBrainsPluginDirs(_ string) []string { return m.jetBrainsPlugDirs }
+func (m *mockPlatform) VSCodeUserConfigDir(_ string) string { return m.vsCodeConfigDir }
+func (m *mockPlatform) CursorAppExists(_ string) bool { return m.cursorAppExists }
+func (m *mockPlatform) JunieBinaryPaths(_ string) []string { return m.junieBinPaths }
+func (m *mockPlatform) IsRoot() bool { return m.isRoot }
+
+func newMockPlatform(homeDir string) *mockPlatform {
+	return &mockPlatform{
+		users:           []UserHome{{Username: "testuser", HomeDir: homeDir}},
+		vsCodeExtDir:    filepath.Join(homeDir, ".vscode", "extensions"),
+		vsCodeConfigDir: filepath.Join(homeDir, ".config", "Code", "User"),
+	}
+}
+
+// --- Claude Code Detector ---
+
+func TestClaudeCodeDetector_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, home string)
+		expected bool
+	}{
+		{
+			name: "claude dir exists",
+			setup: func(t *testing.T, home string) {
+				mustMkdirAll(t, filepath.Join(home, ".claude"))
+			},
+			expected: true,
+		},
+		{
+			name: "claude.json exists",
+			setup: func(t *testing.T, home string) {
+				mustWriteFile(t, filepath.Join(home, ".claude.json"), "{}")
+			},
+			expected: true,
+		},
+		{
+			name:     "nothing exists",
+			setup:    func(_ *testing.T, _ string) {},
+			expected: false,
+		},
+	}
+
+	d := &claudeCodeDetector{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := resolvedTempDir(t)
+			tt.setup(t, home)
+			p := newMockPlatform(home)
+			if got := d.Detect(home, home, p); got != tt.expected {
+				t.Errorf("Detect() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestClaudeCodeDetector_CheckMCP(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{
+			name:     "MCP enabled",
+			content:  `{"mcpServers":{"armis-appsec-mcp":{"command":"npx"}}}`,
+			expected: true,
+		},
+		{
+			name:     "MCP not configured",
+			content:  `{"mcpServers":{}}`,
+			expected: false,
+		},
+	}
+
+	d := &claudeCodeDetector{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := resolvedTempDir(t)
+			settingsDir := filepath.Join(home, ".claude")
+			mustMkdirAll(t, settingsDir)
+			mustWriteFile(t, filepath.Join(settingsDir, "settings.json"), tt.content)
+			p := newMockPlatform(home)
+			if got := d.CheckMCP(home, home, p); got != tt.expected {
+				t.Errorf("CheckMCP() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// --- Windsurf Detector ---
+
+func TestWindsurfDetector_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, home string, p *mockPlatform)
+		expected bool
+	}{
+		{
+			name: "windsurf dir exists",
+			setup: func(t *testing.T, home string, _ *mockPlatform) {
+				mustMkdirAll(t, filepath.Join(home, ".windsurf"))
+			},
+			expected: true,
+		},
+		{
+			name: "vscode extension exists",
+			setup: func(t *testing.T, home string, p *mockPlatform) {
+				extDir := filepath.Join(home, ".vscode", "extensions")
+				mustMkdirAll(t, filepath.Join(extDir, "codeium.windsurf-1.0.0"))
+				p.vsCodeExtDir = extDir
+			},
+			expected: true,
+		},
+		{
+			name:     "nothing exists",
+			setup:    func(_ *testing.T, _ string, _ *mockPlatform) {},
+			expected: false,
+		},
+	}
+
+	d := &windsurfDetector{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := resolvedTempDir(t)
+			p := newMockPlatform(home)
+			tt.setup(t, home, p)
+			if got := d.Detect(home, home, p); got != tt.expected {
+				t.Errorf("Detect() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWindsurfDetector_CheckMCP(t *testing.T) {
+	d := &windsurfDetector{}
+	home := resolvedTempDir(t)
+	mcpDir := filepath.Join(home, ".codeium", "windsurf")
+	mustMkdirAll(t, mcpDir)
+	mustWriteFile(t, filepath.Join(mcpDir, "mcp_config.json"),
+		`{"mcpServers":{"armis-appsec-mcp":{"command":"npx"}}}`)
+	p := newMockPlatform(home)
+	if !d.CheckMCP(home, home, p) {
+		t.Error("CheckMCP() should return true when armis MCP is configured")
+	}
+}
+
+func TestWindsurfDetector_Version(t *testing.T) {
+	d := &windsurfDetector{}
+	home := resolvedTempDir(t)
+	extDir := filepath.Join(home, ".vscode", "extensions", "codeium.windsurf-1.2.3")
+	mustMkdirAll(t, extDir)
+	mustWriteFile(t, filepath.Join(extDir, "package.json"), `{"version":"1.2.3"}`)
+	p := newMockPlatform(home)
+	p.vsCodeExtDir = filepath.Join(home, ".vscode", "extensions")
+	if got := d.DetectVersion(home, home, p); got != "1.2.3" {
+		t.Errorf("DetectVersion() = %q, want %q", got, "1.2.3")
+	}
+}
+
+// --- Google Antigravity Detector ---
+
+func TestAntigravityDetector_Detect(t *testing.T) {
+	d := &antigravityDetector{}
+
+	t.Run("directory exists", func(t *testing.T) {
+		home := resolvedTempDir(t)
+		mustMkdirAll(t, filepath.Join(home, ".gemini", "antigravity"))
+		p := newMockPlatform(home)
+		if !d.Detect(home, home, p) {
+			t.Error("Detect() should return true when .gemini/antigravity exists")
+		}
+	})
+
+	t.Run("directory missing", func(t *testing.T) {
+		home := resolvedTempDir(t)
+		p := newMockPlatform(home)
+		if d.Detect(home, home, p) {
+			t.Error("Detect() should return false when .gemini/antigravity is missing")
+		}
+	})
+}
+
+func TestAntigravityDetector_CheckMCP(t *testing.T) {
+	d := &antigravityDetector{}
+	home := resolvedTempDir(t)
+	mcpDir := filepath.Join(home, ".gemini", "antigravity")
+	mustMkdirAll(t, mcpDir)
+	mustWriteFile(t, filepath.Join(mcpDir, "mcp_config.json"),
+		`{"mcpServers":{"armis-appsec-mcp":{"command":"npx"}}}`)
+	p := newMockPlatform(home)
+	if !d.CheckMCP(home, home, p) {
+		t.Error("CheckMCP() should return true when armis MCP is configured")
+	}
+}
+
+// --- GitHub Copilot Detector ---
+
+func TestCopilotDetector_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, home string, p *mockPlatform)
+		expected bool
+	}{
+		{
+			name: "vscode extension exists",
+			setup: func(t *testing.T, home string, p *mockPlatform) {
+				extDir := filepath.Join(home, ".vscode", "extensions")
+				mustMkdirAll(t, filepath.Join(extDir, "github.copilot-1.0.0"))
+				p.vsCodeExtDir = extDir
+			},
+			expected: true,
+		},
+		{
+			name: "config dir exists",
+			setup: func(t *testing.T, home string, _ *mockPlatform) {
+				mustMkdirAll(t, filepath.Join(home, ".config", "github-copilot"))
+			},
+			expected: true,
+		},
+		{
+			name: "jetbrains plugin exists",
+			setup: func(t *testing.T, home string, p *mockPlatform) {
+				pluginDir := filepath.Join(home, "jb-plugins")
+				mustMkdirAll(t, filepath.Join(pluginDir, "github-copilot-1.0"))
+				p.jetBrainsPlugDirs = []string{pluginDir}
+			},
+			expected: true,
+		},
+		{
+			name:     "nothing exists",
+			setup:    func(_ *testing.T, _ string, _ *mockPlatform) {},
+			expected: false,
+		},
+	}
+
+	d := &copilotDetector{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := resolvedTempDir(t)
+			p := newMockPlatform(home)
+			tt.setup(t, home, p)
+			if got := d.Detect(home, home, p); got != tt.expected {
+				t.Errorf("Detect() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCopilotDetector_CheckMCP(t *testing.T) {
+	d := &copilotDetector{}
+	home := resolvedTempDir(t)
+	configDir := filepath.Join(home, ".config", "Code", "User")
+	mustMkdirAll(t, configDir)
+	mustWriteFile(t, filepath.Join(configDir, "mcp.json"),
+		`{"mcpServers":{"armis-appsec-mcp":{"command":"npx"}}}`)
+	p := newMockPlatform(home)
+	p.vsCodeConfigDir = configDir
+	if !d.CheckMCP(home, home, p) {
+		t.Error("CheckMCP() should return true when armis MCP is configured")
+	}
+}
+
+// --- Cursor Detector ---
+
+func TestCursorDetector_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, home string, p *mockPlatform)
+		expected bool
+	}{
+		{
+			name: "cursor dir exists",
+			setup: func(t *testing.T, home string, _ *mockPlatform) {
+				mustMkdirAll(t, filepath.Join(home, ".cursor"))
+			},
+			expected: true,
+		},
+		{
+			name: "cursor app exists",
+			setup: func(_ *testing.T, _ string, p *mockPlatform) {
+				p.cursorAppExists = true
+			},
+			expected: true,
+		},
+		{
+			name:     "nothing exists",
+			setup:    func(_ *testing.T, _ string, _ *mockPlatform) {},
+			expected: false,
+		},
+	}
+
+	d := &cursorDetector{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := resolvedTempDir(t)
+			p := newMockPlatform(home)
+			tt.setup(t, home, p)
+			if got := d.Detect(home, home, p); got != tt.expected {
+				t.Errorf("Detect() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCursorDetector_CheckMCP(t *testing.T) {
+	d := &cursorDetector{}
+	home := resolvedTempDir(t)
+	cursorDir := filepath.Join(home, ".cursor")
+	mustMkdirAll(t, cursorDir)
+	mustWriteFile(t, filepath.Join(cursorDir, "mcp.json"),
+		`{"mcpServers":{"armis-appsec-mcp":{"command":"npx"}}}`)
+	p := newMockPlatform(home)
+	if !d.CheckMCP(home, home, p) {
+		t.Error("CheckMCP() should return true when armis MCP is configured")
+	}
+}
+
+// --- Cline Detector ---
+
+func TestClineDetector_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, home string, p *mockPlatform)
+		expected bool
+	}{
+		{
+			name: "cline dir exists",
+			setup: func(t *testing.T, home string, _ *mockPlatform) {
+				mustMkdirAll(t, filepath.Join(home, ".cline"))
+			},
+			expected: true,
+		},
+		{
+			name: "vscode extension exists",
+			setup: func(t *testing.T, home string, p *mockPlatform) {
+				extDir := filepath.Join(home, ".vscode", "extensions")
+				mustMkdirAll(t, filepath.Join(extDir, "saoudrizwan.claude-dev-2.0.0"))
+				p.vsCodeExtDir = extDir
+			},
+			expected: true,
+		},
+		{
+			name:     "nothing exists",
+			setup:    func(_ *testing.T, _ string, _ *mockPlatform) {},
+			expected: false,
+		},
+	}
+
+	d := &clineDetector{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := resolvedTempDir(t)
+			p := newMockPlatform(home)
+			tt.setup(t, home, p)
+			if got := d.Detect(home, home, p); got != tt.expected {
+				t.Errorf("Detect() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestClineDetector_CheckMCP(t *testing.T) {
+	d := &clineDetector{}
+	home := resolvedTempDir(t)
+	clineDir := filepath.Join(home, ".cline")
+	mustMkdirAll(t, clineDir)
+	mustWriteFile(t, filepath.Join(clineDir, "mcp_settings.json"),
+		`{"mcpServers":{"armis-appsec-mcp":{"command":"npx"}}}`)
+	p := newMockPlatform(home)
+	if !d.CheckMCP(home, home, p) {
+		t.Error("CheckMCP() should return true when armis MCP is configured")
+	}
+}
+
+func TestClineDetector_Version(t *testing.T) {
+	d := &clineDetector{}
+	home := resolvedTempDir(t)
+	extDir := filepath.Join(home, ".vscode", "extensions", "saoudrizwan.claude-dev-2.1.0")
+	mustMkdirAll(t, extDir)
+	mustWriteFile(t, filepath.Join(extDir, "package.json"), `{"version":"2.1.0"}`)
+	p := newMockPlatform(home)
+	p.vsCodeExtDir = filepath.Join(home, ".vscode", "extensions")
+	if got := d.DetectVersion(home, home, p); got != "2.1.0" {
+		t.Errorf("DetectVersion() = %q, want %q", got, "2.1.0")
+	}
+}
+
+// --- Roo Code Detector ---
+
+func TestRooCodeDetector_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, home string, p *mockPlatform)
+		expected bool
+	}{
+		{
+			name: "roo-cline dir exists",
+			setup: func(t *testing.T, home string, _ *mockPlatform) {
+				mustMkdirAll(t, filepath.Join(home, ".roo-cline"))
+			},
+			expected: true,
+		},
+		{
+			name: "vscode extension exists",
+			setup: func(t *testing.T, home string, p *mockPlatform) {
+				extDir := filepath.Join(home, ".vscode", "extensions")
+				mustMkdirAll(t, filepath.Join(extDir, "rooveterinaryinc.roo-cline-1.5.0"))
+				p.vsCodeExtDir = extDir
+			},
+			expected: true,
+		},
+		{
+			name:     "nothing exists",
+			setup:    func(_ *testing.T, _ string, _ *mockPlatform) {},
+			expected: false,
+		},
+	}
+
+	d := &rooCodeDetector{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := resolvedTempDir(t)
+			p := newMockPlatform(home)
+			tt.setup(t, home, p)
+			if got := d.Detect(home, home, p); got != tt.expected {
+				t.Errorf("Detect() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRooCodeDetector_CheckMCP(t *testing.T) {
+	d := &rooCodeDetector{}
+	home := resolvedTempDir(t)
+	rooDir := filepath.Join(home, ".roo-cline")
+	mustMkdirAll(t, rooDir)
+	mustWriteFile(t, filepath.Join(rooDir, "mcp_settings.json"),
+		`{"mcpServers":{"armis-appsec-mcp":{"command":"npx"}}}`)
+	p := newMockPlatform(home)
+	if !d.CheckMCP(home, home, p) {
+		t.Error("CheckMCP() should return true when armis MCP is configured")
+	}
+}
+
+func TestRooCodeDetector_Version(t *testing.T) {
+	d := &rooCodeDetector{}
+	home := resolvedTempDir(t)
+	extDir := filepath.Join(home, ".vscode", "extensions", "rooveterinaryinc.roo-cline-1.5.0")
+	mustMkdirAll(t, extDir)
+	mustWriteFile(t, filepath.Join(extDir, "package.json"), `{"version":"1.5.0"}`)
+	p := newMockPlatform(home)
+	p.vsCodeExtDir = filepath.Join(home, ".vscode", "extensions")
+	if got := d.DetectVersion(home, home, p); got != "1.5.0" {
+		t.Errorf("DetectVersion() = %q, want %q", got, "1.5.0")
+	}
+}
+
+// --- Aider Detector ---
+
+func TestAiderDetector_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, home string)
+		expected bool
+	}{
+		{
+			name: "aider dir exists",
+			setup: func(t *testing.T, home string) {
+				mustMkdirAll(t, filepath.Join(home, ".aider"))
+			},
+			expected: true,
+		},
+		{
+			name: "aider config file exists",
+			setup: func(t *testing.T, home string) {
+				mustWriteFile(t, filepath.Join(home, ".aider.conf.yml"), "model: gpt-4")
+			},
+			expected: true,
+		},
+		{
+			name:     "nothing exists",
+			setup:    func(_ *testing.T, _ string) {},
+			expected: false,
+		},
+	}
+
+	d := &aiderDetector{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := resolvedTempDir(t)
+			tt.setup(t, home)
+			p := newMockPlatform(home)
+			if got := d.Detect(home, home, p); got != tt.expected {
+				t.Errorf("Detect() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// --- Devin Detector ---
+
+func TestDevinDetector_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, home string)
+		expected bool
+	}{
+		{
+			name: "devin dir exists",
+			setup: func(t *testing.T, home string) {
+				mustMkdirAll(t, filepath.Join(home, ".devin"))
+			},
+			expected: true,
+		},
+		{
+			name:     "nothing exists",
+			setup:    func(_ *testing.T, _ string) {},
+			expected: false,
+		},
+	}
+
+	d := &devinDetector{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := resolvedTempDir(t)
+			tt.setup(t, home)
+			p := newMockPlatform(home)
+			if got := d.Detect(home, home, p); got != tt.expected {
+				t.Errorf("Detect() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// --- OpenHands Detector ---
+
+func TestOpenHandsDetector_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, home string)
+		expected bool
+	}{
+		{
+			name: "openhands dir exists",
+			setup: func(t *testing.T, home string) {
+				mustMkdirAll(t, filepath.Join(home, ".openhands"))
+			},
+			expected: true,
+		},
+		{
+			name:     "nothing exists",
+			setup:    func(_ *testing.T, _ string) {},
+			expected: false,
+		},
+	}
+
+	d := &openHandsDetector{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := resolvedTempDir(t)
+			tt.setup(t, home)
+			p := newMockPlatform(home)
+			if got := d.Detect(home, home, p); got != tt.expected {
+				t.Errorf("Detect() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// --- Amazon Q Detector ---
+
+func TestAmazonQDetector_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, home string, p *mockPlatform)
+		expected bool
+	}{
+		{
+			name: "aws amazonq dir exists",
+			setup: func(t *testing.T, home string, _ *mockPlatform) {
+				mustMkdirAll(t, filepath.Join(home, ".aws", "amazonq"))
+			},
+			expected: true,
+		},
+		{
+			name: "vscode extension exists",
+			setup: func(t *testing.T, home string, p *mockPlatform) {
+				extDir := filepath.Join(home, ".vscode", "extensions")
+				mustMkdirAll(t, filepath.Join(extDir, "amazonwebservices.amazon-q-vscode-1.0.0"))
+				p.vsCodeExtDir = extDir
+			},
+			expected: true,
+		},
+		{
+			name: "jetbrains plugin exists",
+			setup: func(t *testing.T, home string, p *mockPlatform) {
+				pluginDir := filepath.Join(home, "jb-plugins")
+				mustMkdirAll(t, filepath.Join(pluginDir, "amazon-q-1.0"))
+				p.jetBrainsPlugDirs = []string{pluginDir}
+			},
+			expected: true,
+		},
+		{
+			name:     "nothing exists",
+			setup:    func(_ *testing.T, _ string, _ *mockPlatform) {},
+			expected: false,
+		},
+	}
+
+	d := &amazonQDetector{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := resolvedTempDir(t)
+			p := newMockPlatform(home)
+			tt.setup(t, home, p)
+			if got := d.Detect(home, home, p); got != tt.expected {
+				t.Errorf("Detect() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAmazonQDetector_Version(t *testing.T) {
+	d := &amazonQDetector{}
+	home := resolvedTempDir(t)
+	extDir := filepath.Join(home, ".vscode", "extensions", "amazonwebservices.amazon-q-vscode-1.3.0")
+	mustMkdirAll(t, extDir)
+	mustWriteFile(t, filepath.Join(extDir, "package.json"), `{"version":"1.3.0"}`)
+	p := newMockPlatform(home)
+	p.vsCodeExtDir = filepath.Join(home, ".vscode", "extensions")
+	if got := d.DetectVersion(home, home, p); got != "1.3.0" {
+		t.Errorf("DetectVersion() = %q, want %q", got, "1.3.0")
+	}
+}
+
+// --- Junie Detector ---
+
+func TestJunieDetector_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, home string, p *mockPlatform)
+		expected bool
+	}{
+		{
+			name: "junie config dir exists",
+			setup: func(t *testing.T, home string, _ *mockPlatform) {
+				mustMkdirAll(t, filepath.Join(home, ".junie"))
+			},
+			expected: true,
+		},
+		{
+			name: "jetbrains plugin exists",
+			setup: func(t *testing.T, home string, p *mockPlatform) {
+				pluginDir := filepath.Join(home, "jb-plugins")
+				mustMkdirAll(t, filepath.Join(pluginDir, "junie-1.0"))
+				p.jetBrainsPlugDirs = []string{pluginDir}
+			},
+			expected: true,
+		},
+		{
+			name: "binary exists",
+			setup: func(t *testing.T, home string, p *mockPlatform) {
+				binDir := filepath.Join(home, ".local", "bin")
+				mustMkdirAll(t, binDir)
+				binPath := filepath.Join(binDir, "junie")
+				mustWriteFile(t, binPath, "")
+				p.junieBinPaths = []string{binPath}
+			},
+			expected: true,
+		},
+		{
+			name:     "nothing exists",
+			setup:    func(_ *testing.T, _ string, _ *mockPlatform) {},
+			expected: false,
+		},
+	}
+
+	d := &junieDetector{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := resolvedTempDir(t)
+			p := newMockPlatform(home)
+			tt.setup(t, home, p)
+			if got := d.Detect(home, home, p); got != tt.expected {
+				t.Errorf("Detect() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestJunieDetector_CheckMCP(t *testing.T) {
+	d := &junieDetector{}
+	home := resolvedTempDir(t)
+	mcpDir := filepath.Join(home, ".junie", "mcp")
+	mustMkdirAll(t, mcpDir)
+	mustWriteFile(t, filepath.Join(mcpDir, "mcp.json"),
+		`{"mcpServers":{"armis-appsec-mcp":{"command":"npx"}}}`)
+	p := newMockPlatform(home)
+	if !d.CheckMCP(home, home, p) {
+		t.Error("CheckMCP() should return true when armis MCP is configured")
+	}
+}
+
+func TestRegistryReturnsAllAgents(t *testing.T) {
+	registry := Registry()
+	expected := map[AgentName]bool{
+		AgentClaudeCode:        false,
+		AgentWindsurf:          false,
+		AgentGoogleAntigravity: false,
+		AgentGitHubCopilot:     false,
+		AgentCursor:            false,
+		AgentCline:             false,
+		AgentRooCode:           false,
+		AgentAider:             false,
+		AgentDevin:             false,
+		AgentOpenHands:         false,
+		AgentAmazonQ:           false,
+		AgentJunie:             false,
+	}
+	for _, d := range registry {
+		expected[d.Name()] = true
+	}
+	for name, found := range expected {
+		if !found {
+			t.Errorf("Registry() missing detector for %s", name)
+		}
+	}
+}
+
+// --- Path Traversal Tests ---
+
+func TestIsUnderDir_RejectsTraversal(t *testing.T) {
+	home := resolvedTempDir(t)
+	mustMkdirAll(t, filepath.Join(home, "legit"))
+
+	tests := []struct {
+		name     string
+		target   string
+		expected bool
+	}{
+		{
+			name:     "child directory",
+			target:   filepath.Join(home, "legit"),
+			expected: true,
+		},
+		{
+			name:     "dotdot traversal",
+			target:   filepath.Join(home, "legit", "..", "..", "etc", "passwd"),
+			expected: false,
+		},
+		{
+			name:     "nonexistent path",
+			target:   filepath.Join(home, "does-not-exist"),
+			expected: false,
+		},
+		{
+			name:     "path outside home",
+			target:   "/tmp",
+			expected: false,
+		},
+		{
+			name:     "home itself is not strictly under",
+			target:   home,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isUnderDir(home, tt.target); got != tt.expected {
+				t.Errorf("isUnderDir(%q, %q) = %v, want %v", home, tt.target, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsUnderDir_RejectsSymlinkEscape(t *testing.T) {
+	home := resolvedTempDir(t)
+	outside := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(outside, "secret.txt"), "sensitive data")
+
+	link := filepath.Join(home, "escape-link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	if isUnderDir(home, filepath.Join(link, "secret.txt")) {
+		t.Error("isUnderDir should reject symlink pointing outside home")
+	}
+}
+
+func TestDirExists_RejectsTraversal(t *testing.T) {
+	home := resolvedTempDir(t)
+	outside := resolvedTempDir(t)
+
+	if dirExists(home, outside) {
+		t.Error("dirExists should reject path outside home")
+	}
+}
+
+func TestFileExists_RejectsTraversal(t *testing.T) {
+	home := resolvedTempDir(t)
+	outside := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(outside, "file.txt"), "data")
+
+	if fileExists(home, filepath.Join(outside, "file.txt")) {
+		t.Error("fileExists should reject path outside home")
+	}
+}
+
+func TestHasArmisMCP_RejectsTraversal(t *testing.T) {
+	home := resolvedTempDir(t)
+	outside := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(outside, "mcp.json"),
+		`{"mcpServers":{"armis-appsec-mcp":{"command":"npx"}}}`)
+
+	if HasArmisMCP(home, filepath.Join(outside, "mcp.json")) {
+		t.Error("HasArmisMCP should reject config path outside home")
+	}
+}
+
+func TestResolvePath_NonexistentReturnsError(t *testing.T) {
+	_, err := resolvePath("/nonexistent/path/that/does/not/exist")
+	if err == nil {
+		t.Error("resolvePath should return error for nonexistent path")
+	}
+}

--- a/internal/agentdetect/detector_test.go
+++ b/internal/agentdetect/detector_test.go
@@ -270,16 +270,32 @@ func TestCopilotDetector_Detect(t *testing.T) {
 
 func TestCopilotDetector_CheckMCP(t *testing.T) {
 	d := &copilotDetector{}
-	home := resolvedTempDir(t)
-	configDir := filepath.Join(home, ".config", "Code", "User")
-	mustMkdirAll(t, configDir)
-	mustWriteFile(t, filepath.Join(configDir, "mcp.json"),
-		`{"mcpServers":{"armis-appsec-mcp":{"command":"npx"}}}`)
-	p := newMockPlatform(home)
-	p.vsCodeConfigDir = configDir
-	if !d.CheckMCP(home, home, p) {
-		t.Error("CheckMCP() should return true when armis MCP is configured")
-	}
+
+	t.Run("mcpServers format", func(t *testing.T) {
+		home := resolvedTempDir(t)
+		configDir := filepath.Join(home, ".config", "Code", "User")
+		mustMkdirAll(t, configDir)
+		mustWriteFile(t, filepath.Join(configDir, "mcp.json"),
+			`{"mcpServers":{"armis-appsec-mcp":{"command":"npx"}}}`)
+		p := newMockPlatform(home)
+		p.vsCodeConfigDir = configDir
+		if !d.CheckMCP(home, home, p) {
+			t.Error("CheckMCP() should return true for mcpServers format")
+		}
+	})
+
+	t.Run("vscode servers format", func(t *testing.T) {
+		home := resolvedTempDir(t)
+		configDir := filepath.Join(home, ".config", "Code", "User")
+		mustMkdirAll(t, configDir)
+		mustWriteFile(t, filepath.Join(configDir, "mcp.json"),
+			`{"servers":{"armis-appsec":{"type":"stdio","command":"python3"}}}`)
+		p := newMockPlatform(home)
+		p.vsCodeConfigDir = configDir
+		if !d.CheckMCP(home, home, p) {
+			t.Error("CheckMCP() should return true for VS Code servers format")
+		}
+	})
 }
 
 // --- Cursor Detector ---
@@ -384,11 +400,14 @@ func TestClineDetector_Detect(t *testing.T) {
 func TestClineDetector_CheckMCP(t *testing.T) {
 	d := &clineDetector{}
 	home := resolvedTempDir(t)
-	clineDir := filepath.Join(home, ".cline")
-	mustMkdirAll(t, clineDir)
-	mustWriteFile(t, filepath.Join(clineDir, "mcp_settings.json"),
+	configDir := filepath.Join(home, ".config", "Code", "User")
+	settingsDir := filepath.Join(configDir, "globalStorage",
+		"saoudrizwan.claude-dev", "settings")
+	mustMkdirAll(t, settingsDir)
+	mustWriteFile(t, filepath.Join(settingsDir, "cline_mcp_settings.json"),
 		`{"mcpServers":{"armis-appsec-mcp":{"command":"npx"}}}`)
 	p := newMockPlatform(home)
+	p.vsCodeConfigDir = configDir
 	if !d.CheckMCP(home, home, p) {
 		t.Error("CheckMCP() should return true when armis MCP is configured")
 	}

--- a/internal/agentdetect/detector_test.go
+++ b/internal/agentdetect/detector_test.go
@@ -831,14 +831,54 @@ func TestContinueDetector_Detect(t *testing.T) {
 
 func TestContinueDetector_CheckMCP(t *testing.T) {
 	d := &continueDetector{}
-	home := resolvedTempDir(t)
-	mcpDir := filepath.Join(home, ".continue", "mcpServers")
-	mustMkdirAll(t, mcpDir)
-	mustWriteFile(t, filepath.Join(mcpDir, "armis-appsec.json"), `{"command":"python3"}`)
-	p := newMockPlatform(home)
-	if !d.CheckMCP(home, home, p) {
-		t.Error("CheckMCP() should return true when armis MCP file exists in mcpServers dir")
-	}
+
+	t.Run("armis MCP in standard install file", func(t *testing.T) {
+		home := resolvedTempDir(t)
+		mcpDir := filepath.Join(home, ".continue", "mcpServers")
+		mustMkdirAll(t, mcpDir)
+		mustWriteFile(t, filepath.Join(mcpDir, "armis-appsec.json"),
+			`{"mcpServers":{"armis-appsec":{"command":"python3"}}}`)
+		p := newMockPlatform(home)
+		if !d.CheckMCP(home, home, p) {
+			t.Error("CheckMCP() should return true when armis MCP config exists")
+		}
+	})
+
+	t.Run("armis MCP in custom filename", func(t *testing.T) {
+		home := resolvedTempDir(t)
+		mcpDir := filepath.Join(home, ".continue", "mcpServers")
+		mustMkdirAll(t, mcpDir)
+		mustWriteFile(t, filepath.Join(mcpDir, "my-servers.json"),
+			`{"mcpServers":{"armis-appsec":{"command":"python3"}}}`)
+		p := newMockPlatform(home)
+		if !d.CheckMCP(home, home, p) {
+			t.Error("CheckMCP() should return true when armis MCP is in any JSON file")
+		}
+	})
+
+	t.Run("non-json file ignored", func(t *testing.T) {
+		home := resolvedTempDir(t)
+		mcpDir := filepath.Join(home, ".continue", "mcpServers")
+		mustMkdirAll(t, mcpDir)
+		mustWriteFile(t, filepath.Join(mcpDir, "armis-appsec.json.bak"),
+			`{"mcpServers":{"armis-appsec":{"command":"python3"}}}`)
+		p := newMockPlatform(home)
+		if d.CheckMCP(home, home, p) {
+			t.Error("CheckMCP() should ignore .bak files")
+		}
+	})
+
+	t.Run("json file without armis MCP", func(t *testing.T) {
+		home := resolvedTempDir(t)
+		mcpDir := filepath.Join(home, ".continue", "mcpServers")
+		mustMkdirAll(t, mcpDir)
+		mustWriteFile(t, filepath.Join(mcpDir, "other.json"),
+			`{"mcpServers":{"some-other-server":{"command":"node"}}}`)
+		p := newMockPlatform(home)
+		if d.CheckMCP(home, home, p) {
+			t.Error("CheckMCP() should return false when no armis MCP entry exists")
+		}
+	})
 }
 
 // --- Gemini CLI Detector ---

--- a/internal/agentdetect/format.go
+++ b/internal/agentdetect/format.go
@@ -5,22 +5,31 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/ArmisSecurity/armis-cli/internal/output"
 )
 
-// FormatPlain writes the plain-text grouped-by-user format.
+// FormatPlain writes the plain-text grouped-by-user format using lipgloss styles.
 func FormatPlain(result *ScanResult, w io.Writer) error {
+	s := output.GetStyles()
+
 	for i, userResult := range result.Users {
 		if i > 0 {
 			if _, err := fmt.Fprintln(w); err != nil {
 				return err
 			}
 		}
-		if _, err := fmt.Fprintf(w, "user: %s\n", userResult.User); err != nil {
+		header := s.Bold.Render("user:") + " " + userResult.User
+		if _, err := fmt.Fprintln(w, header); err != nil {
 			return err
 		}
 		agents := make([]string, 0, len(userResult.Agents))
 		for _, agent := range userResult.Agents {
-			agents = append(agents, fmt.Sprintf("%s(MCP:%t)", agent.Name, agent.MCPInstalled))
+			mcpStatus := s.ErrorText.Render("MCP:false")
+			if agent.MCPInstalled {
+				mcpStatus = s.SuccessText.Render("MCP:true")
+			}
+			agents = append(agents, fmt.Sprintf("%s(%s)", agent.Name, mcpStatus))
 		}
 		if _, err := fmt.Fprintln(w, strings.Join(agents, ", ")); err != nil {
 			return err

--- a/internal/agentdetect/format.go
+++ b/internal/agentdetect/format.go
@@ -1,0 +1,41 @@
+package agentdetect
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// FormatPlain writes the plain-text grouped-by-user format.
+func FormatPlain(result *ScanResult, w io.Writer) error {
+	for i, userResult := range result.Users {
+		if i > 0 {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintf(w, "user: %s\n", userResult.User); err != nil {
+			return err
+		}
+		agents := make([]string, 0, len(userResult.Agents))
+		for _, agent := range userResult.Agents {
+			agents = append(agents, fmt.Sprintf("%s(MCP:%t)", agent.Name, agent.MCPInstalled))
+		}
+		if _, err := fmt.Fprintln(w, strings.Join(agents, ", ")); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// FormatJSON writes the flat JSON array of all detected agents.
+func FormatJSON(result *ScanResult, w io.Writer) error {
+	flat := result.FlatResults()
+	if flat == nil {
+		flat = []DetectedAgent{}
+	}
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(flat)
+}

--- a/internal/agentdetect/mcpconfig.go
+++ b/internal/agentdetect/mcpconfig.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-const armisMCPIdentifier = "armis-appsec-mcp"
+const armisMCPIdentifier = "armis-appsec"
 
 // mcpServerConfig is used to unmarshal MCP config files that have a top-level "mcpServers" key.
 // Used by Windsurf, Cursor, GitHub Copilot, and Google Antigravity.
@@ -55,6 +55,30 @@ func HasArmisMCPInClaudeSettings(resolvedHome, settingsPath string) bool {
 	}
 	for key, enabled := range settings.EnabledPlugins {
 		if enabled && strings.Contains(strings.ToLower(key), armisMCPIdentifier) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasArmisMCPInZedSettings checks if Zed's settings.json contains an armis MCP entry
+// in the context_servers key. settingsPath must resolve under resolvedHome.
+func HasArmisMCPInZedSettings(resolvedHome, settingsPath string) bool {
+	if !isUnderDir(resolvedHome, settingsPath) {
+		return false
+	}
+	data, err := os.ReadFile(settingsPath) //nolint:gosec // path validated by isUnderDir
+	if err != nil {
+		return false
+	}
+	var settings struct {
+		ContextServers map[string]json.RawMessage `json:"context_servers"`
+	}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return false
+	}
+	for key := range settings.ContextServers {
+		if strings.Contains(strings.ToLower(key), armisMCPIdentifier) {
 			return true
 		}
 	}

--- a/internal/agentdetect/mcpconfig.go
+++ b/internal/agentdetect/mcpconfig.go
@@ -85,6 +85,33 @@ func HasArmisMCPInZedSettings(resolvedHome, settingsPath string) bool {
 	return false
 }
 
+// vsCodeMCPConfig represents VS Code's native MCP format with a top-level "servers" key.
+type vsCodeMCPConfig struct {
+	Servers map[string]json.RawMessage `json:"servers"`
+}
+
+// HasArmisMCPInVSCodeFormat checks if a VS Code mcp.json contains an armis entry
+// in the "servers" key (VS Code native format). configPath must resolve under resolvedHome.
+func HasArmisMCPInVSCodeFormat(resolvedHome, configPath string) bool {
+	if !isUnderDir(resolvedHome, configPath) {
+		return false
+	}
+	data, err := os.ReadFile(configPath) //nolint:gosec // path validated by isUnderDir
+	if err != nil {
+		return false
+	}
+	var config vsCodeMCPConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		return false
+	}
+	for key := range config.Servers {
+		if strings.Contains(strings.ToLower(key), armisMCPIdentifier) {
+			return true
+		}
+	}
+	return false
+}
+
 // hasArmisMCPInData checks raw JSON data for the armis MCP identifier.
 // Works for both standard MCP configs and Claude Code settings by checking
 // if any key in mcpServers contains the armis identifier.

--- a/internal/agentdetect/mcpconfig.go
+++ b/internal/agentdetect/mcpconfig.go
@@ -1,0 +1,78 @@
+package agentdetect
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+)
+
+const armisMCPIdentifier = "armis-appsec-mcp"
+
+// mcpServerConfig is used to unmarshal MCP config files that have a top-level "mcpServers" key.
+// Used by Windsurf, Cursor, GitHub Copilot, and Google Antigravity.
+type mcpServerConfig struct {
+	MCPServers map[string]json.RawMessage `json:"mcpServers"`
+}
+
+// HasArmisMCP checks if a standard MCP config file (mcp.json, mcp_config.json) contains
+// an armis-appsec-mcp server entry. configPath must resolve under resolvedHome.
+func HasArmisMCP(resolvedHome, configPath string) bool {
+	if !isUnderDir(resolvedHome, configPath) {
+		return false
+	}
+	data, err := os.ReadFile(configPath) //nolint:gosec // path validated by isUnderDir
+	if err != nil {
+		return false
+	}
+	return hasArmisMCPInData(data)
+}
+
+// claudeSettings represents the relevant fields in Claude Code's settings.json.
+type claudeSettings struct {
+	MCPServers     map[string]json.RawMessage `json:"mcpServers"`
+	EnabledPlugins map[string]bool            `json:"enabledPlugins"`
+}
+
+// HasArmisMCPInClaudeSettings checks if Claude Code's settings.json contains
+// an armis-appsec-mcp entry in either mcpServers or enabledPlugins.
+// settingsPath must resolve under resolvedHome.
+func HasArmisMCPInClaudeSettings(resolvedHome, settingsPath string) bool {
+	if !isUnderDir(resolvedHome, settingsPath) {
+		return false
+	}
+	data, err := os.ReadFile(settingsPath) //nolint:gosec // path validated by isUnderDir
+	if err != nil {
+		return false
+	}
+	var settings claudeSettings
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return false
+	}
+	for key := range settings.MCPServers {
+		if strings.Contains(strings.ToLower(key), armisMCPIdentifier) {
+			return true
+		}
+	}
+	for key, enabled := range settings.EnabledPlugins {
+		if enabled && strings.Contains(strings.ToLower(key), armisMCPIdentifier) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasArmisMCPInData checks raw JSON data for the armis MCP identifier.
+// Works for both standard MCP configs and Claude Code settings by checking
+// if any key in mcpServers contains the armis identifier.
+func hasArmisMCPInData(data []byte) bool {
+	var config mcpServerConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		return false
+	}
+	for key := range config.MCPServers {
+		if strings.Contains(strings.ToLower(key), armisMCPIdentifier) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agentdetect/mcpconfig_test.go
+++ b/internal/agentdetect/mcpconfig_test.go
@@ -1,0 +1,153 @@
+package agentdetect
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHasArmisMCP(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{
+			name: "armis MCP present",
+			content: `{
+				"mcpServers": {
+					"armis-appsec-mcp": {
+						"command": "npx",
+						"args": ["armis-appsec-mcp"]
+					}
+				}
+			}`,
+			expected: true,
+		},
+		{
+			name: "armis MCP absent",
+			content: `{
+				"mcpServers": {
+					"some-other-server": {
+						"command": "npx",
+						"args": ["other"]
+					}
+				}
+			}`,
+			expected: false,
+		},
+		{
+			name:     "empty mcpServers",
+			content:  `{"mcpServers": {}}`,
+			expected: false,
+		},
+		{
+			name:     "no mcpServers key",
+			content:  `{"other": "value"}`,
+			expected: false,
+		},
+		{
+			name:     "invalid JSON",
+			content:  `not json at all`,
+			expected: false,
+		},
+		{
+			name:     "empty file",
+			content:  ``,
+			expected: false,
+		},
+		{
+			name: "armis MCP with mixed case key",
+			content: `{
+				"mcpServers": {
+					"Armis-AppSec-MCP": {
+						"command": "npx"
+					}
+				}
+			}`,
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := resolvedTempDir(t)
+			path := filepath.Join(dir, "mcp.json")
+			if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			got := HasArmisMCP(dir, path)
+			if got != tt.expected {
+				t.Errorf("HasArmisMCP() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHasArmisMCP_MissingFile(t *testing.T) {
+	dir := resolvedTempDir(t)
+	got := HasArmisMCP(dir, filepath.Join(dir, "mcp.json"))
+	if got {
+		t.Error("HasArmisMCP() should return false for missing file")
+	}
+}
+
+func TestHasArmisMCPInClaudeSettings(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{
+			name: "claude settings with armis MCP",
+			content: `{
+				"mcpServers": {
+					"armis-appsec-mcp": {
+						"command": "/usr/local/bin/armis-appsec-mcp"
+					}
+				}
+			}`,
+			expected: true,
+		},
+		{
+			name: "claude settings without armis MCP",
+			content: `{
+				"mcpServers": {},
+				"permissions": {}
+			}`,
+			expected: false,
+		},
+		{
+			name: "claude settings with enabledPlugins",
+			content: `{
+				"enabledPlugins": {
+					"armis-appsec@armis-appsec-mcp": true
+				}
+			}`,
+			expected: true,
+		},
+		{
+			name: "claude settings with disabled plugin",
+			content: `{
+				"enabledPlugins": {
+					"armis-appsec@armis-appsec-mcp": false
+				}
+			}`,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := resolvedTempDir(t)
+			path := filepath.Join(dir, "settings.json")
+			if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			got := HasArmisMCPInClaudeSettings(dir, path)
+			if got != tt.expected {
+				t.Errorf("HasArmisMCPInClaudeSettings() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/agentdetect/platform.go
+++ b/internal/agentdetect/platform.go
@@ -1,0 +1,33 @@
+package agentdetect
+
+// Platform provides OS-specific paths and operations.
+type Platform interface {
+	// UserHomeDirs returns home directories for all local users.
+	// When running as root/SYSTEM, returns all user profiles.
+	// When running as regular user, returns only the current user's home.
+	UserHomeDirs() ([]UserHome, error)
+
+	// VSCodeExtensionsDir returns the VS Code extensions directory for a given home.
+	VSCodeExtensionsDir(homeDir string) string
+
+	// JetBrainsPluginDirs returns JetBrains plugin directories for a given home.
+	JetBrainsPluginDirs(homeDir string) []string
+
+	// VSCodeUserConfigDir returns the VS Code user config directory (for mcp.json, settings.json).
+	VSCodeUserConfigDir(homeDir string) string
+
+	// CursorAppExists returns true if the Cursor application is installed at a platform-standard location.
+	CursorAppExists(homeDir string) bool
+
+	// JunieBinaryPaths returns platform-specific paths where the Junie binary may be installed.
+	JunieBinaryPaths(homeDir string) []string
+
+	// IsRoot returns true if the current process has elevated privileges.
+	IsRoot() bool
+}
+
+// UserHome represents a discovered user profile.
+type UserHome struct {
+	Username string
+	HomeDir  string
+}

--- a/internal/agentdetect/platform.go
+++ b/internal/agentdetect/platform.go
@@ -22,6 +22,9 @@ type Platform interface {
 	// JunieBinaryPaths returns platform-specific paths where the Junie binary may be installed.
 	JunieBinaryPaths(homeDir string) []string
 
+	// ZedConfigDir returns the Zed editor config directory for a given home.
+	ZedConfigDir(homeDir string) string
+
 	// IsRoot returns true if the current process has elevated privileges.
 	IsRoot() bool
 }

--- a/internal/agentdetect/platform_darwin.go
+++ b/internal/agentdetect/platform_darwin.go
@@ -1,0 +1,56 @@
+//go:build darwin
+
+package agentdetect
+
+import (
+	"os"
+	"path/filepath"
+)
+
+type darwinPlatform struct{}
+
+// NewPlatform returns the macOS platform implementation.
+func NewPlatform() Platform {
+	return &darwinPlatform{}
+}
+
+func (p *darwinPlatform) UserHomeDirs() ([]UserHome, error) {
+	if p.IsRoot() {
+		return enumerateUserDirs("/Users", darwinSkipDirs)
+	}
+	return currentUserOnly()
+}
+
+func (p *darwinPlatform) VSCodeExtensionsDir(homeDir string) string {
+	return filepath.Join(homeDir, ".vscode", "extensions")
+}
+
+func (p *darwinPlatform) JetBrainsPluginDirs(homeDir string) []string {
+	return globJetBrainsPluginDirs(filepath.Join(homeDir, "Library", "Application Support", "JetBrains"))
+}
+
+func (p *darwinPlatform) VSCodeUserConfigDir(homeDir string) string {
+	return filepath.Join(homeDir, "Library", "Application Support", "Code", "User")
+}
+
+func (p *darwinPlatform) CursorAppExists(_ string) bool {
+	_, err := os.Stat("/Applications/Cursor.app")
+	return err == nil
+}
+
+func (p *darwinPlatform) JunieBinaryPaths(homeDir string) []string {
+	return []string{
+		"/usr/local/bin/junie",
+		filepath.Join(homeDir, ".local", "bin", "junie"),
+	}
+}
+
+func (p *darwinPlatform) IsRoot() bool {
+	return os.Getuid() == 0
+}
+
+var darwinSkipDirs = map[string]bool{
+	"Shared":     true,
+	".localized": true,
+	"Guest":      true,
+}

--- a/internal/agentdetect/platform_darwin.go
+++ b/internal/agentdetect/platform_darwin.go
@@ -45,6 +45,10 @@ func (p *darwinPlatform) JunieBinaryPaths(homeDir string) []string {
 	}
 }
 
+func (p *darwinPlatform) ZedConfigDir(homeDir string) string {
+	return filepath.Join(homeDir, "Library", "Application Support", "Zed")
+}
+
 func (p *darwinPlatform) IsRoot() bool {
 	return os.Getuid() == 0
 }

--- a/internal/agentdetect/platform_linux.go
+++ b/internal/agentdetect/platform_linux.go
@@ -44,6 +44,10 @@ func (p *linuxPlatform) JunieBinaryPaths(homeDir string) []string {
 	}
 }
 
+func (p *linuxPlatform) ZedConfigDir(homeDir string) string {
+	return filepath.Join(homeDir, ".config", "Zed")
+}
+
 func (p *linuxPlatform) IsRoot() bool {
 	return os.Getuid() == 0
 }

--- a/internal/agentdetect/platform_linux.go
+++ b/internal/agentdetect/platform_linux.go
@@ -1,0 +1,51 @@
+//go:build linux
+
+package agentdetect
+
+import (
+	"os"
+	"path/filepath"
+)
+
+type linuxPlatform struct{}
+
+// NewPlatform returns the Linux platform implementation.
+func NewPlatform() Platform {
+	return &linuxPlatform{}
+}
+
+func (p *linuxPlatform) UserHomeDirs() ([]UserHome, error) {
+	if p.IsRoot() {
+		return enumerateUserDirs("/home", linuxSkipDirs)
+	}
+	return currentUserOnly()
+}
+
+func (p *linuxPlatform) VSCodeExtensionsDir(homeDir string) string {
+	return filepath.Join(homeDir, ".vscode", "extensions")
+}
+
+func (p *linuxPlatform) JetBrainsPluginDirs(homeDir string) []string {
+	return globJetBrainsPluginDirs(filepath.Join(homeDir, ".local", "share", "JetBrains"))
+}
+
+func (p *linuxPlatform) VSCodeUserConfigDir(homeDir string) string {
+	return filepath.Join(homeDir, ".config", "Code", "User")
+}
+
+func (p *linuxPlatform) CursorAppExists(_ string) bool {
+	return false
+}
+
+func (p *linuxPlatform) JunieBinaryPaths(homeDir string) []string {
+	return []string{
+		"/usr/local/bin/junie",
+		filepath.Join(homeDir, ".local", "bin", "junie"),
+	}
+}
+
+func (p *linuxPlatform) IsRoot() bool {
+	return os.Getuid() == 0
+}
+
+var linuxSkipDirs = map[string]bool{}

--- a/internal/agentdetect/platform_windows.go
+++ b/internal/agentdetect/platform_windows.go
@@ -47,6 +47,10 @@ func (p *windowsPlatform) JunieBinaryPaths(homeDir string) []string {
 	}
 }
 
+func (p *windowsPlatform) ZedConfigDir(_ string) string {
+	return ""
+}
+
 func (p *windowsPlatform) IsRoot() bool {
 	var sid *windows.SID
 	err := windows.AllocateAndInitializeSid(

--- a/internal/agentdetect/platform_windows.go
+++ b/internal/agentdetect/platform_windows.go
@@ -1,0 +1,77 @@
+//go:build windows
+
+package agentdetect
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+type windowsPlatform struct{}
+
+// NewPlatform returns the Windows platform implementation.
+func NewPlatform() Platform {
+	return &windowsPlatform{}
+}
+
+func (p *windowsPlatform) UserHomeDirs() ([]UserHome, error) {
+	if p.IsRoot() {
+		return enumerateUserDirs(`C:\Users`, windowsSkipDirs)
+	}
+	return currentUserOnly()
+}
+
+func (p *windowsPlatform) VSCodeExtensionsDir(homeDir string) string {
+	return filepath.Join(homeDir, ".vscode", "extensions")
+}
+
+func (p *windowsPlatform) JetBrainsPluginDirs(homeDir string) []string {
+	return globJetBrainsPluginDirs(filepath.Join(homeDir, "AppData", "Roaming", "JetBrains"))
+}
+
+func (p *windowsPlatform) VSCodeUserConfigDir(homeDir string) string {
+	return filepath.Join(homeDir, "AppData", "Roaming", "Code", "User")
+}
+
+func (p *windowsPlatform) CursorAppExists(homeDir string) bool {
+	cursorPath := filepath.Join(homeDir, "AppData", "Local", "Programs", "Cursor", "Cursor.exe")
+	_, err := os.Stat(cursorPath)
+	return err == nil
+}
+
+func (p *windowsPlatform) JunieBinaryPaths(homeDir string) []string {
+	return []string{
+		filepath.Join(homeDir, "AppData", "Local", "Programs", "Junie", "junie.exe"),
+	}
+}
+
+func (p *windowsPlatform) IsRoot() bool {
+	var sid *windows.SID
+	err := windows.AllocateAndInitializeSid(
+		&windows.SECURITY_NT_AUTHORITY,
+		2,
+		windows.SECURITY_BUILTIN_DOMAIN_RID,
+		windows.DOMAIN_ALIAS_RID_ADMINS,
+		0, 0, 0, 0, 0, 0,
+		&sid,
+	)
+	if err != nil {
+		return false
+	}
+	defer windows.FreeSid(sid)
+
+	member, err := windows.Token(0).IsMember(sid)
+	if err != nil {
+		return false
+	}
+	return member
+}
+
+var windowsSkipDirs = map[string]bool{
+	"Default":      true,
+	"Default User": true,
+	"Public":       true,
+	"All Users":    true,
+}

--- a/internal/agentdetect/userprofile.go
+++ b/internal/agentdetect/userprofile.go
@@ -1,0 +1,60 @@
+package agentdetect
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+)
+
+// enumerateUserDirs lists user home directories under baseDir, skipping entries in skipSet.
+// Hidden directories (starting with ".") are always skipped.
+func enumerateUserDirs(baseDir string, skipSet map[string]bool) ([]UserHome, error) {
+	entries, err := os.ReadDir(baseDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var users []UserHome
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		if skipSet[name] {
+			continue
+		}
+		users = append(users, UserHome{
+			Username: name,
+			HomeDir:  filepath.Join(baseDir, name),
+		})
+	}
+	return users, nil
+}
+
+// currentUserOnly returns a single-element slice with the current user's home directory.
+func currentUserOnly() ([]UserHome, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	u, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+	return []UserHome{{Username: u.Username, HomeDir: homeDir}}, nil
+}
+
+// globJetBrainsPluginDirs finds plugin directories across JetBrains product versions.
+// The baseDir is the JetBrains config root (e.g., ~/Library/Application Support/JetBrains).
+func globJetBrainsPluginDirs(baseDir string) []string {
+	pattern := filepath.Join(baseDir, "*", "plugins")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil
+	}
+	return matches
+}

--- a/internal/cmd/agent_detection.go
+++ b/internal/cmd/agent_detection.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/ArmisSecurity/armis-cli/internal/agentdetect"
+	"github.com/spf13/cobra"
+)
+
+const (
+	agentFormatPlain = "plain"
+	agentFormatJSON  = "json"
+)
+
+var agentDetectFormat string
+
+var agentDetectionCmd = &cobra.Command{
+	Use:   "agent-detection",
+	Short: "Detect AI coding agents installed on this system",
+	Long: `Detect AI coding agents (Claude Code, Cursor, Copilot, Windsurf, Google Antigravity)
+across user profiles and check if Armis AppSec MCP is enabled.
+
+When run as root (macOS/Linux) or SYSTEM (Windows), scans all local user profiles.
+When run as a standard user, scans only the current user's home directory.`,
+	Example: `  # Detect agents for current user
+  armis-cli agent-detection
+
+  # Detect agents with JSON output
+  armis-cli agent-detection --format json
+
+  # Detect agents across all users (requires root/admin)
+  sudo armis-cli agent-detection`,
+	RunE: runAgentDetection,
+}
+
+func init() {
+	agentDetectionCmd.Flags().StringVarP(&agentDetectFormat, "format", "f", agentFormatPlain, "Output format: plain, json")
+	rootCmd.AddCommand(agentDetectionCmd)
+}
+
+func runAgentDetection(cmd *cobra.Command, _ []string) error {
+	switch agentDetectFormat {
+	case agentFormatPlain, agentFormatJSON:
+	default:
+		return fmt.Errorf("invalid --format value %q: must be plain or json", agentDetectFormat)
+	}
+
+	platform := agentdetect.NewPlatform()
+	scanner := agentdetect.NewScanner(platform)
+
+	result, err := scanner.Scan()
+	if err != nil {
+		return fmt.Errorf("agent detection failed: %w", err)
+	}
+
+	switch agentDetectFormat {
+	case agentFormatJSON:
+		return agentdetect.FormatJSON(result, cmd.OutOrStdout())
+	default:
+		return agentdetect.FormatPlain(result, cmd.OutOrStdout())
+	}
+}

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -29,10 +29,13 @@ Supported editors:
   continue      Continue
   antigravity   Antigravity
   gemini        Gemini CLI
+  roocode       Roo Code
+  junie         Junie
 
 Not auto-configurable (manual setup required):
   jetbrains  JetBrains IDEs (per-project .jb-mcp.json)
   devin      Devin (cloud-based, configure via web UI)
+  openhands  OpenHands (cloud-based, configure via web UI)
   aider      Aider (no MCP support)`,
 	Example: `  # Install to all detected editors
   armis-cli install
@@ -156,6 +159,10 @@ func installTargets(targets []string) error {
 		case "devin":
 			fmt.Fprintln(os.Stderr, "Devin: MCP servers are configured via the Devin web UI.")
 			fmt.Fprintln(os.Stderr, "See: Settings → MCP Servers in your Devin dashboard.")
+			fmt.Fprintln(os.Stderr, "")
+		case "openhands":
+			fmt.Fprintln(os.Stderr, "OpenHands: MCP servers are configured via the web UI.")
+			fmt.Fprintln(os.Stderr, "See: Settings → MCP Servers in your OpenHands dashboard.")
 			fmt.Fprintln(os.Stderr, "")
 		case "aider":
 			fmt.Fprintln(os.Stderr, "Aider does not support MCP servers.")

--- a/internal/install/editors.go
+++ b/internal/install/editors.go
@@ -23,6 +23,8 @@ const (
 	EditorContinue    EditorID = "continue"
 	EditorAntigravity EditorID = "antigravity"
 	EditorGemini      EditorID = "gemini"
+	EditorRooCode     EditorID = "roocode"
+	EditorJunie       EditorID = "junie"
 )
 
 // Editor represents a code editor with MCP server support.
@@ -42,6 +44,8 @@ var AllEditors = []Editor{
 	{EditorContinue, "Continue"},
 	{EditorAntigravity, "Antigravity"},
 	{EditorGemini, "Gemini CLI"},
+	{EditorRooCode, "Roo Code"},
+	{EditorJunie, "Junie"},
 }
 
 // EditorByID returns the editor with the given ID.
@@ -181,6 +185,10 @@ func defaultConfigPath(id EditorID) string {
 		return homeDir(".gemini", "antigravity", "mcp_config.json")
 	case EditorGemini:
 		return homeDir(".gemini", "settings.json")
+	case EditorRooCode:
+		return homeDir(".roo-cline", "mcp_settings.json")
+	case EditorJunie:
+		return homeDir(".junie", "mcp", "mcp.json")
 	}
 	return ""
 }


### PR DESCRIPTION
## Related Issue

* [PPSC-697](https://your-jira.atlassian.net/browse/PPSC-697)

## Type of Change

* [x] New feature (non-breaking change which adds functionality)

## Problem

Armis Cloud has no visibility into which AI coding agents (Claude Code, Cursor, Copilot, Windsurf, etc.) are installed across developer workstations, nor whether those agents have the Armis AppSec MCP server configured. This data is needed to track agent adoption and MCP deployment coverage.

## Solution

Add a new `armis-cli agent-detection` command that scans the local filesystem for 15 AI coding agents and reports whether each has Armis AppSec MCP installed.

**Agent detection (`internal/agentdetect/`):**
- Detects 15 agents: Claude Code, Windsurf, Google Antigravity, GitHub Copilot, Cursor, Cline, Roo Code, Aider, Devin, OpenHands, Amazon Q, Junie, Zed, Continue, Gemini CLI
- Detection works by checking for config directories, VS Code extensions, JetBrains plugins, and platform-specific binary paths
- MCP installation status checked per-agent by parsing each agent's config format (mcp.json, settings.json, mcp_settings.json, context_servers, enabledPlugins)
- Platform-specific implementations for macOS, Linux, and Windows (user enumeration, app paths, JetBrains dirs)
- When run as root/admin, scans all user profiles; as regular user, scans only current user

**Output formats:**
- `--format plain` (default): grouped by user, one line per user with agents and MCP status
- `--format json`: flat array of `DetectedAgent` objects

**Install command updates:**
- Added Roo Code and Junie as new installable editor targets
- Added OpenHands to the "manual setup required" list

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [ ] Integration tests added/updated
* [x] All tests passing locally

### Manual Testing

1. `armis-cli agent-detection` — verified detection of locally installed agents (Claude Code, Cursor) with correct MCP status
2. `sudo armis-cli agent-detection --format json` — scan all users on the machine, JSON output
3. `armis-cli install roocode` / `armis-cli install junie` — verified new editor targets work

## Reviewer Notes

---

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] Documentation updated (if needed)
* [ ] Breaking changes documented (if applicable)
* [x] No new warnings generated


[PPSC-697]: https://armis-security.atlassian.net/browse/PPSC-697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ