### PR TITLE
[PPSC-705] feat(scan): add suppression directive parsing to .armisignore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/schollz/progressbar/v3 v3.19.0
 	github.com/spf13/cobra v1.10.2
 	github.com/xeipuuv/gojsonschema v1.2.0
+	golang.org/x/sys v0.43.0
 	golang.org/x/term v0.42.0
 )
 
@@ -39,6 +40,5 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/net v0.48.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/internal/scan/repo/ignore.go
+++ b/internal/scan/repo/ignore.go
@@ -21,7 +21,6 @@ var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 // IgnoreMatcher matches files against ignore patterns.
 type IgnoreMatcher struct {
 	patterns []gitignore.Pattern
-	domain   []string
 }
 
 // LoadIgnorePatterns loads ignore patterns from .armisignore files in the repository.
@@ -80,10 +79,8 @@ func LoadArmisIgnore(repoRoot string) (*IgnoreMatcher, *SuppressionConfig, error
 		return nil, nil, err
 	}
 
-	domain := strings.Split(repoRoot, string(filepath.Separator))
 	matcher := &IgnoreMatcher{
 		patterns: allPatterns,
-		domain:   domain,
 	}
 
 	if config.IsEmpty() {
@@ -124,7 +121,8 @@ func parseArmisIgnoreFile(ignoreFilePath, repoRoot string, isRoot bool) ([]gitig
 		domain = strings.Split(relDir, string(filepath.Separator))
 	}
 
-	lines := strings.Split(string(data), "\n")
+	content := strings.TrimSuffix(string(data), "\n")
+	lines := strings.Split(content, "\n")
 
 	var warnings []string
 	if len(lines) > maxIgnoreFileLines {
@@ -141,15 +139,15 @@ func parseArmisIgnoreFile(ignoreFilePath, repoRoot string, isRoot bool) ([]gitig
 			continue
 		}
 
-		if isRoot {
+		if isRoot && hasDirectivePrefix(trimmed) {
 			directive, isDirective, warning := parseDirectiveLine(trimmed)
 			if warning != "" {
 				warnings = append(warnings, warning)
 			}
 			if isDirective {
 				directives = append(directives, *directive)
-				continue
 			}
+			continue
 		}
 
 		pattern := gitignore.ParsePattern(trimmed, domain)

--- a/internal/scan/repo/ignore.go
+++ b/internal/scan/repo/ignore.go
@@ -1,17 +1,22 @@
 package repo
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/ArmisSecurity/armis-cli/internal/cli"
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 )
 
 // maxIgnoreFileSize is the maximum allowed size for a .armisignore file (1 MB).
 const maxIgnoreFileSize = 1 << 20
+
+// utf8BOM is the byte order mark that some editors prepend to UTF-8 files.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 
 // IgnoreMatcher matches files against ignore patterns.
 type IgnoreMatcher struct {
@@ -20,8 +25,20 @@ type IgnoreMatcher struct {
 }
 
 // LoadIgnorePatterns loads ignore patterns from .armisignore files in the repository.
+// This is a backward-compatible wrapper around LoadArmisIgnore that discards directives.
 func LoadIgnorePatterns(repoRoot string) (*IgnoreMatcher, error) {
+	matcher, _, err := LoadArmisIgnore(repoRoot)
+	return matcher, err
+}
+
+// LoadArmisIgnore loads both path patterns and suppression directives from .armisignore files.
+// Path patterns are collected from all .armisignore files (root and nested).
+// Suppression directives are only collected from the root .armisignore file.
+// Warnings for invalid directives are emitted to stderr via cli.PrintWarningf.
+func LoadArmisIgnore(repoRoot string) (*IgnoreMatcher, *SuppressionConfig, error) {
 	var allPatterns []gitignore.Pattern
+	config := NewSuppressionConfig()
+	rootIgnorePath := filepath.Join(repoRoot, ".armisignore")
 
 	err := filepath.Walk(repoRoot, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -36,48 +53,70 @@ func LoadIgnorePatterns(repoRoot string) (*IgnoreMatcher, error) {
 			if info.Mode()&os.ModeSymlink != 0 {
 				return fmt.Errorf(".armisignore is a symlink (rejected): %s", path)
 			}
-			patterns, err := loadIgnoreFile(path, repoRoot)
-			if err != nil {
-				return err
+
+			isRoot := path == rootIgnorePath
+			patterns, directives, warnings, parseErr := parseArmisIgnoreFile(path, repoRoot, isRoot)
+			if parseErr != nil {
+				return parseErr
 			}
+
 			allPatterns = append(allPatterns, patterns...)
+
+			if isRoot {
+				for i := range directives {
+					config.Add(directives[i])
+				}
+			}
+
+			for _, w := range warnings {
+				cli.PrintWarningf(".armisignore: %s", w)
+			}
 		}
 
 		return nil
 	})
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	domain := strings.Split(repoRoot, string(filepath.Separator))
-	return &IgnoreMatcher{
+	matcher := &IgnoreMatcher{
 		patterns: allPatterns,
 		domain:   domain,
-	}, nil
+	}
+
+	if config.IsEmpty() {
+		return matcher, nil, nil
+	}
+	return matcher, config, nil
 }
 
-func loadIgnoreFile(ignoreFilePath, repoRoot string) ([]gitignore.Pattern, error) {
+// parseArmisIgnoreFile reads and parses a single .armisignore file.
+// When isRoot is true, directive lines are parsed and returned.
+// When isRoot is false, directive-like lines are still treated as path patterns (backward compat).
+func parseArmisIgnoreFile(ignoreFilePath, repoRoot string, isRoot bool) ([]gitignore.Pattern, []SuppressionDirective, []string, error) {
 	f, err := os.Open(ignoreFilePath) // #nosec G304 - ignore file path is constructed internally
 	if err != nil {
-		return nil, err
+		return nil, nil, nil, err
 	}
 	defer f.Close() //nolint:errcheck // read-only file
 
-	// Read up to maxIgnoreFileSize+1 to detect files exceeding the limit.
 	limited := io.LimitReader(f, maxIgnoreFileSize+1)
 	data, err := io.ReadAll(limited)
 	if err != nil {
-		return nil, err
+		return nil, nil, nil, err
 	}
 	if len(data) > maxIgnoreFileSize {
-		return nil, fmt.Errorf(".armisignore file too large (max %d bytes): %s", maxIgnoreFileSize, ignoreFilePath)
+		return nil, nil, nil, fmt.Errorf(".armisignore file too large (max %d bytes): %s", maxIgnoreFileSize, ignoreFilePath)
 	}
+
+	data = bytes.TrimPrefix(data, utf8BOM)
 
 	ignoreDir := filepath.Dir(ignoreFilePath)
 	relDir, err := filepath.Rel(repoRoot, ignoreDir)
 	if err != nil {
-		return nil, err
+		return nil, nil, nil, err
 	}
 
 	var domain []string
@@ -86,19 +125,38 @@ func loadIgnoreFile(ignoreFilePath, repoRoot string) ([]gitignore.Pattern, error
 	}
 
 	lines := strings.Split(string(data), "\n")
+
+	var warnings []string
+	if len(lines) > maxIgnoreFileLines {
+		warnings = append(warnings, fmt.Sprintf("file exceeds %d lines, truncated: %s", maxIgnoreFileLines, ignoreFilePath))
+		lines = lines[:maxIgnoreFileLines]
+	}
+
 	patterns := make([]gitignore.Pattern, 0, len(lines))
+	var directives []SuppressionDirective
 
 	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
 		}
 
-		pattern := gitignore.ParsePattern(line, domain)
+		if isRoot {
+			directive, isDirective, warning := parseDirectiveLine(trimmed)
+			if warning != "" {
+				warnings = append(warnings, warning)
+			}
+			if isDirective {
+				directives = append(directives, *directive)
+				continue
+			}
+		}
+
+		pattern := gitignore.ParsePattern(trimmed, domain)
 		patterns = append(patterns, pattern)
 	}
 
-	return patterns, nil
+	return patterns, directives, warnings, nil
 }
 
 // Match returns true if the path matches any ignore pattern.

--- a/internal/scan/repo/ignore_test.go
+++ b/internal/scan/repo/ignore_test.go
@@ -279,7 +279,8 @@ func TestLoadArmisIgnore_DirectivesOnlyFromRoot(t *testing.T) {
 func TestLoadArmisIgnore_LineLimitTruncation(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create a file with 1005 lines: 1000 path patterns + 5 directives after the limit
+	// Create a file with 1005 lines: 1000 path patterns + 5 directives after the limit.
+	// Using \n-joined content ensures exactly 1005 lines after TrimSuffix+Split.
 	var lines []string
 	for i := range 1000 {
 		lines = append(lines, fmt.Sprintf("pattern_%d/", i))
@@ -287,7 +288,7 @@ func TestLoadArmisIgnore_LineLimitTruncation(t *testing.T) {
 	// These directives should be truncated (beyond line 1000)
 	lines = append(lines, "cwe:798", "cwe:79", "cwe:89", "cwe:22", "cwe:502")
 
-	content := strings.Join(lines, "\n")
+	content := strings.Join(lines, "\n") + "\n"
 	if err := os.WriteFile(filepath.Join(tmpDir, ".armisignore"), []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
@@ -300,6 +301,36 @@ func TestLoadArmisIgnore_LineLimitTruncation(t *testing.T) {
 	// Directives after line 1000 should not be parsed
 	if config != nil {
 		t.Errorf("Expected nil config (directives were beyond line limit), got %d CWEs", len(config.CWEs))
+	}
+}
+
+func TestLoadArmisIgnore_InvalidDirectiveNotPathPattern(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// An invalid directive (severity:BOGUS) should NOT become a path pattern
+	content := "severity:BOGUS\nvendor/\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, ".armisignore"), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	matcher, config, err := LoadArmisIgnore(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadArmisIgnore failed: %v", err)
+	}
+
+	// Invalid directive should not produce a suppression
+	if config != nil {
+		t.Error("Expected nil config for invalid directive")
+	}
+
+	// "severity:BOGUS" should NOT be treated as a path pattern
+	if matcher.Match("severity:BOGUS", false) {
+		t.Error("Invalid directive should not become a path pattern")
+	}
+
+	// Valid path pattern should still work
+	if !matcher.Match("vendor/lib.go", false) {
+		t.Error("Expected vendor/lib.go to match")
 	}
 }
 

--- a/internal/scan/repo/ignore_test.go
+++ b/internal/scan/repo/ignore_test.go
@@ -1,6 +1,7 @@
 package repo
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -142,5 +143,230 @@ func TestLoadIgnorePatternsOversizedFile(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "too large") {
 		t.Fatalf("expected 'too large' error, got: %v", err)
+	}
+}
+
+func TestLoadArmisIgnore_MixedFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	content := `# Mixed .armisignore file
+vendor/
+*.log
+node_modules/
+
+# Suppression directives
+cwe:798 -- Environment variables
+severity:LOW -- Team policy
+category:secrets
+rule:CKV_AWS_18 -- Required for pipeline
+
+# More path patterns
+docs/
+`
+	ignoreFile := filepath.Join(tmpDir, ".armisignore")
+	if err := os.WriteFile(ignoreFile, []byte(content), 0600); err != nil {
+		t.Fatalf("Failed to create ignore file: %v", err)
+	}
+
+	matcher, config, err := LoadArmisIgnore(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadArmisIgnore failed: %v", err)
+	}
+
+	// Verify path patterns work
+	if !matcher.Match("vendor/lib.go", false) {
+		t.Error("Expected vendor/lib.go to match path pattern")
+	}
+	if !matcher.Match("test.log", false) {
+		t.Error("Expected test.log to match path pattern")
+	}
+	if !matcher.Match("docs/readme.md", false) {
+		t.Error("Expected docs/readme.md to match path pattern")
+	}
+
+	// Verify directives were parsed
+	if config == nil {
+		t.Fatal("Expected non-nil SuppressionConfig")
+	}
+	if len(config.CWEs) != 1 {
+		t.Errorf("CWEs count = %d, want 1", len(config.CWEs))
+	} else {
+		if config.CWEs[0].Value != "798" {
+			t.Errorf("CWE value = %q, want %q", config.CWEs[0].Value, "798")
+		}
+		if config.CWEs[0].Reason != "Environment variables" {
+			t.Errorf("CWE reason = %q, want %q", config.CWEs[0].Reason, "Environment variables")
+		}
+	}
+	if len(config.Severities) != 1 {
+		t.Errorf("Severities count = %d, want 1", len(config.Severities))
+	} else if config.Severities[0].Value != "LOW" {
+		t.Errorf("Severity value = %q, want %q", config.Severities[0].Value, "LOW")
+	}
+	if len(config.Categories) != 1 {
+		t.Errorf("Categories count = %d, want 1", len(config.Categories))
+	} else if config.Categories[0].Value != "secrets" {
+		t.Errorf("Category value = %q, want %q", config.Categories[0].Value, "secrets")
+	}
+	if len(config.Rules) != 1 {
+		t.Errorf("Rules count = %d, want 1", len(config.Rules))
+	} else if config.Rules[0].Value != "CKV_AWS_18" {
+		t.Errorf("Rule value = %q, want %q", config.Rules[0].Value, "CKV_AWS_18")
+	}
+}
+
+func TestLoadArmisIgnore_NoFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	matcher, config, err := LoadArmisIgnore(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadArmisIgnore failed: %v", err)
+	}
+
+	if matcher == nil {
+		t.Fatal("Expected non-nil matcher")
+	}
+	if config != nil {
+		t.Error("Expected nil config when no .armisignore exists")
+	}
+}
+
+func TestLoadArmisIgnore_DirectivesOnlyFromRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Root .armisignore with directives
+	rootContent := "cwe:798\n*.log\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, ".armisignore"), []byte(rootContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Nested .armisignore with a directive-like line
+	subDir := filepath.Join(tmpDir, "subdir")
+	if err := os.MkdirAll(subDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	nestedContent := "cwe:79\n*.tmp\n"
+	if err := os.WriteFile(filepath.Join(subDir, ".armisignore"), []byte(nestedContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	matcher, config, err := LoadArmisIgnore(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadArmisIgnore failed: %v", err)
+	}
+
+	// Root directive should be parsed
+	if config == nil {
+		t.Fatal("Expected non-nil config")
+	}
+	if len(config.CWEs) != 1 {
+		t.Fatalf("CWEs count = %d, want 1 (only root directives)", len(config.CWEs))
+	}
+	if config.CWEs[0].Value != "798" {
+		t.Errorf("CWE value = %q, want %q", config.CWEs[0].Value, "798")
+	}
+
+	// Nested "cwe:79" should be treated as a path pattern (not a directive)
+	// Path patterns from both files should work
+	if !matcher.Match("test.log", false) {
+		t.Error("Expected test.log to match root pattern")
+	}
+	if !matcher.Match("subdir/test.tmp", false) {
+		t.Error("Expected subdir/test.tmp to match nested pattern")
+	}
+}
+
+func TestLoadArmisIgnore_LineLimitTruncation(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a file with 1005 lines: 1000 path patterns + 5 directives after the limit
+	var lines []string
+	for i := range 1000 {
+		lines = append(lines, fmt.Sprintf("pattern_%d/", i))
+	}
+	// These directives should be truncated (beyond line 1000)
+	lines = append(lines, "cwe:798", "cwe:79", "cwe:89", "cwe:22", "cwe:502")
+
+	content := strings.Join(lines, "\n")
+	if err := os.WriteFile(filepath.Join(tmpDir, ".armisignore"), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, config, err := LoadArmisIgnore(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadArmisIgnore failed: %v", err)
+	}
+
+	// Directives after line 1000 should not be parsed
+	if config != nil {
+		t.Errorf("Expected nil config (directives were beyond line limit), got %d CWEs", len(config.CWEs))
+	}
+}
+
+func TestLoadArmisIgnore_UTF8BOM(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// UTF-8 BOM + content
+	bom := []byte{0xEF, 0xBB, 0xBF}
+	content := append(bom, []byte("cwe:798\nvendor/\n")...)
+	if err := os.WriteFile(filepath.Join(tmpDir, ".armisignore"), content, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	matcher, config, err := LoadArmisIgnore(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadArmisIgnore failed: %v", err)
+	}
+
+	if config == nil {
+		t.Fatal("Expected non-nil config")
+	}
+	if len(config.CWEs) != 1 {
+		t.Fatalf("CWEs count = %d, want 1", len(config.CWEs))
+	}
+	if config.CWEs[0].Value != "798" {
+		t.Errorf("CWE value = %q, want %q", config.CWEs[0].Value, "798")
+	}
+	if !matcher.Match("vendor/lib.go", false) {
+		t.Error("Expected vendor/lib.go to match")
+	}
+}
+
+func TestLoadArmisIgnore_BackwardCompat(t *testing.T) {
+	// Verify LoadIgnorePatterns and LoadArmisIgnore produce identical matchers
+	tmpDir := t.TempDir()
+
+	content := "*.log\nnode_modules/\n!important.log\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, ".armisignore"), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldMatcher, err := LoadIgnorePatterns(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadIgnorePatterns failed: %v", err)
+	}
+
+	newMatcher, _, newErr := LoadArmisIgnore(tmpDir)
+	if newErr != nil {
+		t.Fatalf("LoadArmisIgnore failed: %v", newErr)
+	}
+
+	paths := []struct {
+		path  string
+		isDir bool
+	}{
+		{"test.log", false},
+		{"important.log", false},
+		{"node_modules", true},
+		{"src/main.go", false},
+	}
+
+	for _, p := range paths {
+		oldResult := oldMatcher.Match(p.path, p.isDir)
+		newResult := newMatcher.Match(p.path, p.isDir)
+		if oldResult != newResult {
+			t.Errorf("Match(%q, %v): LoadIgnorePatterns=%v, LoadArmisIgnore=%v",
+				p.path, p.isDir, oldResult, newResult)
+		}
 	}
 }

--- a/internal/scan/repo/suppression.go
+++ b/internal/scan/repo/suppression.go
@@ -68,17 +68,30 @@ func (c *SuppressionConfig) IsEmpty() bool {
 		len(c.Severities) == 0 && len(c.CWEs) == 0
 }
 
+// maxDirectivesPerType is the maximum number of directives stored per type.
+// This bounds memory usage even if a malicious .armisignore is provided.
+const maxDirectivesPerType = 100
+
 // Add appends a directive to the appropriate slice based on its type.
+// Directives beyond maxDirectivesPerType per type are silently dropped.
 func (c *SuppressionConfig) Add(d SuppressionDirective) {
 	switch d.Type {
 	case DirectiveRule:
-		c.Rules = append(c.Rules, d)
+		if len(c.Rules) < maxDirectivesPerType {
+			c.Rules = append(c.Rules, d)
+		}
 	case DirectiveCategory:
-		c.Categories = append(c.Categories, d)
+		if len(c.Categories) < maxDirectivesPerType {
+			c.Categories = append(c.Categories, d)
+		}
 	case DirectiveSeverity:
-		c.Severities = append(c.Severities, d)
+		if len(c.Severities) < maxDirectivesPerType {
+			c.Severities = append(c.Severities, d)
+		}
 	case DirectiveCWE:
-		c.CWEs = append(c.CWEs, d)
+		if len(c.CWEs) < maxDirectivesPerType {
+			c.CWEs = append(c.CWEs, d)
+		}
 	}
 }
 
@@ -142,11 +155,11 @@ func parseDirectiveLine(line string) (*SuppressionDirective, bool, string) {
 		return &SuppressionDirective{Type: DirectiveSeverity, Value: normalized, Reason: reason}, true, ""
 
 	case "cwe":
-		valid, warning := validateCWE(value)
+		normalized, valid, warning := validateCWE(value)
 		if !valid {
 			return nil, false, warning
 		}
-		return &SuppressionDirective{Type: DirectiveCWE, Value: value, Reason: reason}, true, warning
+		return &SuppressionDirective{Type: DirectiveCWE, Value: normalized, Reason: reason}, true, warning
 
 	default:
 		return nil, false, ""
@@ -166,21 +179,23 @@ func hasDirectivePrefix(line string) bool {
 }
 
 // validateCWE checks whether a CWE value string is a valid non-negative integer.
-// Returns (valid, warning). When valid is false the directive should be rejected.
+// Returns (normalized, valid, warning). The normalized value is the canonical integer
+// string (e.g. "0079" becomes "79"). When valid is false the directive should be rejected.
 // When valid is true but warning is non-empty, the directive is accepted with a warning.
-func validateCWE(value string) (bool, string) {
+func validateCWE(value string) (string, bool, string) {
 	if value == "" {
-		return false, "empty cwe directive ignored"
+		return "", false, "empty cwe directive ignored"
 	}
 	n, err := strconv.Atoi(value)
 	if err != nil {
-		return false, fmt.Sprintf("invalid cwe value %q ignored (must be a positive integer)", value)
+		return "", false, fmt.Sprintf("invalid cwe value %q ignored (must be a non-negative integer)", value)
 	}
 	if n < 0 {
-		return false, fmt.Sprintf("invalid cwe value %q ignored (must be a positive integer)", value)
+		return "", false, fmt.Sprintf("invalid cwe value %q ignored (must be a non-negative integer)", value)
 	}
+	normalized := strconv.Itoa(n)
 	if n == 0 {
-		return true, "cwe:0 will never match any findings"
+		return normalized, true, "cwe:0 will never match any findings"
 	}
-	return true, ""
+	return normalized, true, ""
 }

--- a/internal/scan/repo/suppression.go
+++ b/internal/scan/repo/suppression.go
@@ -1,0 +1,186 @@
+package repo
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// maxIgnoreFileLines is the maximum number of lines parsed from a .armisignore file.
+// Lines beyond this limit are truncated with a warning (fail-open per ADR-0008 Section 12).
+const maxIgnoreFileLines = 1000
+
+// DirectiveType represents the type of a suppression directive.
+type DirectiveType string
+
+const (
+	DirectiveRule     DirectiveType = "rule"
+	DirectiveCategory DirectiveType = "category"
+	DirectiveSeverity DirectiveType = "severity"
+	DirectiveCWE      DirectiveType = "cwe"
+)
+
+// SuppressionDirective represents a single parsed finding-level suppression directive.
+type SuppressionDirective struct {
+	Type   DirectiveType
+	Value  string // normalized: severity uppercase, category lowercase, cwe bare int string, rule as-is
+	Reason string // optional text after " -- " delimiter
+}
+
+// SuppressionConfig holds all parsed finding-level suppression directives from .armisignore.
+type SuppressionConfig struct {
+	Rules      []SuppressionDirective
+	Categories []SuppressionDirective
+	Severities []SuppressionDirective
+	CWEs       []SuppressionDirective
+}
+
+var validSeverities = map[string]bool{
+	"CRITICAL": true,
+	"HIGH":     true,
+	"MEDIUM":   true,
+	"LOW":      true,
+	"INFO":     true,
+}
+
+var validCategories = map[string][]string{
+	"sast":    {"CODE_VULNERABILITY", "CLIENT_SIDE_SECURITY_MISUSE", "GENERIC_CODE_QUALITY_ISSUE", "DEBUG_CODE_LEFTOVER"},
+	"secrets": {"HARDCODED_SECRET_EXPOSURE", "CREDENTIAL_LEAKAGE"},
+	"iac":     {"INFRA_AS_CODE_MISCONFIGURATION", "CI_CD_SECURITY_MISCONFIGURATION", "POLICY_VIOLATION"},
+	"sca":     {"CODE_PACKAGE_VULNERABILITY", "CODE_PACKAGE_VULNERABILITY_WITH_NO_FIX", "BASE_IMAGE_VULNERABILITY"},
+	"license": {"LICENSE_COMPLIANCE_RISK"},
+}
+
+// directivePrefixes defines recognized directive prefixes for quick lookup.
+var directivePrefixes = []string{"rule:", "category:", "severity:", "cwe:"}
+
+// NewSuppressionConfig creates an empty SuppressionConfig.
+func NewSuppressionConfig() *SuppressionConfig {
+	return &SuppressionConfig{}
+}
+
+// IsEmpty returns true if no suppression directives have been parsed.
+func (c *SuppressionConfig) IsEmpty() bool {
+	if c == nil {
+		return true
+	}
+	return len(c.Rules) == 0 && len(c.Categories) == 0 &&
+		len(c.Severities) == 0 && len(c.CWEs) == 0
+}
+
+// Add appends a directive to the appropriate slice based on its type.
+func (c *SuppressionConfig) Add(d SuppressionDirective) {
+	switch d.Type {
+	case DirectiveRule:
+		c.Rules = append(c.Rules, d)
+	case DirectiveCategory:
+		c.Categories = append(c.Categories, d)
+	case DirectiveSeverity:
+		c.Severities = append(c.Severities, d)
+	case DirectiveCWE:
+		c.CWEs = append(c.CWEs, d)
+	}
+}
+
+// CategoryMapping returns a copy of the customer-facing category to internal classification mapping.
+func CategoryMapping() map[string][]string {
+	result := make(map[string][]string, len(validCategories))
+	for k, v := range validCategories {
+		copied := make([]string, len(v))
+		copy(copied, v)
+		result[k] = copied
+	}
+	return result
+}
+
+// parseDirectiveLine determines whether a line is a finding-level suppression directive.
+// Returns the parsed directive and true if it's a directive, or nil and false if it's a
+// path pattern (or blank/comment). A non-empty warning is returned for malformed directives.
+func parseDirectiveLine(line string) (*SuppressionDirective, bool, string) {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return nil, false, ""
+	}
+
+	if !hasDirectivePrefix(line) {
+		return nil, false, ""
+	}
+
+	var reason string
+	if idx := strings.Index(line, " -- "); idx >= 0 {
+		reason = strings.TrimSpace(line[idx+4:])
+		line = strings.TrimSpace(line[:idx])
+	}
+
+	colonIdx := strings.Index(line, ":")
+	if colonIdx < 0 {
+		return nil, false, ""
+	}
+
+	prefix := strings.ToLower(line[:colonIdx])
+	value := strings.TrimSpace(line[colonIdx+1:])
+
+	switch prefix {
+	case "rule":
+		if value == "" {
+			return nil, false, fmt.Sprintf("empty rule directive ignored: %q", line)
+		}
+		return &SuppressionDirective{Type: DirectiveRule, Value: value, Reason: reason}, true, ""
+
+	case "category":
+		normalized := strings.ToLower(value)
+		if _, ok := validCategories[normalized]; !ok {
+			return nil, false, fmt.Sprintf("unknown category %q ignored (valid: sast, secrets, iac, sca, license)", value)
+		}
+		return &SuppressionDirective{Type: DirectiveCategory, Value: normalized, Reason: reason}, true, ""
+
+	case "severity":
+		normalized := strings.ToUpper(value)
+		if !validSeverities[normalized] {
+			return nil, false, fmt.Sprintf("unknown severity %q ignored (valid: CRITICAL, HIGH, MEDIUM, LOW, INFO)", value)
+		}
+		return &SuppressionDirective{Type: DirectiveSeverity, Value: normalized, Reason: reason}, true, ""
+
+	case "cwe":
+		valid, warning := validateCWE(value)
+		if !valid {
+			return nil, false, warning
+		}
+		return &SuppressionDirective{Type: DirectiveCWE, Value: value, Reason: reason}, true, warning
+
+	default:
+		return nil, false, ""
+	}
+}
+
+// hasDirectivePrefix checks whether a line starts with any recognized directive prefix.
+// This is used before splitting on " -- " to avoid treating path patterns as directives.
+func hasDirectivePrefix(line string) bool {
+	lower := strings.ToLower(line)
+	for _, prefix := range directivePrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// validateCWE checks whether a CWE value string is a valid non-negative integer.
+// Returns (valid, warning). When valid is false the directive should be rejected.
+// When valid is true but warning is non-empty, the directive is accepted with a warning.
+func validateCWE(value string) (bool, string) {
+	if value == "" {
+		return false, "empty cwe directive ignored"
+	}
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return false, fmt.Sprintf("invalid cwe value %q ignored (must be a positive integer)", value)
+	}
+	if n < 0 {
+		return false, fmt.Sprintf("invalid cwe value %q ignored (must be a positive integer)", value)
+	}
+	if n == 0 {
+		return true, "cwe:0 will never match any findings"
+	}
+	return true, ""
+}

--- a/internal/scan/repo/suppression_test.go
+++ b/internal/scan/repo/suppression_test.go
@@ -49,18 +49,24 @@ func TestParseDirectiveLine(t *testing.T) {
 			wantIsDir: true,
 		},
 		{
+			name:      "cwe:0079 leading zeros normalized",
+			line:      "cwe:0079",
+			wantDir:   &SuppressionDirective{Type: DirectiveCWE, Value: "79"},
+			wantIsDir: true,
+		},
+		{
 			name:        "cwe:abc invalid",
 			line:        "cwe:abc",
 			wantDir:     nil,
 			wantIsDir:   false,
-			wantWarning: `invalid cwe value "abc" ignored (must be a positive integer)`,
+			wantWarning: `invalid cwe value "abc" ignored (must be a non-negative integer)`,
 		},
 		{
 			name:        "cwe:-1 negative",
 			line:        "cwe:-1",
 			wantDir:     nil,
 			wantIsDir:   false,
-			wantWarning: `invalid cwe value "-1" ignored (must be a positive integer)`,
+			wantWarning: `invalid cwe value "-1" ignored (must be a non-negative integer)`,
 		},
 		{
 			name:        "cwe:0 zero",
@@ -254,7 +260,7 @@ func TestParseDirectiveLine(t *testing.T) {
 			line:        "cwe:798-- not a reason",
 			wantDir:     nil,
 			wantIsDir:   false,
-			wantWarning: `invalid cwe value "798-- not a reason" ignored (must be a positive integer)`,
+			wantWarning: `invalid cwe value "798-- not a reason" ignored (must be a non-negative integer)`,
 		},
 	}
 
@@ -367,25 +373,30 @@ func TestCategoryMapping(t *testing.T) {
 
 func TestValidateCWE(t *testing.T) {
 	tests := []struct {
-		value       string
-		wantValid   bool
-		wantWarning string
+		value          string
+		wantNormalized string
+		wantValid      bool
+		wantWarning    string
 	}{
-		{"798", true, ""},
-		{"79", true, ""},
-		{"1", true, ""},
-		{"0", true, "cwe:0 will never match any findings"},
-		{"-1", false, `invalid cwe value "-1" ignored (must be a positive integer)`},
-		{"abc", false, `invalid cwe value "abc" ignored (must be a positive integer)`},
-		{"", false, "empty cwe directive ignored"},
-		{"12.5", false, `invalid cwe value "12.5" ignored (must be a positive integer)`},
+		{"798", "798", true, ""},
+		{"79", "79", true, ""},
+		{"1", "1", true, ""},
+		{"0079", "79", true, ""},
+		{"0", "0", true, "cwe:0 will never match any findings"},
+		{"-1", "", false, `invalid cwe value "-1" ignored (must be a non-negative integer)`},
+		{"abc", "", false, `invalid cwe value "abc" ignored (must be a non-negative integer)`},
+		{"", "", false, "empty cwe directive ignored"},
+		{"12.5", "", false, `invalid cwe value "12.5" ignored (must be a non-negative integer)`},
 	}
 
 	for _, tt := range tests {
 		t.Run("cwe:"+tt.value, func(t *testing.T) {
-			valid, warning := validateCWE(tt.value)
+			normalized, valid, warning := validateCWE(tt.value)
 			if valid != tt.wantValid {
 				t.Errorf("validateCWE(%q) valid = %v, want %v", tt.value, valid, tt.wantValid)
+			}
+			if normalized != tt.wantNormalized {
+				t.Errorf("validateCWE(%q) normalized = %q, want %q", tt.value, normalized, tt.wantNormalized)
 			}
 			if warning != tt.wantWarning {
 				t.Errorf("validateCWE(%q) warning = %q, want %q", tt.value, warning, tt.wantWarning)

--- a/internal/scan/repo/suppression_test.go
+++ b/internal/scan/repo/suppression_test.go
@@ -1,0 +1,423 @@
+package repo
+
+import (
+	"testing"
+)
+
+func TestParseDirectiveLine(t *testing.T) {
+	tests := []struct {
+		name        string
+		line        string
+		wantDir     *SuppressionDirective
+		wantIsDir   bool
+		wantWarning string
+	}{
+		// Empty and comment lines
+		{
+			name:    "empty line",
+			line:    "",
+			wantDir: nil, wantIsDir: false,
+		},
+		{
+			name:    "whitespace only",
+			line:    "   ",
+			wantDir: nil, wantIsDir: false,
+		},
+		{
+			name:    "comment line",
+			line:    "# this is a comment",
+			wantDir: nil, wantIsDir: false,
+		},
+
+		// CWE directives
+		{
+			name:      "cwe:798",
+			line:      "cwe:798",
+			wantDir:   &SuppressionDirective{Type: DirectiveCWE, Value: "798"},
+			wantIsDir: true,
+		},
+		{
+			name:      "cwe:798 with reason",
+			line:      "cwe:798 -- Environment variables, not hardcoded",
+			wantDir:   &SuppressionDirective{Type: DirectiveCWE, Value: "798", Reason: "Environment variables, not hardcoded"},
+			wantIsDir: true,
+		},
+		{
+			name:      "cwe:79",
+			line:      "cwe:79",
+			wantDir:   &SuppressionDirective{Type: DirectiveCWE, Value: "79"},
+			wantIsDir: true,
+		},
+		{
+			name:        "cwe:abc invalid",
+			line:        "cwe:abc",
+			wantDir:     nil,
+			wantIsDir:   false,
+			wantWarning: `invalid cwe value "abc" ignored (must be a positive integer)`,
+		},
+		{
+			name:        "cwe:-1 negative",
+			line:        "cwe:-1",
+			wantDir:     nil,
+			wantIsDir:   false,
+			wantWarning: `invalid cwe value "-1" ignored (must be a positive integer)`,
+		},
+		{
+			name:        "cwe:0 zero",
+			line:        "cwe:0",
+			wantDir:     &SuppressionDirective{Type: DirectiveCWE, Value: "0"},
+			wantIsDir:   true,
+			wantWarning: "cwe:0 will never match any findings",
+		},
+		{
+			name:        "cwe: empty value",
+			line:        "cwe:",
+			wantDir:     nil,
+			wantIsDir:   false,
+			wantWarning: "empty cwe directive ignored",
+		},
+
+		// Severity directives
+		{
+			name:      "severity:HIGH",
+			line:      "severity:HIGH",
+			wantDir:   &SuppressionDirective{Type: DirectiveSeverity, Value: "HIGH"},
+			wantIsDir: true,
+		},
+		{
+			name:      "severity:low case insensitive",
+			line:      "severity:low",
+			wantDir:   &SuppressionDirective{Type: DirectiveSeverity, Value: "LOW"},
+			wantIsDir: true,
+		},
+		{
+			name:      "severity:Critical mixed case",
+			line:      "severity:Critical",
+			wantDir:   &SuppressionDirective{Type: DirectiveSeverity, Value: "CRITICAL"},
+			wantIsDir: true,
+		},
+		{
+			name:      "severity:INFO",
+			line:      "severity:INFO",
+			wantDir:   &SuppressionDirective{Type: DirectiveSeverity, Value: "INFO"},
+			wantIsDir: true,
+		},
+		{
+			name:      "severity with reason",
+			line:      "severity:LOW -- Team policy: only address MEDIUM+ findings",
+			wantDir:   &SuppressionDirective{Type: DirectiveSeverity, Value: "LOW", Reason: "Team policy: only address MEDIUM+ findings"},
+			wantIsDir: true,
+		},
+		{
+			name:        "severity:UNKNOWN invalid",
+			line:        "severity:UNKNOWN",
+			wantDir:     nil,
+			wantIsDir:   false,
+			wantWarning: `unknown severity "UNKNOWN" ignored (valid: CRITICAL, HIGH, MEDIUM, LOW, INFO)`,
+		},
+		{
+			name:        "severity:BOGUS invalid",
+			line:        "severity:BOGUS",
+			wantDir:     nil,
+			wantIsDir:   false,
+			wantWarning: `unknown severity "BOGUS" ignored (valid: CRITICAL, HIGH, MEDIUM, LOW, INFO)`,
+		},
+
+		// Category directives
+		{
+			name:      "category:secrets",
+			line:      "category:secrets",
+			wantDir:   &SuppressionDirective{Type: DirectiveCategory, Value: "secrets"},
+			wantIsDir: true,
+		},
+		{
+			name:      "category:SAST case insensitive",
+			line:      "category:SAST",
+			wantDir:   &SuppressionDirective{Type: DirectiveCategory, Value: "sast"},
+			wantIsDir: true,
+		},
+		{
+			name:      "category:iac",
+			line:      "category:iac",
+			wantDir:   &SuppressionDirective{Type: DirectiveCategory, Value: "iac"},
+			wantIsDir: true,
+		},
+		{
+			name:      "category:sca",
+			line:      "category:sca",
+			wantDir:   &SuppressionDirective{Type: DirectiveCategory, Value: "sca"},
+			wantIsDir: true,
+		},
+		{
+			name:      "category:license",
+			line:      "category:license",
+			wantDir:   &SuppressionDirective{Type: DirectiveCategory, Value: "license"},
+			wantIsDir: true,
+		},
+		{
+			name:      "category with reason",
+			line:      "category:secrets -- We use HashiCorp Vault",
+			wantDir:   &SuppressionDirective{Type: DirectiveCategory, Value: "secrets", Reason: "We use HashiCorp Vault"},
+			wantIsDir: true,
+		},
+		{
+			name:        "category:invalid unknown",
+			line:        "category:invalid",
+			wantDir:     nil,
+			wantIsDir:   false,
+			wantWarning: `unknown category "invalid" ignored (valid: sast, secrets, iac, sca, license)`,
+		},
+
+		// Rule directives
+		{
+			name:      "rule:CKV_AWS_18",
+			line:      "rule:CKV_AWS_18",
+			wantDir:   &SuppressionDirective{Type: DirectiveRule, Value: "CKV_AWS_18"},
+			wantIsDir: true,
+		},
+		{
+			name:      "rule with dots",
+			line:      "rule:python.lang.security.audit.subprocess-shell-true",
+			wantDir:   &SuppressionDirective{Type: DirectiveRule, Value: "python.lang.security.audit.subprocess-shell-true"},
+			wantIsDir: true,
+		},
+		{
+			name:      "rule with reason",
+			line:      "rule:CKV_DOCKER_3 -- Required for our build pipeline",
+			wantDir:   &SuppressionDirective{Type: DirectiveRule, Value: "CKV_DOCKER_3", Reason: "Required for our build pipeline"},
+			wantIsDir: true,
+		},
+		{
+			name:        "rule: empty value",
+			line:        "rule:",
+			wantDir:     nil,
+			wantIsDir:   false,
+			wantWarning: `empty rule directive ignored: "rule:"`,
+		},
+
+		// Path patterns (not directives)
+		{
+			name:    "vendor/ path pattern",
+			line:    "vendor/",
+			wantDir: nil, wantIsDir: false,
+		},
+		{
+			name:    "*.min.js path pattern",
+			line:    "*.min.js",
+			wantDir: nil, wantIsDir: false,
+		},
+		{
+			name:    "generated/**/*.go path pattern",
+			line:    "generated/**/*.go",
+			wantDir: nil, wantIsDir: false,
+		},
+		{
+			name:    "invalid:directive treated as path",
+			line:    "invalid:directive",
+			wantDir: nil, wantIsDir: false,
+		},
+		{
+			name:    "docs/ path pattern",
+			line:    "docs/",
+			wantDir: nil, wantIsDir: false,
+		},
+
+		// Whitespace handling
+		{
+			name:      "leading whitespace",
+			line:      "  cwe:798",
+			wantDir:   &SuppressionDirective{Type: DirectiveCWE, Value: "798"},
+			wantIsDir: true,
+		},
+		{
+			name:      "trailing whitespace",
+			line:      "cwe:798  ",
+			wantDir:   &SuppressionDirective{Type: DirectiveCWE, Value: "798"},
+			wantIsDir: true,
+		},
+		{
+			name:      "whitespace around value",
+			line:      "  severity:HIGH  ",
+			wantDir:   &SuppressionDirective{Type: DirectiveSeverity, Value: "HIGH"},
+			wantIsDir: true,
+		},
+
+		// Reason delimiter edge cases
+		{
+			name:      "reason with -- in text",
+			line:      "cwe:798 -- reason -- with dashes",
+			wantDir:   &SuppressionDirective{Type: DirectiveCWE, Value: "798", Reason: "reason -- with dashes"},
+			wantIsDir: true,
+		},
+		{
+			name:        "no space before -- not a delimiter",
+			line:        "cwe:798-- not a reason",
+			wantDir:     nil,
+			wantIsDir:   false,
+			wantWarning: `invalid cwe value "798-- not a reason" ignored (must be a positive integer)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, isDir, warning := parseDirectiveLine(tt.line)
+
+			if isDir != tt.wantIsDir {
+				t.Errorf("isDirective = %v, want %v", isDir, tt.wantIsDir)
+			}
+
+			if tt.wantDir == nil {
+				if dir != nil {
+					t.Errorf("directive = %+v, want nil", dir)
+				}
+			} else {
+				if dir == nil {
+					t.Fatalf("directive = nil, want %+v", tt.wantDir)
+				}
+				if dir.Type != tt.wantDir.Type {
+					t.Errorf("Type = %q, want %q", dir.Type, tt.wantDir.Type)
+				}
+				if dir.Value != tt.wantDir.Value {
+					t.Errorf("Value = %q, want %q", dir.Value, tt.wantDir.Value)
+				}
+				if dir.Reason != tt.wantDir.Reason {
+					t.Errorf("Reason = %q, want %q", dir.Reason, tt.wantDir.Reason)
+				}
+			}
+
+			if tt.wantWarning != "" {
+				if warning != tt.wantWarning {
+					t.Errorf("warning = %q, want %q", warning, tt.wantWarning)
+				}
+			} else if warning != "" {
+				t.Errorf("unexpected warning: %q", warning)
+			}
+		})
+	}
+}
+
+func TestSuppressionConfig_Add(t *testing.T) {
+	config := NewSuppressionConfig()
+
+	config.Add(SuppressionDirective{Type: DirectiveRule, Value: "CKV_AWS_18"})
+	config.Add(SuppressionDirective{Type: DirectiveCategory, Value: "secrets"})
+	config.Add(SuppressionDirective{Type: DirectiveSeverity, Value: "LOW"})
+	config.Add(SuppressionDirective{Type: DirectiveCWE, Value: "798"})
+	config.Add(SuppressionDirective{Type: DirectiveCWE, Value: "79"})
+
+	if len(config.Rules) != 1 {
+		t.Errorf("Rules count = %d, want 1", len(config.Rules))
+	}
+	if len(config.Categories) != 1 {
+		t.Errorf("Categories count = %d, want 1", len(config.Categories))
+	}
+	if len(config.Severities) != 1 {
+		t.Errorf("Severities count = %d, want 1", len(config.Severities))
+	}
+	if len(config.CWEs) != 2 {
+		t.Errorf("CWEs count = %d, want 2", len(config.CWEs))
+	}
+}
+
+func TestSuppressionConfig_IsEmpty(t *testing.T) {
+	t.Run("nil config", func(t *testing.T) {
+		var config *SuppressionConfig
+		if !config.IsEmpty() {
+			t.Error("nil config should be empty")
+		}
+	})
+
+	t.Run("new config", func(t *testing.T) {
+		config := NewSuppressionConfig()
+		if !config.IsEmpty() {
+			t.Error("new config should be empty")
+		}
+	})
+
+	t.Run("config with directive", func(t *testing.T) {
+		config := NewSuppressionConfig()
+		config.Add(SuppressionDirective{Type: DirectiveCWE, Value: "798"})
+		if config.IsEmpty() {
+			t.Error("config with directive should not be empty")
+		}
+	})
+}
+
+func TestCategoryMapping(t *testing.T) {
+	mapping := CategoryMapping()
+
+	expectedCategories := []string{"sast", "secrets", "iac", "sca", "license"}
+	for _, cat := range expectedCategories {
+		if _, ok := mapping[cat]; !ok {
+			t.Errorf("CategoryMapping missing category %q", cat)
+		}
+	}
+
+	if len(mapping) != 5 {
+		t.Errorf("CategoryMapping has %d categories, want 5", len(mapping))
+	}
+
+	// Verify deep copy (modifying returned map doesn't affect source)
+	mapping["sast"] = []string{"modified"}
+	original := CategoryMapping()
+	if len(original["sast"]) == 1 && original["sast"][0] == "modified" {
+		t.Error("CategoryMapping should return a deep copy")
+	}
+}
+
+func TestValidateCWE(t *testing.T) {
+	tests := []struct {
+		value       string
+		wantValid   bool
+		wantWarning string
+	}{
+		{"798", true, ""},
+		{"79", true, ""},
+		{"1", true, ""},
+		{"0", true, "cwe:0 will never match any findings"},
+		{"-1", false, `invalid cwe value "-1" ignored (must be a positive integer)`},
+		{"abc", false, `invalid cwe value "abc" ignored (must be a positive integer)`},
+		{"", false, "empty cwe directive ignored"},
+		{"12.5", false, `invalid cwe value "12.5" ignored (must be a positive integer)`},
+	}
+
+	for _, tt := range tests {
+		t.Run("cwe:"+tt.value, func(t *testing.T) {
+			valid, warning := validateCWE(tt.value)
+			if valid != tt.wantValid {
+				t.Errorf("validateCWE(%q) valid = %v, want %v", tt.value, valid, tt.wantValid)
+			}
+			if warning != tt.wantWarning {
+				t.Errorf("validateCWE(%q) warning = %q, want %q", tt.value, warning, tt.wantWarning)
+			}
+		})
+	}
+}
+
+func TestHasDirectivePrefix(t *testing.T) {
+	tests := []struct {
+		line string
+		want bool
+	}{
+		{"rule:CKV_AWS_18", true},
+		{"category:secrets", true},
+		{"severity:HIGH", true},
+		{"cwe:798", true},
+		{"Rule:CKV_AWS_18", true},   // case insensitive
+		{"SEVERITY:HIGH", true},     // case insensitive
+		{"vendor/", false},          // path pattern
+		{"*.log", false},            // path pattern
+		{"invalid:foo", false},      // unrecognized prefix
+		{"# cwe:798", false},        // comment (but hasDirectivePrefix doesn't check for #)
+		{"norule:something", false}, // not a prefix match
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			got := hasDirectivePrefix(tt.line)
+			if got != tt.want {
+				t.Errorf("hasDirectivePrefix(%q) = %v, want %v", tt.line, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Related Issue

* [PPSC-705](https://armis-security.atlassian.net/browse/PPSC-705)

## Type of Change

* [x] New feature (non-breaking change which adds functionality)

## Problem

The `.armisignore` file only supported path-based exclusion patterns. Users had no way to suppress findings by rule ID, CWE, severity, or category directly from their repository configuration.

## Solution

Extend the `.armisignore` parser to recognize finding-level suppression directives (`rule:`, `category:`, `severity:`, `cwe:`) alongside existing path patterns. A new `LoadArmisIgnore()` function returns both an `IgnoreMatcher` (path patterns) and a `SuppressionConfig` (parsed directives). Directives are only honored from the root `.armisignore` — nested files treat directive-like lines as path patterns for backward compatibility. Invalid directives produce user-friendly warnings on stderr.

Additional hardening: UTF-8 BOM stripping, 1000-line truncation limit (fail-open per ADR-0008 Section 12).

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

- Verified mixed files with both patterns and directives parse correctly
- Verified nested .armisignore files do not have directives extracted
- Verified backward compatibility: `LoadIgnorePatterns` produces identical results to before

## Reviewer Notes

- `LoadIgnorePatterns` is preserved as a backward-compatible wrapper around `LoadArmisIgnore` — no callers need updating yet
- The `SuppressionConfig` is returned but not yet consumed by the scan flow — integration will follow in a subsequent PR
- Directives use ` -- ` (space-dash-dash-space) as the reason delimiter to avoid conflicts with path patterns

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-705]: https://armis-security.atlassian.net/browse/PPSC-705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ