### PR TITLE
[PPSC-734] feat(action): add JWT authentication support to GitHub Action

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -58,5 +58,7 @@ jobs:
       # PR comment only makes sense for pull_request events
       pr-comment: ${{ github.event_name == 'pull_request' }}
     secrets:
+      client-id: ${{ secrets.ARMIS_CLIENT_ID }}
+      client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}
       api-token: ${{ secrets.ARMIS_API_TOKEN }}
       tenant-id: ${{ secrets.ARMIS_TENANT_ID }}

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -39,6 +39,10 @@ on:
         description: 'Comma-separated list of file paths to scan (relative to repository root)'
         type: string
         default: ''
+      region:
+        description: 'Armis cloud region for JWT authentication (overrides auto-discovery)'
+        type: string
+        default: ''
       build-from-source:
         description: 'Build CLI from source instead of downloading release (for testing scanner changes)'
         type: boolean
@@ -90,6 +94,7 @@ jobs:
           scan-target: ${{ inputs.scan-target }}
           client-id: ${{ secrets.client-id }}
           client-secret: ${{ secrets.client-secret }}
+          region: ${{ inputs.region }}
           api-token: ${{ secrets.api-token }}
           tenant-id: ${{ secrets.tenant-id }}
           format: sarif

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -44,12 +44,18 @@ on:
         type: boolean
         default: false
     secrets:
+      client-id:
+        description: 'Client ID for JWT authentication (recommended)'
+        required: false
+      client-secret:
+        description: 'Client secret for JWT authentication (recommended)'
+        required: false
       api-token:
-        description: 'Armis API token for authentication'
-        required: true
+        description: 'Armis API token for Basic authentication (legacy)'
+        required: false
       tenant-id:
-        description: 'Tenant identifier for Armis Cloud'
-        required: true
+        description: 'Tenant identifier for Armis Cloud (legacy, not needed with JWT)'
+        required: false
 
 # Top-level permissions define the maximum permissions available to this workflow.
 # Job-level permissions further restrict as needed.
@@ -82,6 +88,8 @@ jobs:
         with:
           scan-type: ${{ inputs.scan-type }}
           scan-target: ${{ inputs.scan-target }}
+          client-id: ${{ secrets.client-id }}
+          client-secret: ${{ secrets.client-secret }}
           api-token: ${{ secrets.api-token }}
           tenant-id: ${{ secrets.tenant-id }}
           format: sarif

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -23,5 +23,7 @@ jobs:
       scan-timeout: 120  # 2 hours
       build-from-source: false
     secrets:
+      client-id: ${{ secrets.ARMIS_CLIENT_ID }}
+      client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}
       api-token: ${{ secrets.ARMIS_API_TOKEN }}
       tenant-id: ${{ secrets.ARMIS_TENANT_ID }}

--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ jobs:
 | `image-tarball` | string | | Path to image tarball (for image scans) |
 | `scan-timeout` | number | `60` | Scan timeout in minutes |
 | `include-files` | string | | Comma-separated file paths to scan (for targeted scanning) |
+| `region` | string | | Armis cloud region (overrides auto-discovery) |
 
 **Required secrets:**
 

--- a/README.md
+++ b/README.md
@@ -520,8 +520,8 @@ jobs:
     with:
       fail-on: CRITICAL,HIGH
     secrets:
-      api-token: ${{ secrets.ARMIS_API_TOKEN }}
-      tenant-id: ${{ secrets.ARMIS_TENANT_ID }}
+      client-id: ${{ secrets.ARMIS_CLIENT_ID }}
+      client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}
 ```
 
 **Available inputs:**
@@ -540,10 +540,10 @@ jobs:
 
 **Required secrets:**
 
-- `api-token`: Armis API token for authentication (legacy — JWT support coming soon)
-- `tenant-id`: Tenant identifier for Armis Cloud (legacy — not needed with JWT)
+- `client-id`: Client ID for JWT authentication (from VIPR external API screen)
+- `client-secret`: Client secret for JWT authentication
 
-> **Note:** The reusable workflow currently accepts Basic auth secrets. For JWT authentication in CI, set `ARMIS_CLIENT_ID` and `ARMIS_CLIENT_SECRET` as environment variables directly in your workflow steps (see [Manual Installation](#option-3-manual-installation) below).
+> **Legacy:** For backward compatibility, `api-token` and `tenant-id` secrets are also accepted.
 
 #### Option 2: GitHub Action
 
@@ -564,8 +564,8 @@ jobs:
       - uses: ArmisSecurity/armis-cli@main
         with:
           scan-type: repo
-          api-token: ${{ secrets.ARMIS_API_TOKEN }}
-          tenant-id: ${{ secrets.ARMIS_TENANT_ID }}
+          client-id: ${{ secrets.ARMIS_CLIENT_ID }}
+          client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}
           format: sarif
           output-file: results.sarif
           fail-on: HIGH,CRITICAL

--- a/action.yml
+++ b/action.yml
@@ -14,12 +14,22 @@ inputs:
     description: 'Target to scan (path for repo, image name for image scan)'
     required: false
     default: '.'
+  client-id:
+    description: 'Client ID for JWT authentication (recommended)'
+    required: false
+  client-secret:
+    description: 'Client secret for JWT authentication (recommended)'
+    required: false
+  region:
+    description: 'Armis cloud region for JWT authentication'
+    required: false
+    default: ''
   api-token:
-    description: 'Armis API token for authentication'
-    required: true
+    description: 'Armis API token for Basic authentication (legacy)'
+    required: false
   tenant-id:
-    description: 'Tenant identifier for Armis Cloud'
-    required: true
+    description: 'Tenant identifier for Armis Cloud (legacy, not needed with JWT)'
+    required: false
   format:
     description: 'Output format: human, json, sarif, junit'
     required: false
@@ -151,6 +161,9 @@ runs:
       id: scan
       shell: bash
       env:
+        ARMIS_CLIENT_ID: ${{ inputs.client-id }}
+        ARMIS_CLIENT_SECRET: ${{ inputs.client-secret }}
+        ARMIS_REGION: ${{ inputs.region }}
         ARMIS_API_TOKEN: ${{ inputs.api-token }}
         ARMIS_TENANT_ID: ${{ inputs.tenant-id }}
         SCAN_TYPE: ${{ inputs.scan-type }}
@@ -166,6 +179,24 @@ runs:
       run: |
         set +e
 
+        # Validate authentication: require JWT (client-id + client-secret) OR Basic (api-token + tenant-id)
+        if [ -n "$ARMIS_CLIENT_ID" ] && [ -z "$ARMIS_CLIENT_SECRET" ]; then
+          echo "Error: 'client-id' provided without 'client-secret'. Both are required for JWT authentication."
+          exit 1
+        fi
+        if [ -z "$ARMIS_CLIENT_ID" ] && [ -n "$ARMIS_CLIENT_SECRET" ]; then
+          echo "Error: 'client-secret' provided without 'client-id'. Both are required for JWT authentication."
+          exit 1
+        fi
+        if [ -n "$ARMIS_API_TOKEN" ] && [ -z "$ARMIS_TENANT_ID" ]; then
+          echo "Error: 'api-token' provided without 'tenant-id'. Both are required for Basic authentication."
+          exit 1
+        fi
+        if [ -z "$ARMIS_CLIENT_ID" ] && [ -z "$ARMIS_API_TOKEN" ]; then
+          echo "Error: No authentication provided. Set 'client-id' + 'client-secret' (recommended) or 'api-token' + 'tenant-id' (legacy)."
+          exit 1
+        fi
+
         # Validate scan-type to prevent injection
         if [[ "$SCAN_TYPE" != "repo" && "$SCAN_TYPE" != "image" ]]; then
           echo "Error: Invalid scan-type '$SCAN_TYPE'. Must be 'repo' or 'image'."
@@ -174,7 +205,9 @@ runs:
 
         # Build command arguments array for safe execution
         SCAN_ARGS=("scan" "$SCAN_TYPE" "$SCAN_TARGET")
-        SCAN_ARGS+=("--tenant-id" "$ARMIS_TENANT_ID")
+        if [ -n "$ARMIS_TENANT_ID" ]; then
+          SCAN_ARGS+=("--tenant-id" "$ARMIS_TENANT_ID")
+        fi
         SCAN_ARGS+=("--format" "$OUTPUT_FORMAT")
 
         if [ -n "$FAIL_ON" ]; then

--- a/action.yml
+++ b/action.yml
@@ -195,17 +195,20 @@ runs:
           echo "Error: 'client-secret' provided without 'client-id'. Both are required for JWT authentication."
           exit 1
         fi
-        if [ -n "$ARMIS_API_TOKEN" ] && [ -z "$ARMIS_TENANT_ID" ]; then
-          echo "Error: 'api-token' provided without 'tenant-id'. Both are required for Basic authentication."
-          exit 1
-        fi
-        if [ -z "$ARMIS_API_TOKEN" ] && [ -n "$ARMIS_TENANT_ID" ]; then
-          echo "Error: 'tenant-id' provided without 'api-token'. Both are required for Basic authentication."
-          exit 1
-        fi
-        if [ -z "$ARMIS_CLIENT_ID" ] && [ -z "$ARMIS_API_TOKEN" ]; then
-          echo "Error: No authentication provided. Set 'client-id' + 'client-secret' (recommended) or 'api-token' + 'tenant-id' (legacy)."
-          exit 1
+        # Only validate Basic auth pairing when JWT is not configured (JWT takes precedence)
+        if [ -z "$ARMIS_CLIENT_ID" ]; then
+          if [ -n "$ARMIS_API_TOKEN" ] && [ -z "$ARMIS_TENANT_ID" ]; then
+            echo "Error: 'api-token' provided without 'tenant-id'. Both are required for Basic authentication."
+            exit 1
+          fi
+          if [ -z "$ARMIS_API_TOKEN" ] && [ -n "$ARMIS_TENANT_ID" ]; then
+            echo "Error: 'tenant-id' provided without 'api-token'. Both are required for Basic authentication."
+            exit 1
+          fi
+          if [ -z "$ARMIS_API_TOKEN" ]; then
+            echo "Error: No authentication provided. Set 'client-id' + 'client-secret' (recommended) or 'api-token' + 'tenant-id' (legacy)."
+            exit 1
+          fi
         fi
 
         # Validate scan-type to prevent injection

--- a/action.yml
+++ b/action.yml
@@ -161,11 +161,11 @@ runs:
       id: scan
       shell: bash
       env:
-        ARMIS_CLIENT_ID: ${{ inputs.client-id }}
-        ARMIS_CLIENT_SECRET: ${{ inputs.client-secret }}
-        ARMIS_REGION: ${{ inputs.region }}
-        ARMIS_API_TOKEN: ${{ inputs.api-token }}
-        ARMIS_TENANT_ID: ${{ inputs.tenant-id }}
+        INPUT_CLIENT_ID: ${{ inputs.client-id }}
+        INPUT_CLIENT_SECRET: ${{ inputs.client-secret }}
+        INPUT_REGION: ${{ inputs.region }}
+        INPUT_API_TOKEN: ${{ inputs.api-token }}
+        INPUT_TENANT_ID: ${{ inputs.tenant-id }}
         SCAN_TYPE: ${{ inputs.scan-type }}
         SCAN_TARGET: ${{ inputs.scan-target }}
         OUTPUT_FORMAT: ${{ inputs.format }}
@@ -179,6 +179,13 @@ runs:
       run: |
         set +e
 
+        # Set ARMIS_* env vars only when inputs are non-empty (avoids overriding job/step-level env)
+        if [ -n "$INPUT_CLIENT_ID" ]; then export ARMIS_CLIENT_ID="$INPUT_CLIENT_ID"; fi
+        if [ -n "$INPUT_CLIENT_SECRET" ]; then export ARMIS_CLIENT_SECRET="$INPUT_CLIENT_SECRET"; fi
+        if [ -n "$INPUT_REGION" ]; then export ARMIS_REGION="$INPUT_REGION"; fi
+        if [ -n "$INPUT_API_TOKEN" ]; then export ARMIS_API_TOKEN="$INPUT_API_TOKEN"; fi
+        if [ -n "$INPUT_TENANT_ID" ]; then export ARMIS_TENANT_ID="$INPUT_TENANT_ID"; fi
+
         # Validate authentication: require JWT (client-id + client-secret) OR Basic (api-token + tenant-id)
         if [ -n "$ARMIS_CLIENT_ID" ] && [ -z "$ARMIS_CLIENT_SECRET" ]; then
           echo "Error: 'client-id' provided without 'client-secret'. Both are required for JWT authentication."
@@ -190,6 +197,10 @@ runs:
         fi
         if [ -n "$ARMIS_API_TOKEN" ] && [ -z "$ARMIS_TENANT_ID" ]; then
           echo "Error: 'api-token' provided without 'tenant-id'. Both are required for Basic authentication."
+          exit 1
+        fi
+        if [ -z "$ARMIS_API_TOKEN" ] && [ -n "$ARMIS_TENANT_ID" ]; then
+          echo "Error: 'tenant-id' provided without 'api-token'. Both are required for Basic authentication."
           exit 1
         fi
         if [ -z "$ARMIS_CLIENT_ID" ] && [ -z "$ARMIS_API_TOKEN" ]; then
@@ -205,7 +216,7 @@ runs:
 
         # Build command arguments array for safe execution
         SCAN_ARGS=("scan" "$SCAN_TYPE" "$SCAN_TARGET")
-        if [ -n "$ARMIS_TENANT_ID" ]; then
+        if [ -n "$ARMIS_TENANT_ID" ] && [ -z "$ARMIS_CLIENT_ID" ]; then
           SCAN_ARGS+=("--tenant-id" "$ARMIS_TENANT_ID")
         fi
         SCAN_ARGS+=("--format" "$OUTPUT_FORMAT")

--- a/docs/CI-INTEGRATION.md
+++ b/docs/CI-INTEGRATION.md
@@ -44,8 +44,8 @@ jobs:
   scan:
     uses: ArmisSecurity/armis-cli/.github/workflows/reusable-security-scan.yml@main
     secrets:
-      api-token: ${{ secrets.ARMIS_API_TOKEN }}
-      tenant-id: ${{ secrets.ARMIS_TENANT_ID }}
+      client-id: ${{ secrets.ARMIS_CLIENT_ID }}
+      client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}
 ```
 
 That's it! This will:
@@ -133,8 +133,8 @@ jobs:
       fail-on: 'CRITICAL,HIGH'
       pr-comment: true
     secrets:
-      api-token: ${{ secrets.ARMIS_API_TOKEN }}
-      tenant-id: ${{ secrets.ARMIS_TENANT_ID }}
+      client-id: ${{ secrets.ARMIS_CLIENT_ID }}
+      client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}
 ```
 
 #### Input Reference
@@ -156,10 +156,10 @@ jobs:
 
 | Secret | Description |
 |--------|-------------|
-| `api-token` | Armis API token (Basic auth) |
-| `tenant-id` | Tenant identifier (Basic auth) |
-
-> **Note:** The reusable workflow currently accepts Basic auth secrets only. For JWT authentication (recommended), use [Option 3: Manual Installation](#option-3-manual-installation) with `ARMIS_CLIENT_ID` and `ARMIS_CLIENT_SECRET` environment variables.
+| `client-id` | Client ID for JWT authentication (recommended) |
+| `client-secret` | Client secret for JWT authentication (recommended) |
+| `api-token` | Armis API token (legacy fallback) |
+| `tenant-id` | Tenant identifier (legacy fallback, not needed with JWT) |
 
 #### Required Permissions
 
@@ -214,8 +214,8 @@ jobs:
         uses: ArmisSecurity/armis-cli@main
         with:
           scan-type: repo
-          api-token: ${{ secrets.ARMIS_API_TOKEN }}
-          tenant-id: ${{ secrets.ARMIS_TENANT_ID }}
+          client-id: ${{ secrets.ARMIS_CLIENT_ID }}
+          client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}
           format: sarif
           output-file: results.sarif
           fail-on: HIGH,CRITICAL
@@ -233,8 +233,11 @@ jobs:
 |-------|----------|---------|-------------|
 | `scan-type` | Yes | | Type of scan: `repo` or `image` |
 | `scan-target` | No | `.` | Path for repo, image name for image scan |
-| `api-token` | Yes | | Armis API token |
-| `tenant-id` | Yes | | Tenant identifier |
+| `client-id` | No* | | Client ID for JWT authentication (recommended) |
+| `client-secret` | No* | | Client secret for JWT authentication (recommended) |
+| `region` | No | | Armis cloud region for JWT authentication |
+| `api-token` | No* | | Armis API token (legacy) |
+| `tenant-id` | No* | | Tenant identifier (legacy, not needed with JWT) |
 | `format` | No | `sarif` | Output format: `human`, `json`, `sarif`, `junit` |
 | `fail-on` | No | `CRITICAL` | Severity levels to fail on |
 | `exit-code` | No | `1` | Exit code when failing |
@@ -244,6 +247,8 @@ jobs:
 | `scan-timeout` | No | `60` | Timeout in minutes |
 | `include-files` | No | | Comma-separated file paths to scan |
 | `build-from-source` | No | `false` | Build from source (testing) |
+
+\* One authentication method is required: either `client-id` + `client-secret` (recommended) or `api-token` + `tenant-id` (legacy).
 
 #### Action Outputs
 
@@ -340,8 +345,8 @@ jobs:
       fail-on: 'CRITICAL,HIGH'
       include-files: ${{ needs.get-changed-files.outputs.files }}
     secrets:
-      api-token: ${{ secrets.ARMIS_API_TOKEN }}
-      tenant-id: ${{ secrets.ARMIS_TENANT_ID }}
+      client-id: ${{ secrets.ARMIS_CLIENT_ID }}
+      client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}
 ```
 
 **Key points:**
@@ -377,8 +382,8 @@ jobs:
       upload-artifact: true
       scan-timeout: 120        # Allow more time for full scan
     secrets:
-      api-token: ${{ secrets.ARMIS_API_TOKEN }}
-      tenant-id: ${{ secrets.ARMIS_TENANT_ID }}
+      client-id: ${{ secrets.ARMIS_CLIENT_ID }}
+      client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}
 ```
 
 **Key points:**
@@ -477,8 +482,8 @@ jobs:
         with:
           scan-type: image
           scan-target: myapp:${{ github.sha }}
-          api-token: ${{ secrets.ARMIS_API_TOKEN }}
-          tenant-id: ${{ secrets.ARMIS_TENANT_ID }}
+          client-id: ${{ secrets.ARMIS_CLIENT_ID }}
+          client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}
           format: sarif
           output-file: image-results.sarif
           fail-on: CRITICAL,HIGH
@@ -525,8 +530,8 @@ For images built in a previous job or CI step:
   with:
     scan-type: image
     image-tarball: image.tar
-    api-token: ${{ secrets.ARMIS_API_TOKEN }}
-    tenant-id: ${{ secrets.ARMIS_TENANT_ID }}
+    client-id: ${{ secrets.ARMIS_CLIENT_ID }}
+    client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}
 ```
 
 ---

--- a/docs/CI-INTEGRATION.md
+++ b/docs/CI-INTEGRATION.md
@@ -150,6 +150,7 @@ jobs:
 | `image-tarball` | string | | Path to image tarball (for image scans) |
 | `scan-timeout` | number | `60` | Scan timeout in minutes |
 | `include-files` | string | | Comma-separated list of file paths to scan (for targeted scanning) |
+| `region` | string | | Armis cloud region (overrides auto-discovery) |
 | `build-from-source` | boolean | `false` | Build CLI from source instead of release (for testing) |
 
 #### Required Secrets

--- a/docs/ci-examples/github-actions-pr-scan.yml
+++ b/docs/ci-examples/github-actions-pr-scan.yml
@@ -71,5 +71,5 @@ jobs:
       fail-on: 'CRITICAL,HIGH'
       include-files: ${{ needs.get-changed-files.outputs.files }}
     secrets:
-      api-token: ${{ secrets.ARMIS_API_TOKEN }}
-      tenant-id: ${{ secrets.ARMIS_TENANT_ID }}
+      client-id: ${{ secrets.ARMIS_CLIENT_ID }}
+      client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}

--- a/docs/ci-examples/github-actions-reusable.yml
+++ b/docs/ci-examples/github-actions-reusable.yml
@@ -8,10 +8,11 @@
 #   - PR comments with severity breakdown
 #   - Artifact storage
 #
-# Required secrets:
-#   The reusable workflow currently accepts Basic auth secrets (api-token/tenant-id).
-#   For JWT authentication (recommended), use manual installation instead.
+# Required secrets (JWT - recommended):
+#   - ARMIS_CLIENT_ID: Client ID from VIPR external API screen
+#   - ARMIS_CLIENT_SECRET: Client secret from VIPR external API screen
 #
+# Legacy secrets (Basic auth):
 #   - ARMIS_API_TOKEN: Your Armis API token
 #   - ARMIS_TENANT_ID: Your Armis tenant identifier
 
@@ -50,5 +51,5 @@ jobs:
       # scan-timeout: 60                 # Timeout in minutes (default: 60)
       # include-files: ''                # Comma-separated file paths for targeted scanning
     secrets:
-      api-token: ${{ secrets.ARMIS_API_TOKEN }}
-      tenant-id: ${{ secrets.ARMIS_TENANT_ID }}
+      client-id: ${{ secrets.ARMIS_CLIENT_ID }}
+      client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}

--- a/docs/ci-examples/github-actions-scheduled.yml
+++ b/docs/ci-examples/github-actions-scheduled.yml
@@ -59,5 +59,5 @@ jobs:
       # Allow more time for comprehensive scans
       scan-timeout: 120
     secrets:
-      api-token: ${{ secrets.ARMIS_API_TOKEN }}
-      tenant-id: ${{ secrets.ARMIS_TENANT_ID }}
+      client-id: ${{ secrets.ARMIS_CLIENT_ID }}
+      client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}

--- a/docs/ci-examples/github-actions.yml
+++ b/docs/ci-examples/github-actions.yml
@@ -36,8 +36,8 @@ jobs:
         with:
           scan-type: repo
           scan-target: '.'
-          api-token: ${{ secrets.ARMIS_API_TOKEN }}
-          tenant-id: ${{ secrets.ARMIS_TENANT_ID }}
+          client-id: ${{ secrets.ARMIS_CLIENT_ID }}
+          client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}
           format: sarif
           output-file: results.sarif
           fail-on: HIGH,CRITICAL


### PR DESCRIPTION
## Related Issue

* [PPSC-734](https://armis-security.atlassian.net/browse/PPSC-734)

## Type of Change

* [x] New feature (non-breaking change which adds functionality)
* [x] Documentation update

## Problem

The GitHub Action (`action.yml`) and reusable workflow only supported Basic auth (`api-token`/`tenant-id`), which is the deprecated authentication method. All README and CI documentation for GitHub Actions Options 1 and 2 referenced this deprecated auth, while the CLI itself has supported JWT for months. Users had to use the manual installation approach (Option 3) to get JWT auth in CI.

## Solution

- Added `client-id`, `client-secret`, and `region` inputs to `action.yml` as the recommended auth method
- Changed `api-token`/`tenant-id` from `required: true` to `required: false` (backward compatible)
- Added runtime bash validation ensuring at least one complete auth method is provided
- Made `--tenant-id` flag conditional (only passed for Basic auth)
- Updated `reusable-security-scan.yml` to accept and pass through JWT secrets
- Updated all documentation and CI examples to show JWT as the primary method
- Repository's own workflows pass both auth methods for safe transition

## Testing

### Automated Tests

* [x] All tests passing locally (1 pre-existing failure unrelated to this PR)
* [x] YAML validation passes for all modified workflow files
* [x] Pre-commit hooks pass (yamllint, markdownlint, check-yaml)

### Manual Testing

- Verified YAML syntax with Ruby YAML parser across all 8 modified workflow files
- Confirmed the pre-existing test failure (`TestScanRepoCmd/repo_command_fails_without_tenant_ID`) reproduces on main without any of these changes

## Reviewer Notes

- **Backward compatible**: Existing workflows passing `api-token`/`tenant-id` continue to work unchanged
- The repo's own CI workflows (`pr-security-scan.yml`, `security-scan.yml`) pass both JWT and Basic auth secrets to allow a safe transition period — once `ARMIS_CLIENT_ID`/`ARMIS_CLIENT_SECRET` are configured as repo secrets, the Basic auth secrets can be removed
- Out of scope: `.github/actions/armis-cli-action/action.yml` (internal action) and `armis-cli-marketplace-sample.yml` — can be updated separately

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] Documentation updated (if needed)
* [x] No new warnings generated

[PPSC-734]: https://armis-security.atlassian.net/browse/PPSC-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ