### PR TITLE
PPSC-707 feat: add agent-detection collect subcommand

### DIFF
--- a/internal/agentdetect/agentdetect.go
+++ b/internal/agentdetect/agentdetect.go
@@ -76,9 +76,7 @@ func (s *Scanner) Scan() (*ScanResult, error) {
 			}
 			userResult.Agents = append(userResult.Agents, agent)
 		}
-		if len(userResult.Agents) > 0 {
-			result.Users = append(result.Users, userResult)
-		}
+		result.Users = append(result.Users, userResult)
 	}
 
 	return result, nil

--- a/internal/agentdetect/agentdetect_test.go
+++ b/internal/agentdetect/agentdetect_test.go
@@ -85,8 +85,14 @@ func TestScanner_Scan_NoAgents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Scan() error: %v", err)
 	}
-	if len(result.Users) != 0 {
-		t.Errorf("expected 0 users with agents, got %d", len(result.Users))
+	if len(result.Users) != 1 {
+		t.Fatalf("expected 1 user, got %d", len(result.Users))
+	}
+	if result.Users[0].User != "bob" {
+		t.Errorf("expected user bob, got %s", result.Users[0].User)
+	}
+	if len(result.Users[0].Agents) != 0 {
+		t.Errorf("expected 0 agents, got %d", len(result.Users[0].Agents))
 	}
 }
 
@@ -178,6 +184,30 @@ func TestFormatPlain(t *testing.T) {
 	}
 	if !strings.Contains(output, "Copilot(MCP:false)") {
 		t.Error("expected 'Copilot(MCP:false)' in output")
+	}
+}
+
+func TestFormatPlain_NoAgentsForUser(t *testing.T) {
+	cli.InitColors(cli.ColorModeNever)
+	output.SyncColors()
+
+	result := &ScanResult{
+		Users: []UserResult{
+			{User: "EmptyUser", Agents: nil},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := FormatPlain(result, &buf); err != nil {
+		t.Fatalf("FormatPlain() error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "user: EmptyUser") {
+		t.Errorf("expected 'user: EmptyUser' in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "No agents detected") {
+		t.Errorf("expected 'No agents detected' in output, got:\n%s", out)
 	}
 }
 

--- a/internal/agentdetect/format.go
+++ b/internal/agentdetect/format.go
@@ -23,6 +23,13 @@ func FormatPlain(result *ScanResult, w io.Writer) error {
 		if _, err := fmt.Fprintln(w, header); err != nil {
 			return err
 		}
+		if len(userResult.Agents) == 0 {
+			line := s.MutedText.Render("No agents detected")
+			if _, err := fmt.Fprintln(w, line); err != nil {
+				return err
+			}
+			continue
+		}
 		agents := make([]string, 0, len(userResult.Agents))
 		for _, agent := range userResult.Agents {
 			mcpStatus := s.ErrorText.Render("MCP:false")

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// AgentInventoryPayload is the request body for POST /api/v1/agents/inventory.
+type AgentInventoryPayload struct {
+	TenantID    string                `json:"tenant_id"`
+	MachineName string                `json:"machine_name"`
+	User        string                `json:"user"`
+	Agents      []AgentInventoryEntry `json:"agents"`
+}
+
+// AgentInventoryEntry describes a single detected agent within an inventory report.
+type AgentInventoryEntry struct {
+	Name              string  `json:"name"`
+	Version           *string `json:"version"`
+	ArmisMCPInstalled bool    `json:"armis_mcp_installed"`
+}
+
+// ReportAgentInventory posts an agent inventory payload to the Armis Cloud API.
+func (c *Client) ReportAgentInventory(ctx context.Context, payload AgentInventoryPayload) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal agent inventory payload: %w", err)
+	}
+
+	endpoint := strings.TrimSuffix(c.baseURL, "/") + "/api/v1/agents/inventory"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	if err := c.setAuthHeader(ctx, req); err != nil {
+		return err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to report agent inventory: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // response body read-only
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, MaxAPIResponseSize))
+		return &APIError{StatusCode: resp.StatusCode, Body: string(bodyBytes)}
+	}
+
+	return nil
+}

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -55,5 +55,6 @@ func (c *Client) ReportAgentInventory(ctx context.Context, payload AgentInventor
 		return &APIError{StatusCode: resp.StatusCode, Body: string(bodyBytes)}
 	}
 
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
 }

--- a/internal/api/agents_test.go
+++ b/internal/api/agents_test.go
@@ -1,0 +1,189 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/ArmisSecurity/armis-cli/internal/httpclient"
+	"github.com/ArmisSecurity/armis-cli/internal/testutil"
+)
+
+func TestClient_ReportAgentInventory(t *testing.T) {
+	t.Parallel()
+
+	t.Run("successful report", func(t *testing.T) {
+		t.Parallel()
+		var receivedPayload AgentInventoryPayload
+
+		server := testutil.NewTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("Expected POST, got %s", r.Method)
+			}
+			if r.URL.Path != "/api/v1/agents/inventory" {
+				t.Errorf("Unexpected path: %s", r.URL.Path)
+			}
+			if r.Header.Get("Content-Type") != "application/json" {
+				t.Errorf("Expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
+			}
+			if !testutil.ContainsSubstring(r.Header.Get("Authorization"), "Basic ") {
+				t.Error("Missing or invalid Authorization header")
+			}
+
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("Failed to read request body: %v", err)
+			}
+			if err := json.Unmarshal(body, &receivedPayload); err != nil {
+				t.Fatalf("Failed to unmarshal request body: %v", err)
+			}
+
+			w.WriteHeader(http.StatusOK)
+		})
+
+		client := newTestClient(t, server.URL)
+		version := "1.2.3"
+		payload := AgentInventoryPayload{
+			TenantID:    "tenant-1",
+			MachineName: "host1",
+			User:        "alice",
+			Agents: []AgentInventoryEntry{
+				{Name: "Cursor", Version: &version, ArmisMCPInstalled: true},
+				{Name: "Aider", Version: nil, ArmisMCPInstalled: false},
+			},
+		}
+
+		err := client.ReportAgentInventory(context.Background(), payload)
+		if err != nil {
+			t.Fatalf("ReportAgentInventory failed: %v", err)
+		}
+
+		if receivedPayload.TenantID != "tenant-1" {
+			t.Errorf("TenantID = %q, want %q", receivedPayload.TenantID, "tenant-1")
+		}
+		if receivedPayload.MachineName != "host1" {
+			t.Errorf("MachineName = %q, want %q", receivedPayload.MachineName, "host1")
+		}
+		if receivedPayload.User != "alice" {
+			t.Errorf("User = %q, want %q", receivedPayload.User, "alice")
+		}
+		if len(receivedPayload.Agents) != 2 {
+			t.Fatalf("len(Agents) = %d, want 2", len(receivedPayload.Agents))
+		}
+		if receivedPayload.Agents[0].Name != "Cursor" {
+			t.Errorf("Agents[0].Name = %q, want %q", receivedPayload.Agents[0].Name, "Cursor")
+		}
+		if receivedPayload.Agents[0].Version == nil || *receivedPayload.Agents[0].Version != "1.2.3" {
+			t.Errorf("Agents[0].Version = %v, want %q", receivedPayload.Agents[0].Version, "1.2.3")
+		}
+		if !receivedPayload.Agents[0].ArmisMCPInstalled {
+			t.Error("Agents[0].ArmisMCPInstalled = false, want true")
+		}
+		if receivedPayload.Agents[1].Version != nil {
+			t.Errorf("Agents[1].Version = %v, want nil", receivedPayload.Agents[1].Version)
+		}
+	})
+
+	t.Run("empty agents array", func(t *testing.T) {
+		t.Parallel()
+		var receivedPayload AgentInventoryPayload
+
+		server := testutil.NewTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("Failed to read request body: %v", err)
+			}
+			if err := json.Unmarshal(body, &receivedPayload); err != nil {
+				t.Fatalf("Failed to unmarshal request body: %v", err)
+			}
+			w.WriteHeader(http.StatusOK)
+		})
+
+		client := newTestClient(t, server.URL)
+		payload := AgentInventoryPayload{
+			MachineName: "host1",
+			User:        "bob",
+			Agents:      []AgentInventoryEntry{},
+		}
+
+		err := client.ReportAgentInventory(context.Background(), payload)
+		if err != nil {
+			t.Fatalf("ReportAgentInventory failed: %v", err)
+		}
+		if len(receivedPayload.Agents) != 0 {
+			t.Errorf("len(Agents) = %d, want 0", len(receivedPayload.Agents))
+		}
+	})
+
+	t.Run("API error", func(t *testing.T) {
+		t.Parallel()
+		server := testutil.NewTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+			testutil.ErrorResponse(w, http.StatusUnauthorized, "invalid credentials")
+		})
+
+		client := newTestClient(t, server.URL)
+		payload := AgentInventoryPayload{
+			MachineName: "host1",
+			User:        "alice",
+			Agents:      []AgentInventoryEntry{},
+		}
+
+		err := client.ReportAgentInventory(context.Background(), payload)
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		apiErr, ok := err.(*APIError)
+		if !ok {
+			t.Fatalf("Expected *APIError, got %T", err)
+		}
+		if apiErr.StatusCode != http.StatusUnauthorized {
+			t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, http.StatusUnauthorized)
+		}
+	})
+
+	t.Run("empty tenant_id", func(t *testing.T) {
+		t.Parallel()
+		var receivedPayload AgentInventoryPayload
+
+		server := testutil.NewTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("Failed to read request body: %v", err)
+			}
+			if err := json.Unmarshal(body, &receivedPayload); err != nil {
+				t.Fatalf("Failed to unmarshal request body: %v", err)
+			}
+			w.WriteHeader(http.StatusOK)
+		})
+
+		client := newTestClient(t, server.URL)
+		payload := AgentInventoryPayload{
+			TenantID:    "",
+			MachineName: "host1",
+			User:        "alice",
+			Agents:      []AgentInventoryEntry{},
+		}
+
+		err := client.ReportAgentInventory(context.Background(), payload)
+		if err != nil {
+			t.Fatalf("ReportAgentInventory failed: %v", err)
+		}
+		if receivedPayload.TenantID != "" {
+			t.Errorf("TenantID = %q, want empty string", receivedPayload.TenantID)
+		}
+	})
+}
+
+func newTestClient(t *testing.T, serverURL string) *Client {
+	t.Helper()
+	httpClient := httpclient.NewClient(httpclient.Config{Timeout: 5 * time.Second})
+	client, err := NewClient(serverURL, testutil.NewTestAuthProvider("token123"), false, 1*time.Minute,
+		WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+	return client
+}

--- a/internal/cmd/agent_detection_collect.go
+++ b/internal/cmd/agent_detection_collect.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ArmisSecurity/armis-cli/internal/agentdetect"
+	"github.com/ArmisSecurity/armis-cli/internal/api"
+	"github.com/ArmisSecurity/armis-cli/internal/cli"
+	"github.com/spf13/cobra"
+)
+
+var agentDetectionCollectCmd = &cobra.Command{
+	Use:   "collect",
+	Short: "Detect agents and report to Armis Cloud inventory",
+	Long: `Detect installed AI coding agents and report the results to the
+Armis Cloud agent inventory API. A separate report is sent for each user.
+
+When run as root (macOS/Linux) or SYSTEM (Windows), scans all local user profiles.
+When run as a standard user, scans only the current user's home directory.`,
+	Example: `  # Report detected agents for the current user
+  armis-cli agent-detection collect
+
+  # Report agents across all users (requires root/admin)
+  sudo armis-cli agent-detection collect`,
+	RunE: runAgentDetectionCollect,
+}
+
+func init() {
+	agentDetectionCmd.AddCommand(agentDetectionCollectCmd)
+}
+
+func runAgentDetectionCollect(cmd *cobra.Command, _ []string) error {
+	ctx, cancel := NewSignalContext()
+	defer cancel()
+
+	authProvider, err := getAuthProvider()
+	if err != nil {
+		return fmt.Errorf("authentication failed: %w", err)
+	}
+
+	tid, err := authProvider.GetTenantID(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get tenant ID: %w", err)
+	}
+
+	client, err := api.NewClient(getAPIBaseURL(), authProvider, debug, 0)
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	machineName, err := os.Hostname()
+	if err != nil {
+		return fmt.Errorf("failed to get hostname: %w", err)
+	}
+
+	platform := agentdetect.NewPlatform()
+	scanner := agentdetect.NewScanner(platform)
+	result, err := scanner.Scan()
+	if err != nil {
+		return fmt.Errorf("agent detection failed: %w", err)
+	}
+
+	var reportErrors []error
+	for _, userResult := range result.Users {
+		payload := buildInventoryPayload(tid, machineName, userResult)
+
+		if err := client.ReportAgentInventory(ctx, payload); err != nil {
+			cli.PrintWarningf("failed to report agents for user %s: %v", userResult.User, err)
+			reportErrors = append(reportErrors, err)
+			continue
+		}
+
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Reported %d agent(s) for user %s\n",
+			len(userResult.Agents), userResult.User)
+	}
+
+	if len(reportErrors) > 0 {
+		return fmt.Errorf("failed to report for %d user(s)", len(reportErrors))
+	}
+	return nil
+}
+
+func buildInventoryPayload(tenantID, machineName string, userResult agentdetect.UserResult) api.AgentInventoryPayload {
+	entries := make([]api.AgentInventoryEntry, 0, len(userResult.Agents))
+	for _, agent := range userResult.Agents {
+		entry := api.AgentInventoryEntry{
+			Name:              agent.Name,
+			ArmisMCPInstalled: agent.MCPInstalled,
+		}
+		if agent.Version != "" {
+			v := agent.Version
+			entry.Version = &v
+		}
+		entries = append(entries, entry)
+	}
+	return api.AgentInventoryPayload{
+		TenantID:    tenantID,
+		MachineName: machineName,
+		User:        userResult.User,
+		Agents:      entries,
+	}
+}

--- a/internal/cmd/agent_detection_collect_test.go
+++ b/internal/cmd/agent_detection_collect_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/ArmisSecurity/armis-cli/internal/agentdetect"
+	"github.com/ArmisSecurity/armis-cli/internal/api"
+)
+
+func TestBuildInventoryPayload(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with agents", func(t *testing.T) {
+		t.Parallel()
+		userResult := agentdetect.UserResult{
+			User: "alice",
+			Agents: []agentdetect.DetectedAgent{
+				{Name: "Cursor", MCPInstalled: true, Version: "1.2.3", User: "alice"},
+				{Name: "Aider", MCPInstalled: false, Version: "", User: "alice"},
+			},
+		}
+
+		payload := buildInventoryPayload("tenant-1", "host1", userResult)
+
+		if payload.TenantID != "tenant-1" {
+			t.Errorf("TenantID = %q, want %q", payload.TenantID, "tenant-1")
+		}
+		if payload.MachineName != "host1" {
+			t.Errorf("MachineName = %q, want %q", payload.MachineName, "host1")
+		}
+		if payload.User != "alice" {
+			t.Errorf("User = %q, want %q", payload.User, "alice")
+		}
+		if len(payload.Agents) != 2 {
+			t.Fatalf("len(Agents) = %d, want 2", len(payload.Agents))
+		}
+
+		assertAgent(t, payload.Agents[0], "Cursor", strPtr("1.2.3"), true)
+		assertAgent(t, payload.Agents[1], "Aider", nil, false)
+	})
+
+	t.Run("empty agents", func(t *testing.T) {
+		t.Parallel()
+		userResult := agentdetect.UserResult{
+			User:   "bob",
+			Agents: nil,
+		}
+
+		payload := buildInventoryPayload("", "host2", userResult)
+
+		if payload.TenantID != "" {
+			t.Errorf("TenantID = %q, want empty", payload.TenantID)
+		}
+		if payload.User != "bob" {
+			t.Errorf("User = %q, want %q", payload.User, "bob")
+		}
+		if len(payload.Agents) != 0 {
+			t.Errorf("len(Agents) = %d, want 0", len(payload.Agents))
+		}
+	})
+}
+
+func assertAgent(t *testing.T, agent api.AgentInventoryEntry, name string, version *string, mcp bool) {
+	t.Helper()
+	if agent.Name != name {
+		t.Errorf("Name = %q, want %q", agent.Name, name)
+	}
+	if agent.ArmisMCPInstalled != mcp {
+		t.Errorf("ArmisMCPInstalled = %v, want %v", agent.ArmisMCPInstalled, mcp)
+	}
+	if version == nil {
+		if agent.Version != nil {
+			t.Errorf("Version = %v, want nil", agent.Version)
+		}
+	} else {
+		if agent.Version == nil || *agent.Version != *version {
+			t.Errorf("Version = %v, want %q", agent.Version, *version)
+		}
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
## Related Issue

* [PPSC-707](https://your-jira.atlassian.net/browse/PPSC-707)

## Type of Change

* [x] New feature (non-breaking change which adds functionality)

## Problem

The `agent-detection` command can detect installed AI coding agents locally, but there is no way to report that inventory to Armis Cloud so the security team has centralized visibility.

## Solution

Add `armis-cli agent-detection collect` subcommand that reports detected agents to the Armis Cloud inventory API (`POST /api/v1/agents/inventory`).

- One request is sent per user, keyed by `(tenant_id, machine_name, user)` — each POST fully replaces the previous record
- Users with zero detected agents are still reported with an empty agents array, so the server has a complete picture of scanned profiles
- `tenant_id` is extracted from JWT; `machine_name` from `os.Hostname()`
- Errors for individual users are reported as warnings; the command continues to report remaining users and returns a summary error at the end

Also includes a small change to the scanner: `Scan()` now includes all successfully scanned users in the result (previously users with no agents were filtered out). `FormatPlain` shows "No agents detected" for these users.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

Coverage includes:
- API client: successful report, empty agents array, API error handling, full payload serialization
- `buildInventoryPayload`: version mapping (`nil` vs `*string`), MCP flag pass-through
- Scanner: users with no agents now included in results
- Output formatting: "No agents detected" message for empty users

### Manual Testing

- Ran `armis-cli agent-detection collect` against dev environment

## Reviewer Notes

- The `collect` subcommand does not support `--format` — it only reports to the API
- Users where home directory resolution fails are silently skipped (warning to stderr), but successfully scanned users with no agents are still reported

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] Documentation updated (if needed)
* [x] No new warnings generated


[PPSC-707]: https://armis-security.atlassian.net/browse/PPSC-707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ