### PR TITLE
[PPSC-724] fix(install): propagate writeEnvFromEnvironment errors

### DIFF
--- a/internal/install/claude.go
+++ b/internal/install/claude.go
@@ -57,7 +57,9 @@ func (ci *ClaudeInstaller) Install() error {
 		return fmt.Errorf("failed to enable plugin: %w", err)
 	}
 
-	writeEnvFromEnvironment(ci.EnvFilePath())
+	if err := writeEnvFromEnvironment(ci.EnvFilePath()); err != nil {
+		return fmt.Errorf("failed to write credentials: %w", err)
+	}
 
 	return nil
 }

--- a/internal/install/editors.go
+++ b/internal/install/editors.go
@@ -134,7 +134,9 @@ func (ei *EditorInstaller) FetchPlugin() error {
 	if err := ei.plugin.FetchAndInstall(ei.pluginDir); err != nil {
 		return err
 	}
-	writeEnvFromEnvironment(ei.EnvFilePath())
+	if err := writeEnvFromEnvironment(ei.EnvFilePath()); err != nil {
+		return fmt.Errorf("failed to write credentials: %w", err)
+	}
 	versionFile := filepath.Join(ei.pluginDir, ".installed-version")
 	_ = os.WriteFile(filepath.Clean(versionFile), []byte(ei.plugin.InstalledVersion()), 0o600)
 	return nil

--- a/internal/install/plugin.go
+++ b/internal/install/plugin.go
@@ -329,10 +329,12 @@ func findPython() string {
 // writeEnvFromEnvironment writes ARMIS_CLIENT_ID and ARMIS_CLIENT_SECRET to a .env
 // file if both are set in the current process environment. Returns nil if the file
 // was written or if there is nothing to do (file exists or env vars unset).
-// Returns an error only if credentials are available but the write fails.
+// Returns an error if the file's existence cannot be determined or if the write fails.
 func writeEnvFromEnvironment(envPath string) error {
 	if _, err := os.Stat(envPath); err == nil {
 		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("checking env file: %w", err)
 	}
 
 	clientID := os.Getenv("ARMIS_CLIENT_ID")

--- a/internal/install/plugin.go
+++ b/internal/install/plugin.go
@@ -327,27 +327,28 @@ func findPython() string {
 }
 
 // writeEnvFromEnvironment writes ARMIS_CLIENT_ID and ARMIS_CLIENT_SECRET to a .env
-// file if both are set in the current process environment. Returns true if the file
-// was written. Skips writing if the file already exists (to preserve user edits).
-func writeEnvFromEnvironment(envPath string) bool {
+// file if both are set in the current process environment. Returns nil if the file
+// was written or if there is nothing to do (file exists or env vars unset).
+// Returns an error only if credentials are available but the write fails.
+func writeEnvFromEnvironment(envPath string) error {
 	if _, err := os.Stat(envPath); err == nil {
-		return false
+		return nil
 	}
 
 	clientID := os.Getenv("ARMIS_CLIENT_ID")
 	clientSecret := os.Getenv("ARMIS_CLIENT_SECRET")
 	if clientID == "" || clientSecret == "" {
-		return false
+		return nil
 	}
 
 	content := fmt.Sprintf("ARMIS_CLIENT_ID=%s\nARMIS_CLIENT_SECRET=%s\n", clientID, clientSecret)
 	if err := os.MkdirAll(filepath.Dir(envPath), 0o750); err != nil {
-		return false
+		return fmt.Errorf("creating env directory: %w", err)
 	}
 	if err := os.WriteFile(filepath.Clean(envPath), []byte(content), 0o600); err != nil { // #nosec G703 - envPath is constructed from pluginDir + ".env"
-		return false
+		return fmt.Errorf("writing env file: %w", err)
 	}
-	return true
+	return nil
 }
 
 // writeHelperScript writes a standalone scan script that editors without

--- a/internal/install/plugin_test.go
+++ b/internal/install/plugin_test.go
@@ -249,6 +249,23 @@ func TestWriteEnvFromEnvironment(t *testing.T) {
 			t.Errorf("writeEnvFromEnvironment() returned error with only client ID: %v", err)
 		}
 	})
+
+	t.Run("returns error when stat fails for non-permission reasons", func(t *testing.T) {
+		t.Setenv("ARMIS_CLIENT_ID", "test-id")
+		t.Setenv("ARMIS_CLIENT_SECRET", "test-secret")
+
+		// Use a path inside a file (not a directory) to trigger a non-IsNotExist stat error
+		regularFile := filepath.Join(t.TempDir(), "not-a-dir")
+		if err := os.WriteFile(regularFile, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		badPath := filepath.Join(regularFile, ".env")
+
+		err := writeEnvFromEnvironment(badPath)
+		if err == nil {
+			t.Error("writeEnvFromEnvironment() should return error when stat fails unexpectedly")
+		}
+	})
 }
 
 // createTestTarball creates a gzipped tarball matching GitHub's format.

--- a/internal/install/plugin_test.go
+++ b/internal/install/plugin_test.go
@@ -189,8 +189,8 @@ func TestWriteEnvFromEnvironment(t *testing.T) {
 		t.Setenv("ARMIS_CLIENT_ID", "test-id")
 		t.Setenv("ARMIS_CLIENT_SECRET", "test-secret")
 
-		if !writeEnvFromEnvironment(envPath) {
-			t.Fatal("writeEnvFromEnvironment() returned false, want true")
+		if err := writeEnvFromEnvironment(envPath); err != nil {
+			t.Fatalf("writeEnvFromEnvironment() returned error: %v", err)
 		}
 
 		b, err := os.ReadFile(filepath.Clean(envPath))
@@ -217,8 +217,8 @@ func TestWriteEnvFromEnvironment(t *testing.T) {
 		t.Setenv("ARMIS_CLIENT_ID", "new-id")
 		t.Setenv("ARMIS_CLIENT_SECRET", "new-secret")
 
-		if writeEnvFromEnvironment(envPath) {
-			t.Error("writeEnvFromEnvironment() returned true for existing file")
+		if err := writeEnvFromEnvironment(envPath); err != nil {
+			t.Errorf("writeEnvFromEnvironment() returned error for existing file: %v", err)
 		}
 
 		b, _ := os.ReadFile(filepath.Clean(envPath))
@@ -232,8 +232,8 @@ func TestWriteEnvFromEnvironment(t *testing.T) {
 		t.Setenv("ARMIS_CLIENT_ID", "")
 		t.Setenv("ARMIS_CLIENT_SECRET", "")
 
-		if writeEnvFromEnvironment(freshPath) {
-			t.Error("writeEnvFromEnvironment() returned true with empty vars")
+		if err := writeEnvFromEnvironment(freshPath); err != nil {
+			t.Errorf("writeEnvFromEnvironment() returned error with empty vars: %v", err)
 		}
 		if _, err := os.Stat(freshPath); err == nil {
 			t.Error("file should not exist when vars are empty")
@@ -245,8 +245,8 @@ func TestWriteEnvFromEnvironment(t *testing.T) {
 		t.Setenv("ARMIS_CLIENT_ID", "test-id")
 		t.Setenv("ARMIS_CLIENT_SECRET", "")
 
-		if writeEnvFromEnvironment(freshPath) {
-			t.Error("writeEnvFromEnvironment() returned true with only client ID")
+		if err := writeEnvFromEnvironment(freshPath); err != nil {
+			t.Errorf("writeEnvFromEnvironment() returned error with only client ID: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Related Issue

* [PPSC-724](https://armis-security.atlassian.net/browse/PPSC-724)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

`writeEnvFromEnvironment` returned a `bool` that both callers (`claude.go:60` and `editors.go:137`) silently discarded. If `ARMIS_CLIENT_ID` and `ARMIS_CLIENT_SECRET` were set in the environment but the `.env` file failed to write (e.g. permission denied, disk full), `armis-cli install` reported success while the plugin had no credentials configured. Detected by CWE-253 (Incorrect Check of Function Return Value) in Armis Security Scanner.

## Solution

Changed `writeEnvFromEnvironment` signature from `bool` to `error`. Returns `nil` for no-op cases (file already exists, env vars unset) and a wrapped error for actual write failures. Both callers now propagate the error, causing the install command to fail visibly when credentials cannot be persisted.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [ ] Integration tests added/updated
* [x] All tests passing locally

### Manual Testing

Verified `go test ./internal/install/...` passes. All four existing test cases updated to assert on `error` return instead of `bool`.

## Reviewer Notes

- The function is unexported — no public API breakage.
- Pre-existing lint issues (gosec in `api/client_test.go`, `auth/client.go`, `scan/repo/repo.go`) are unrelated to this change.
- Error messages expose filesystem paths but never credential values.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [ ] Documentation updated (if needed)
* [ ] Breaking changes documented (if applicable)
* [x] No new warnings generated

[PPSC-724]: https://armis-security.atlassian.net/browse/PPSC-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ