### PR TITLE
[PPSC-733] fix(sarif): normalize rule IDs and remove unstable fingerprints

### DIFF
--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -156,26 +156,27 @@ var (
 	mdBlockquoteRegex = regexp.MustCompile(`(?m)^>\s*`)
 )
 
-// Compiled regexes for CWE/CVE ID normalization.
+// Compiled regexes for CWE/CVE ID normalization (case-insensitive).
 var (
-	cwePattern = regexp.MustCompile(`^(CWE-\d+)`)
-	cvePattern = regexp.MustCompile(`^(CVE-\d{4}-\d+)`)
+	cwePattern = regexp.MustCompile(`(?i)^(CWE-\d+)`)
+	cvePattern = regexp.MustCompile(`(?i)^(CVE-\d{4}-\d+)`)
 )
 
-// normalizeCWE extracts just the CWE identifier (e.g. "CWE-78") from a string
-// that may include a full title (e.g. "CWE-78: Improper Neutralization...").
+// normalizeCWE extracts just the CWE identifier from a string that may include
+// a full title (e.g. "CWE-78: Improper Neutralization...") and canonicalizes
+// to uppercase (e.g. "cwe-78" → "CWE-78").
 func normalizeCWE(s string) string {
 	if m := cwePattern.FindString(s); m != "" {
-		return m
+		return strings.ToUpper(m)
 	}
 	return s
 }
 
-// normalizeCVE extracts just the CVE identifier (e.g. "CVE-2024-1234") from a
-// string that may include a description suffix.
+// normalizeCVE extracts just the CVE identifier from a string that may include
+// a description suffix and canonicalizes to uppercase (e.g. "cve-2024-1234" → "CVE-2024-1234").
 func normalizeCVE(s string) string {
 	if m := cvePattern.FindString(s); m != "" {
-		return m
+		return strings.ToUpper(m)
 	}
 	return s
 }

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -1,8 +1,6 @@
 package output
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -158,6 +156,30 @@ var (
 	mdBlockquoteRegex = regexp.MustCompile(`(?m)^>\s*`)
 )
 
+// Compiled regexes for CWE/CVE ID normalization.
+var (
+	cwePattern = regexp.MustCompile(`^(CWE-\d+)`)
+	cvePattern = regexp.MustCompile(`^(CVE-\d{4}-\d+)`)
+)
+
+// normalizeCWE extracts just the CWE identifier (e.g. "CWE-78") from a string
+// that may include a full title (e.g. "CWE-78: Improper Neutralization...").
+func normalizeCWE(s string) string {
+	if m := cwePattern.FindString(s); m != "" {
+		return m
+	}
+	return s
+}
+
+// normalizeCVE extracts just the CVE identifier (e.g. "CVE-2024-1234") from a
+// string that may include a description suffix.
+func normalizeCVE(s string) string {
+	if m := cvePattern.FindString(s); m != "" {
+		return m
+	}
+	return s
+}
+
 // stripMarkdown removes common markdown formatting to produce plain text.
 // Used to generate SARIF Help.Text from markdown content per SARIF 2.1.0 spec,
 // which requires Help.Text to be readable without markdown rendering.
@@ -214,39 +236,21 @@ func firstNonEmpty(values []string) string {
 }
 
 // stableRuleID derives a stable SARIF ruleId from a finding's classification.
+// Normalizes CWE/CVE identifiers to strip variable description text that the
+// backend may return differently between runs, ensuring GitHub Code Scanning
+// can match alerts across runs.
 // Falls back through CWE → CVE → FindingCategory → finding.ID.
 func stableRuleID(finding model.Finding) string {
 	if v := firstNonEmpty(finding.CWEs); v != "" {
-		return v
+		return normalizeCWE(v)
 	}
 	if v := firstNonEmpty(finding.CVEs); v != "" {
-		return v
+		return normalizeCVE(v)
 	}
 	if v := strings.TrimSpace(finding.FindingCategory); v != "" {
 		return v
 	}
 	return finding.ID
-}
-
-// computeFingerprint produces a stable SHA-256 fingerprint for cross-run dedup.
-// Uses length-prefixed fields to prevent separator collision between different tuples.
-func computeFingerprint(ruleID, file, snippet string, startLine int) string {
-	h := sha256.New()
-
-	writeField := func(name, value string) {
-		fmt.Fprintf(h, "%s:%d:", name, len(value)) //nolint:errcheck,gosec // hash.Write never returns an error
-		io.WriteString(h, value)                   //nolint:errcheck,gosec // hash.Write never returns an error
-	}
-
-	writeField("ruleID", ruleID)
-	writeField("file", file)
-	if snippet != "" {
-		writeField("snippet", snippet)
-	} else {
-		writeField("startLine", strconv.Itoa(startLine))
-	}
-
-	return hex.EncodeToString(h.Sum(nil))
 }
 
 // buildRules creates SARIF rules from findings, deduplicating by rule ID.
@@ -345,9 +349,6 @@ func convertToSarifResults(findings []model.Finding, ruleIndexMap map[string]int
 			Level:     severityToSarifLevel(finding.Severity),
 			Message: sarifMessage{
 				Text: buildMessageText(finding.Title, finding.Description),
-			},
-			PartialFingerprints: map[string]string{
-				"primaryLocationLineHash": computeFingerprint(ruleID, resolvedFile, finding.CodeSnippet, finding.StartLine),
 			},
 			Properties: &sarifResultProperties{
 				FindingID:   finding.ID,
@@ -464,18 +465,19 @@ func severityToSecurityScore(severity model.Severity) string {
 // Priority matches stableRuleID: CWE → CVE → reference URL.
 func generateHelpURI(finding model.Finding) string {
 	if cweID := firstNonEmpty(finding.CWEs); cweID != "" {
+		normalized := normalizeCWE(cweID)
 		var cweNum string
-		if strings.HasPrefix(strings.ToUpper(cweID), "CWE-") {
-			cweNum = cweID[4:]
+		if strings.HasPrefix(strings.ToUpper(normalized), "CWE-") {
+			cweNum = normalized[4:]
 		} else {
-			cweNum = cweID
+			cweNum = normalized
 		}
 		if _, err := strconv.Atoi(cweNum); err == nil {
 			return "https://cwe.mitre.org/data/definitions/" + cweNum + ".html"
 		}
 	}
 	if cve := firstNonEmpty(finding.CVEs); cve != "" {
-		return "https://nvd.nist.gov/vuln/detail/" + cve
+		return "https://nvd.nist.gov/vuln/detail/" + normalizeCVE(cve)
 	}
 	if len(finding.URLs) > 0 {
 		return finding.URLs[0]

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -745,6 +745,11 @@ func TestGenerateHelpURI(t *testing.T) {
 			expected: "https://cwe.mitre.org/data/definitions/89.html",
 		},
 		{
+			name:     "CWE with full title is normalized",
+			finding:  model.Finding{CWEs: []string{"CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"}},
+			expected: "https://cwe.mitre.org/data/definitions/78.html",
+		},
+		{
 			name:     "CVE used when no CWE",
 			finding:  model.Finding{CVEs: []string{"CVE-2023-1234"}},
 			expected: "https://nvd.nist.gov/vuln/detail/CVE-2023-1234",
@@ -1217,6 +1222,52 @@ func TestSARIF_SchemaValidation(t *testing.T) {
 	}
 }
 
+func TestNormalizeCWE(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"CWE-78", "CWE-78"},
+		{"CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')", "CWE-78"},
+		{"CWE-1004: Sensitive Cookie Without 'HttpOnly' Flag", "CWE-1004"},
+		{"CWE-79", "CWE-79"},
+		{"not-a-cwe", "not-a-cwe"},
+		{"", ""},
+		{"cwe-78: lowercase", "cwe-78: lowercase"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeCWE(tt.input)
+			if got != tt.expected {
+				t.Errorf("normalizeCWE(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeCVE(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"CVE-2024-1234", "CVE-2024-1234"},
+		{"CVE-2024-1234: Some description", "CVE-2024-1234"},
+		{"CVE-2024-12345678", "CVE-2024-12345678"},
+		{"not-a-cve", "not-a-cve"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeCVE(tt.input)
+			if got != tt.expected {
+				t.Errorf("normalizeCVE(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestStableRuleID(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1229,9 +1280,24 @@ func TestStableRuleID(t *testing.T) {
 			expected: "CWE-79",
 		},
 		{
+			name:     "CWE full title is normalized",
+			finding:  model.Finding{ID: "server-id-cwe-full", CWEs: []string{"CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"}},
+			expected: "CWE-78",
+		},
+		{
+			name:     "multiple CWEs sorted then normalized",
+			finding:  model.Finding{ID: "multi-norm", CWEs: []string{"CWE-89: SQL Injection", "CWE-22: Path Traversal"}},
+			expected: "CWE-22",
+		},
+		{
 			name:     "CVE when no CWE",
 			finding:  model.Finding{ID: "server-id-456", CVEs: []string{"CVE-2023-5678"}},
 			expected: "CVE-2023-5678",
+		},
+		{
+			name:     "CVE with description is normalized",
+			finding:  model.Finding{ID: "server-id-cve-desc", CVEs: []string{"CVE-2024-1234: Some vulnerability"}},
+			expected: "CVE-2024-1234",
 		},
 		{
 			name:     "FindingCategory when no CWE/CVE",
@@ -1283,59 +1349,6 @@ func TestStableRuleID(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestComputeFingerprint(t *testing.T) {
-	t.Run("deterministic", func(t *testing.T) {
-		fp1 := computeFingerprint("CWE-79", "src/app.js", "eval(input)", 10)
-		fp2 := computeFingerprint("CWE-79", "src/app.js", "eval(input)", 10)
-		if fp1 != fp2 {
-			t.Errorf("fingerprint not deterministic: %q != %q", fp1, fp2)
-		}
-	})
-
-	t.Run("uses snippet when available", func(t *testing.T) {
-		withSnippet := computeFingerprint("CWE-79", "src/app.js", "eval(input)", 10)
-		diffLine := computeFingerprint("CWE-79", "src/app.js", "eval(input)", 99)
-		if withSnippet != diffLine {
-			t.Error("fingerprint should ignore startLine when snippet is present")
-		}
-	})
-
-	t.Run("falls back to startLine without snippet", func(t *testing.T) {
-		fp1 := computeFingerprint("CWE-79", "src/app.js", "", 10)
-		fp2 := computeFingerprint("CWE-79", "src/app.js", "", 20)
-		if fp1 == fp2 {
-			t.Error("fingerprint should differ when startLine differs and no snippet")
-		}
-	})
-
-	t.Run("different inputs produce different hashes", func(t *testing.T) {
-		fp1 := computeFingerprint("CWE-79", "src/app.js", "eval(input)", 10)
-		fp2 := computeFingerprint("CWE-22", "src/app.js", "eval(input)", 10)
-		fp3 := computeFingerprint("CWE-79", "src/other.js", "eval(input)", 10)
-		if fp1 == fp2 {
-			t.Error("different ruleIDs should produce different fingerprints")
-		}
-		if fp1 == fp3 {
-			t.Error("different files should produce different fingerprints")
-		}
-	})
-
-	t.Run("returns hex-encoded SHA-256", func(t *testing.T) {
-		fp := computeFingerprint("CWE-79", "src/app.js", "eval(input)", 10)
-		if len(fp) != 64 {
-			t.Errorf("expected 64 hex chars, got %d", len(fp))
-		}
-	})
-
-	t.Run("no separator collision", func(t *testing.T) {
-		fp1 := computeFingerprint("CWE:7", "9", "snippet", 1)
-		fp2 := computeFingerprint("CWE", "7:9", "snippet", 1)
-		if fp1 == fp2 {
-			t.Error("length-prefixed encoding should prevent separator collision")
-		}
-	})
 }
 
 func TestBuildRulesStableCollapsing(t *testing.T) {
@@ -1407,11 +1420,8 @@ func TestSARIFFormatter_FindingIDAndFingerprints(t *testing.T) {
 		t.Errorf("ruleId = %q, want CWE-79", res.RuleID)
 	}
 
-	if res.PartialFingerprints == nil {
-		t.Fatal("expected partialFingerprints to be set")
-	}
-	if fp, ok := res.PartialFingerprints["primaryLocationLineHash"]; !ok || fp == "" {
-		t.Error("expected primaryLocationLineHash to be non-empty")
+	if res.PartialFingerprints != nil {
+		t.Errorf("expected partialFingerprints to be nil (delegated to upload-sarif action), got %v", res.PartialFingerprints)
 	}
 
 	if res.Properties == nil {

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -1231,9 +1231,11 @@ func TestNormalizeCWE(t *testing.T) {
 		{"CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')", "CWE-78"},
 		{"CWE-1004: Sensitive Cookie Without 'HttpOnly' Flag", "CWE-1004"},
 		{"CWE-79", "CWE-79"},
+		{"cwe-78", "CWE-78"},
+		{"cwe-78: lowercase with title", "CWE-78"},
+		{"Cwe-200: Mixed Case", "CWE-200"},
 		{"not-a-cwe", "not-a-cwe"},
 		{"", ""},
-		{"cwe-78: lowercase", "cwe-78: lowercase"},
 	}
 
 	for _, tt := range tests {
@@ -1254,6 +1256,9 @@ func TestNormalizeCVE(t *testing.T) {
 		{"CVE-2024-1234", "CVE-2024-1234"},
 		{"CVE-2024-1234: Some description", "CVE-2024-1234"},
 		{"CVE-2024-12345678", "CVE-2024-12345678"},
+		{"cve-2024-1234", "CVE-2024-1234"},
+		{"cve-2024-5678: lowercase with desc", "CVE-2024-5678"},
+		{"Cve-2024-9999: Mixed Case", "CVE-2024-9999"},
 		{"not-a-cve", "not-a-cve"},
 		{"", ""},
 	}
@@ -1298,6 +1303,16 @@ func TestStableRuleID(t *testing.T) {
 			name:     "CVE with description is normalized",
 			finding:  model.Finding{ID: "server-id-cve-desc", CVEs: []string{"CVE-2024-1234: Some vulnerability"}},
 			expected: "CVE-2024-1234",
+		},
+		{
+			name:     "lowercase CWE is canonicalized to uppercase",
+			finding:  model.Finding{ID: "server-id-lower-cwe", CWEs: []string{"cwe-78: os command injection"}},
+			expected: "CWE-78",
+		},
+		{
+			name:     "mixed-case CVE is canonicalized to uppercase",
+			finding:  model.Finding{ID: "server-id-mixed-cve", CVEs: []string{"Cve-2024-5678"}},
+			expected: "CVE-2024-5678",
 		},
 		{
 			name:     "FindingCategory when no CWE/CVE",


### PR DESCRIPTION
## Related Issue

* [PPSC-733](https://armis-security.atlassian.net/browse/PPSC-733)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

The daily security scan creates ~30 new GitHub Code Scanning alerts every day instead of matching existing ones. Over 800 alerts have been dismissed with no end in sight. The root cause is that the backend returns CWE descriptions with inconsistent title text between runs (e.g. "Command Injection" vs "OS Command Injection"), and GitHub uses `(tool + category + ruleId)` as the dedup key — so different text = new alert. Additionally, our custom `partialFingerprints` encode the unstable rule ID, which prevents the `upload-sarif` action from using its own stable fingerprints.

## Solution

1. **Normalize rule IDs** — `stableRuleID()` now strips CWE/CVE descriptions to just the identifier (e.g. `CWE-78: Improper Neutralization...` → `CWE-78`).
2. **Remove `partialFingerprints`** — deleted `computeFingerprint()` and its emission. The `codeql-action/upload-sarif@v4` action will now calculate its own stable fingerprints from source code hashes.
3. **Fix `generateHelpURI()`** — now uses normalization before extracting the CWE number, fixing a latent bug where full-title inputs caused `strconv.Atoi` failures.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

- `go test -v ./internal/output/... -run TestNormalizeCWE` — all pass
- `go test -v ./internal/output/... -run TestNormalizeCVE` — all pass
- `go test -v ./internal/output/... -run TestStableRuleID` — all pass (includes new normalization cases)
- `go test -v ./internal/output/... -run TestGenerateHelpURI` — all pass (includes full-title CWE case)
- `go test -v ./internal/output/... -run TestSARIFFormatter_FindingIDAndFingerprints` — asserts nil fingerprints
- `go test -short ./internal/output/...` — full package passes

## Reviewer Notes

- After merge, the next scan will produce clean `CWE-78` style rule IDs + action-calculated fingerprints
- Existing open alerts with full-title rule IDs won't match → GitHub will auto-close them as "fixed"
- New alerts appear with stable IDs — one final round of dismissal needed, then dismissed alerts stay dismissed
- Pre-existing lint warnings in `internal/api/` and `internal/auth/` are unrelated (gosec G117/G120/G122)

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-733]: https://armis-security.atlassian.net/browse/PPSC-733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ