### PR TITLE
fix(ci): add --bundle flag for cosign v2.5+ signing compatibility

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -124,7 +124,7 @@ release:
     cosign verify-blob \
       --certificate-identity-regexp 'https://github.com/ArmisSecurity/armis-cli/.github/workflows/release.yml@refs/tags/.*' \
       --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-      --signature armis-cli-checksums.txt.sig \
+      --bundle armis-cli-checksums.txt.bundle \
       armis-cli-checksums.txt
     ```
   footer: |
@@ -143,10 +143,10 @@ signs:
     output: true
     args:
       - sign-blob
-      - "--output-signature=${signature}"
-      - "--bundle=${signature}.bundle"
+      - "--bundle=${signature}"
       - "${artifact}"
       - "--yes"
+    signature: "${artifact}.bundle"
 
 # Homebrew tap updates are handled by a separate workflow in the homebrew-tap repo
 # that auto-detects new releases from this repository


### PR DESCRIPTION
## Summary

- Remove deprecated `--output-signature` flag (ignored by cosign v2.5+ with new bundle format)
- Use `--bundle=${signature}` as the sole signing output
- Set GoReleaser `signature: "${artifact}.bundle"` so it looks for the correct file after signing
- Update release verification instructions to use `cosign verify-blob --bundle`

Previous PR #160 only added `--bundle` alongside the deprecated flag, but cosign still didn't produce the `.sig` file that GoReleaser expected to upload.

## Test plan

- [ ] Merge this PR
- [ ] Re-tag `v1.7.0`
- [ ] Verify Release workflow completes: cosign signs → GoReleaser uploads `.bundle` → SLSA provenance generated