### PR TITLE
fix(ci): pin cosign-installer to v4.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         uses: anchore/sbom-action/download-syft@v0.24.0
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.1
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7


### PR DESCRIPTION
## Summary

- Pin `sigstore/cosign-installer` to `v4.1.1` — the repo doesn't publish a floating `v4` major tag, causing `unable to find version` errors in the release workflow

Unblocks the v1.7.0 release (tag will be re-created after merge).

## Test plan

- [ ] Merge this PR
- [ ] Re-tag `v1.7.0` on main
- [ ] Verify Release workflow passes