### PR TITLE
[PPSC-720] feat(scan): add client-side finding suppression via .armisignore

### DIFF
--- a/internal/cmd/scan_repo.go
+++ b/internal/cmd/scan_repo.go
@@ -18,6 +18,9 @@ import (
 // changedRef holds the value for the --changed flag (repo-specific, not shared with scan image).
 var changedRef string
 
+// showSuppressed controls whether findings suppressed by .armisignore are displayed.
+var showSuppressed bool
+
 var scanRepoCmd = &cobra.Command{
 	Use:   "repo [path]",
 	Short: "Scan a local repository",
@@ -175,6 +178,7 @@ var scanRepoCmd = &cobra.Command{
 			Debug:            debug,
 			SummaryTop:       summaryTop,
 			FailOnSeverities: failOnSeverities,
+			ShowSuppressed:   showSuppressed,
 		}
 
 		if err := formatter.FormatWithOptions(result, outputCfg.Writer, opts); err != nil {
@@ -188,6 +192,8 @@ var scanRepoCmd = &cobra.Command{
 func init() {
 	scanRepoCmd.Flags().StringSliceVar(&includeFiles, "include-files", nil,
 		"Comma-separated list of file paths to include in scan (relative to repository root)")
+	scanRepoCmd.Flags().BoolVar(&showSuppressed, "show-suppressed", false,
+		"Show findings suppressed by .armisignore directives")
 	scanRepoCmd.Flags().StringVar(&changedRef, "changed", "",
 		"Scan only git-changed files: --changed for uncommitted, "+
 			"--changed=staged for staged only, --changed=REF for changes vs a branch/tag "+

--- a/internal/model/finding.go
+++ b/internal/model/finding.go
@@ -33,6 +33,13 @@ const (
 	FindingTypeMisconfig FindingType = "MISCONFIG"
 )
 
+// SuppressionInfo describes why a finding was suppressed by .armisignore.
+type SuppressionInfo struct {
+	Type   string `json:"type"`             // "severity", "category", "cwe", "rule"
+	Value  string `json:"value"`            // the directive value that matched
+	Reason string `json:"reason,omitempty"` // user-provided reason from " -- " delimiter
+}
+
 // Finding represents a single security finding from a scan.
 type Finding struct {
 	ID                      string             `json:"id"`
@@ -58,6 +65,8 @@ type Finding struct {
 	OWASPCategories         []OWASPCategory    `json:"owasp_categories,omitempty"`
 	LongDescriptionMarkdown string             `json:"long_description_markdown,omitempty"`
 	URLs                    []string           `json:"urls,omitempty"`
+	Suppressed              bool               `json:"suppressed,omitempty"`
+	SuppressionInfo         *SuppressionInfo   `json:"suppression_info,omitempty"`
 }
 
 // ScanResult represents the complete result of a security scan.
@@ -77,6 +86,7 @@ type Summary struct {
 	ByType                 map[FindingType]int `json:"by_type"`
 	ByCategory             map[string]int      `json:"by_category"`
 	FilteredNonExploitable int                 `json:"filtered_non_exploitable"`
+	Suppressed             int                 `json:"suppressed,omitempty"`
 }
 
 // IngestUploadResponse represents the response from uploading a scan artifact.

--- a/internal/output/human.go
+++ b/internal/output/human.go
@@ -317,7 +317,12 @@ func (f *HumanFormatter) FormatWithOptions(result *model.ScanResult, w io.Writer
 	}
 
 	// 5. Findings section
-	if len(result.Findings) > 0 {
+	displayFindings := result.Findings
+	if !opts.ShowSuppressed {
+		displayFindings = FilterActiveFindings(result.Findings)
+	}
+
+	if len(displayFindings) > 0 {
 		ew.write("\n")
 		sectionStyle := s.SectionTitle.
 			BorderStyle(lipgloss.NormalBorder()).
@@ -331,11 +336,27 @@ func (f *HumanFormatter) FormatWithOptions(result *model.ScanResult, w io.Writer
 
 		// 5. Individual findings
 		if opts.GroupBy != "" && opts.GroupBy != "none" {
-			groups := groupFindings(result.Findings, opts.GroupBy)
+			groups := groupFindings(displayFindings, opts.GroupBy)
 			renderGroupedFindings(w, groups, opts)
 		} else {
-			sortedFindings := sortFindingsBySeverity(result.Findings)
+			sortedFindings := sortFindingsBySeverity(displayFindings)
 			renderFindings(w, sortedFindings, opts)
+		}
+	}
+
+	// CRITICAL suppression warning
+	if result.Summary.Suppressed > 0 {
+		criticalSuppressed := 0
+		for _, f := range result.Findings {
+			if f.Suppressed && f.Severity == model.SeverityCritical {
+				criticalSuppressed++
+			}
+		}
+		if criticalSuppressed > 0 {
+			ew.write("\n")
+			ew.write("%s\n", s.WarningText.Render(
+				fmt.Sprintf("WARNING: %d CRITICAL %s suppressed by .armisignore",
+					criticalSuppressed, pluralize("finding", criticalSuppressed))))
 		}
 	}
 
@@ -681,11 +702,19 @@ func renderBriefStatus(w io.Writer, result *model.ScanResult) error {
 	s := GetStyles()
 
 	total := result.Summary.Total
+	suppressed := result.Summary.Suppressed
 
 	// Handle edge case: no findings
-	if total == 0 {
+	if total == 0 && suppressed == 0 {
 		successStyle := s.SuccessText
 		ew.write("%s %s\n", IconSuccess, successStyle.Render("No issues found"))
+		return ew.err
+	}
+
+	if total == 0 && suppressed > 0 {
+		successStyle := s.SuccessText
+		ew.write("%s %s\n", IconSuccess, successStyle.Render(
+			fmt.Sprintf("No active issues (%d suppressed by .armisignore)", suppressed)))
 		return ew.err
 	}
 
@@ -707,11 +736,20 @@ func renderBriefStatus(w io.Writer, result *model.ScanResult) error {
 		}
 	}
 
-	// Format: "N issues  ·  X critical, Y high, Z medium"
-	ew.write("%s  %s  %s\n",
-		s.Bold.Render(fmt.Sprintf("%d %s", total, pluralize("issue", total))),
-		s.MutedText.Render("·"),
-		strings.Join(parts, s.MutedText.Render(", ")))
+	if suppressed > 0 {
+		// Format: "N issues (M suppressed by .armisignore)  ·  X critical, Y high"
+		ew.write("%s  %s  %s\n",
+			s.Bold.Render(fmt.Sprintf("%d %s", total, pluralize("issue", total)))+
+				s.MutedText.Render(fmt.Sprintf(" (%d suppressed by .armisignore)", suppressed)),
+			s.MutedText.Render("·"),
+			strings.Join(parts, s.MutedText.Render(", ")))
+	} else {
+		// Format: "N issues  ·  X critical, Y high, Z medium"
+		ew.write("%s  %s  %s\n",
+			s.Bold.Render(fmt.Sprintf("%d %s", total, pluralize("issue", total))),
+			s.MutedText.Render("·"),
+			strings.Join(parts, s.MutedText.Render(", ")))
+	}
 
 	return ew.err
 }
@@ -740,6 +778,12 @@ func renderSummaryDashboard(w io.Writer, result *model.ScanResult) error {
 	if result.Summary.FilteredNonExploitable > 0 {
 		filtered := s.MutedText.Render(fmt.Sprintf("(%d filtered as non-exploitable)", result.Summary.FilteredNonExploitable))
 		content.WriteString(filtered + "\n")
+	}
+
+	// Suppressed count if any
+	if result.Summary.Suppressed > 0 {
+		suppressed := s.MutedText.Render(fmt.Sprintf("(%d suppressed by .armisignore)", result.Summary.Suppressed))
+		content.WriteString(suppressed + "\n")
 	}
 
 	// Severity breakdown - minimal inline format with colored dots
@@ -828,6 +872,23 @@ func renderFindings(w io.Writer, findings []model.Finding, opts FormatOptions) {
 
 func renderFinding(w io.Writer, finding model.Finding, opts FormatOptions) {
 	s := GetStyles()
+
+	// Show suppression label if finding is suppressed and --show-suppressed is active
+	if finding.Suppressed {
+		suppLabel := s.MutedText.Render("[SUPPRESSED]")
+		var reason string
+		if finding.SuppressionInfo != nil {
+			reason = fmt.Sprintf("%s:%s", finding.SuppressionInfo.Type, finding.SuppressionInfo.Value)
+			if finding.SuppressionInfo.Reason != "" {
+				reason += " -- " + finding.SuppressionInfo.Reason
+			}
+		}
+		if reason != "" {
+			_, _ = fmt.Fprintf(w, "%s %s\n", suppLabel, s.MutedText.Render(reason))
+		} else {
+			_, _ = fmt.Fprintf(w, "%s\n", suppLabel)
+		}
+	}
 
 	// Severity (bold colored text) + Title on same line
 	sevStyle := s.GetSeverityText(finding.Severity)

--- a/internal/output/human.go
+++ b/internal/output/human.go
@@ -873,7 +873,8 @@ func renderFindings(w io.Writer, findings []model.Finding, opts FormatOptions) {
 func renderFinding(w io.Writer, finding model.Finding, opts FormatOptions) {
 	s := GetStyles()
 
-	// Show suppression label if finding is suppressed and --show-suppressed is active
+	// Show suppression label whenever a suppressed finding is rendered (callers
+	// are responsible for filtering suppressed findings when --show-suppressed is off).
 	if finding.Suppressed {
 		suppLabel := s.MutedText.Render("[SUPPRESSED]")
 		var reason string

--- a/internal/output/human.go
+++ b/internal/output/human.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ArmisSecurity/armis-cli/internal/cli"
 	"github.com/ArmisSecurity/armis-cli/internal/model"
 	"github.com/ArmisSecurity/armis-cli/internal/util"
 	"github.com/charmbracelet/lipgloss"
@@ -344,7 +345,7 @@ func (f *HumanFormatter) FormatWithOptions(result *model.ScanResult, w io.Writer
 		}
 	}
 
-	// CRITICAL suppression warning
+	// CRITICAL suppression warning — emitted to stderr so it doesn't pollute stdout
 	if result.Summary.Suppressed > 0 {
 		criticalSuppressed := 0
 		for _, f := range result.Findings {
@@ -353,10 +354,8 @@ func (f *HumanFormatter) FormatWithOptions(result *model.ScanResult, w io.Writer
 			}
 		}
 		if criticalSuppressed > 0 {
-			ew.write("\n")
-			ew.write("%s\n", s.WarningText.Render(
-				fmt.Sprintf("WARNING: %d CRITICAL %s suppressed by .armisignore",
-					criticalSuppressed, pluralize("finding", criticalSuppressed))))
+			cli.PrintWarningf("%d CRITICAL %s suppressed by .armisignore",
+				criticalSuppressed, pluralize("finding", criticalSuppressed))
 		}
 	}
 

--- a/internal/output/human_test.go
+++ b/internal/output/human_test.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1009,4 +1010,172 @@ func TestMaskFixForDisplay(t *testing.T) {
 
 func ptrString(s string) *string {
 	return &s
+}
+
+func TestRenderBriefStatus_WithSuppressed(t *testing.T) {
+	cli.InitColors(cli.ColorModeNever)
+	SyncColors()
+
+	result := &model.ScanResult{
+		Summary: model.Summary{
+			Total:      3,
+			BySeverity: map[model.Severity]int{model.SeverityHigh: 2, model.SeverityMedium: 1},
+			Suppressed: 2,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := renderBriefStatus(&buf, result); err != nil {
+		t.Fatalf("renderBriefStatus failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "3 issues") {
+		t.Errorf("expected '3 issues', got %q", output)
+	}
+	if !strings.Contains(output, "2 suppressed by .armisignore") {
+		t.Errorf("expected suppression info, got %q", output)
+	}
+}
+
+func TestRenderBriefStatus_ZeroSuppressedUnchangedFormat(t *testing.T) {
+	cli.InitColors(cli.ColorModeNever)
+	SyncColors()
+
+	result := &model.ScanResult{
+		Summary: model.Summary{
+			Total:      2,
+			BySeverity: map[model.Severity]int{model.SeverityHigh: 2},
+			Suppressed: 0,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := renderBriefStatus(&buf, result); err != nil {
+		t.Fatalf("renderBriefStatus failed: %v", err)
+	}
+
+	output := buf.String()
+	if strings.Contains(output, "suppressed") {
+		t.Errorf("should not mention suppression when count is 0, got %q", output)
+	}
+}
+
+func TestRenderSummaryDashboard_ShowsSuppressionLine(t *testing.T) {
+	cli.InitColors(cli.ColorModeNever)
+	SyncColors()
+
+	result := &model.ScanResult{
+		Summary: model.Summary{
+			Total:      5,
+			BySeverity: map[model.Severity]int{model.SeverityHigh: 5},
+			Suppressed: 3,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := renderSummaryDashboard(&buf, result); err != nil {
+		t.Fatalf("renderSummaryDashboard failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "3 suppressed by .armisignore") {
+		t.Errorf("expected suppression line in dashboard, got %q", output)
+	}
+}
+
+func TestHumanFormatter_CriticalSuppressionWarning(t *testing.T) {
+	cli.InitColors(cli.ColorModeNever)
+	SyncColors()
+
+	result := &model.ScanResult{
+		ScanID: "test-warn",
+		Status: "completed",
+		Summary: model.Summary{
+			Total:      1,
+			BySeverity: map[model.Severity]int{model.SeverityLow: 1},
+			Suppressed: 1,
+		},
+		Findings: []model.Finding{
+			{ID: "a", Severity: model.SeverityLow, Title: "Active Low"},
+			{ID: "b", Severity: model.SeverityCritical, Title: "Suppressed Crit", Suppressed: true},
+		},
+	}
+
+	formatter := &HumanFormatter{}
+	var buf bytes.Buffer
+	err := formatter.FormatWithOptions(result, &buf, FormatOptions{})
+	if err != nil {
+		t.Fatalf("FormatWithOptions failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "WARNING: 1 CRITICAL finding suppressed by .armisignore") {
+		t.Errorf("expected CRITICAL suppression warning, got:\n%s", output)
+	}
+}
+
+func TestHumanFormatter_NoCriticalNoWarning(t *testing.T) {
+	cli.InitColors(cli.ColorModeNever)
+	SyncColors()
+
+	result := &model.ScanResult{
+		ScanID: "test-nowarn",
+		Status: "completed",
+		Summary: model.Summary{
+			Total:      1,
+			BySeverity: map[model.Severity]int{model.SeverityHigh: 1},
+			Suppressed: 1,
+		},
+		Findings: []model.Finding{
+			{ID: "a", Severity: model.SeverityHigh, Title: "Active High"},
+			{ID: "b", Severity: model.SeverityLow, Title: "Suppressed Low", Suppressed: true},
+		},
+	}
+
+	formatter := &HumanFormatter{}
+	var buf bytes.Buffer
+	err := formatter.FormatWithOptions(result, &buf, FormatOptions{})
+	if err != nil {
+		t.Fatalf("FormatWithOptions failed: %v", err)
+	}
+
+	output := buf.String()
+	if strings.Contains(output, "WARNING") {
+		t.Errorf("should not show CRITICAL warning when no CRITICAL suppressed, got:\n%s", output)
+	}
+}
+
+func TestHumanFormatter_ShowSuppressedFalse_HidesSuppressedFindings(t *testing.T) {
+	cli.InitColors(cli.ColorModeNever)
+	SyncColors()
+
+	result := &model.ScanResult{
+		ScanID: "test-hide",
+		Status: "completed",
+		Summary: model.Summary{
+			Total:      1,
+			BySeverity: map[model.Severity]int{model.SeverityHigh: 1},
+			Suppressed: 1,
+		},
+		Findings: []model.Finding{
+			{ID: "active", Severity: model.SeverityHigh, Title: "Active Finding"},
+			{ID: "hidden", Severity: model.SeverityLow, Title: "Hidden Finding", Suppressed: true},
+		},
+	}
+
+	formatter := &HumanFormatter{}
+	var buf bytes.Buffer
+	err := formatter.FormatWithOptions(result, &buf, FormatOptions{ShowSuppressed: false})
+	if err != nil {
+		t.Fatalf("FormatWithOptions failed: %v", err)
+	}
+
+	output := buf.String()
+	if strings.Contains(output, "Hidden Finding") {
+		t.Errorf("suppressed finding should not appear when ShowSuppressed=false")
+	}
+	if !strings.Contains(output, "Active Finding") {
+		t.Errorf("active finding should appear")
+	}
 }

--- a/internal/output/human_test.go
+++ b/internal/output/human_test.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1102,16 +1103,32 @@ func TestHumanFormatter_CriticalSuppressionWarning(t *testing.T) {
 		},
 	}
 
+	// Capture stderr to verify the warning goes there (not stdout)
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
 	formatter := &HumanFormatter{}
 	var buf bytes.Buffer
 	err := formatter.FormatWithOptions(result, &buf, FormatOptions{})
 	if err != nil {
+		os.Stderr = oldStderr
 		t.Fatalf("FormatWithOptions failed: %v", err)
 	}
 
-	output := buf.String()
-	if !strings.Contains(output, "WARNING: 1 CRITICAL finding suppressed by .armisignore") {
-		t.Errorf("expected CRITICAL suppression warning, got:\n%s", output)
+	_ = w.Close()
+	var stderrBuf bytes.Buffer
+	_, _ = io.Copy(&stderrBuf, r)
+	os.Stderr = oldStderr
+
+	stderrOutput := stderrBuf.String()
+	if !strings.Contains(stderrOutput, "1 CRITICAL finding suppressed by .armisignore") {
+		t.Errorf("expected CRITICAL suppression warning on stderr, got:\n%s", stderrOutput)
+	}
+
+	stdoutOutput := buf.String()
+	if strings.Contains(stdoutOutput, "CRITICAL finding suppressed") {
+		t.Errorf("CRITICAL suppression warning should not appear on stdout")
 	}
 }
 

--- a/internal/output/json_test.go
+++ b/internal/output/json_test.go
@@ -401,3 +401,62 @@ func TestJSONFormatter_NilAndEmptyHandling(t *testing.T) {
 		}
 	})
 }
+
+func TestJSONFormatter_SuppressedFieldPresent(t *testing.T) {
+	formatter := &JSONFormatter{}
+	result := &model.ScanResult{
+		ScanID: "test-json-supp",
+		Findings: []model.Finding{
+			{
+				ID:         "supp-1",
+				Severity:   model.SeverityLow,
+				Title:      "Suppressed finding",
+				Suppressed: true,
+				SuppressionInfo: &model.SuppressionInfo{
+					Type:  "severity",
+					Value: "LOW",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(result, &buf); err != nil {
+		t.Fatalf("Format failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, `"suppressed": true`) {
+		t.Error("expected suppressed:true in JSON output")
+	}
+	if !strings.Contains(output, `"suppression_info"`) {
+		t.Error("expected suppression_info in JSON output")
+	}
+}
+
+func TestJSONFormatter_NonSuppressedOmitsSuppressedField(t *testing.T) {
+	formatter := &JSONFormatter{}
+	result := &model.ScanResult{
+		ScanID: "test-json-nosupp",
+		Findings: []model.Finding{
+			{
+				ID:       "active-1",
+				Severity: model.SeverityHigh,
+				Title:    "Active finding",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(result, &buf); err != nil {
+		t.Fatalf("Format failed: %v", err)
+	}
+
+	output := buf.String()
+	if strings.Contains(output, `"suppressed"`) {
+		t.Error("non-suppressed finding should not have 'suppressed' key (omitempty)")
+	}
+	if strings.Contains(output, `"suppression_info"`) {
+		t.Error("non-suppressed finding should not have 'suppression_info' key (omitempty)")
+	}
+}

--- a/internal/output/junit.go
+++ b/internal/output/junit.go
@@ -61,15 +61,16 @@ func (f *JUnitFormatter) FormatWithOptions(result *model.ScanResult, w io.Writer
 }
 
 func (f *JUnitFormatter) formatWithSeverities(result *model.ScanResult, w io.Writer, failOnSeverities []string) error {
+	activeFindings := FilterActiveFindings(result.Findings)
 	suites := junitTestSuites{
 		Suites: []junitTestSuite{
 			{
 				Name:     "Armis Security Scan",
-				Tests:    len(result.Findings),
-				Failures: countFailuresWithSeverities(result.Findings, failOnSeverities),
+				Tests:    len(activeFindings),
+				Failures: countFailuresWithSeverities(activeFindings, failOnSeverities),
 				Errors:   0,
 				Time:     "0",
-				Cases:    convertToJUnitCasesWithSeverities(result.Findings, failOnSeverities),
+				Cases:    convertToJUnitCasesWithSeverities(activeFindings, failOnSeverities),
 			},
 		},
 	}

--- a/internal/output/junit_test.go
+++ b/internal/output/junit_test.go
@@ -205,3 +205,79 @@ func TestJUnitFormatter_FormatWithOptions(t *testing.T) {
 		t.Fatalf("Expected 1 test suite, got %d", len(suites.Suites))
 	}
 }
+
+func TestJUnitFormatter_SuppressedFindingsExcluded(t *testing.T) {
+	formatter := &JUnitFormatter{}
+	result := &model.ScanResult{
+		ScanID: "test-junit-supp",
+		Findings: []model.Finding{
+			{
+				ID:       "active-1",
+				Severity: model.SeverityCritical,
+				Title:    "Active Critical",
+				Type:     model.FindingTypeVulnerability,
+			},
+			{
+				ID:         "supp-1",
+				Severity:   model.SeverityLow,
+				Title:      "Suppressed Low",
+				Type:       model.FindingTypeSCA,
+				Suppressed: true,
+			},
+			{
+				ID:         "supp-2",
+				Severity:   model.SeverityHigh,
+				Title:      "Suppressed High",
+				Type:       model.FindingTypeSecret,
+				Suppressed: true,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := formatter.Format(result, &buf)
+	if err != nil {
+		t.Fatalf("Format failed: %v", err)
+	}
+
+	var suites junitTestSuites
+	if err := xml.Unmarshal(buf.Bytes(), &suites); err != nil {
+		t.Fatalf("Failed to decode JUnit XML: %v", err)
+	}
+
+	suite := suites.Suites[0]
+	if suite.Tests != 1 {
+		t.Errorf("Tests count = %d, want 1 (only active findings)", suite.Tests)
+	}
+	if len(suite.Cases) != 1 {
+		t.Fatalf("Cases count = %d, want 1", len(suite.Cases))
+	}
+	if suite.Cases[0].Name != "Active Critical" {
+		t.Errorf("Case name = %q, want %q", suite.Cases[0].Name, "Active Critical")
+	}
+}
+
+func TestJUnitFormatter_AllSuppressedEmptyOutput(t *testing.T) {
+	formatter := &JUnitFormatter{}
+	result := &model.ScanResult{
+		ScanID: "test-junit-allsupp",
+		Findings: []model.Finding{
+			{
+				ID:         "supp-1",
+				Severity:   model.SeverityLow,
+				Title:      "Suppressed",
+				Suppressed: true,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(result, &buf); err != nil {
+		t.Fatalf("Format failed: %v", err)
+	}
+
+	output := buf.String()
+	if strings.Contains(output, "Suppressed") {
+		t.Error("suppressed finding should not appear in JUnit output")
+	}
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -43,6 +43,7 @@ type FormatOptions struct {
 	Debug            bool
 	SummaryTop       bool
 	FailOnSeverities []string // Severities that count as failures (for JUnit output)
+	ShowSuppressed   bool     // Show findings suppressed by .armisignore directives
 }
 
 // Formatter is the interface for formatting scan results in different output formats.
@@ -68,6 +69,7 @@ func GetFormatter(format string) (Formatter, error) {
 }
 
 // ShouldFail determines if the scan should fail based on the severity of findings.
+// Suppressed findings are excluded from the evaluation.
 func ShouldFail(result *model.ScanResult, failOnSeverities []string) bool {
 	severityMap := make(map[string]bool)
 	for _, sev := range failOnSeverities {
@@ -75,12 +77,26 @@ func ShouldFail(result *model.ScanResult, failOnSeverities []string) bool {
 	}
 
 	for _, finding := range result.Findings {
+		if finding.Suppressed {
+			continue
+		}
 		if severityMap[string(finding.Severity)] {
 			return true
 		}
 	}
 
 	return false
+}
+
+// FilterActiveFindings returns only non-suppressed findings.
+func FilterActiveFindings(findings []model.Finding) []model.Finding {
+	active := make([]model.Finding, 0, len(findings))
+	for _, f := range findings {
+		if !f.Suppressed {
+			active = append(active, f)
+		}
+	}
+	return active
 }
 
 // CheckExit returns an error if the scan should fail based on severity of findings.

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -274,6 +274,50 @@ func TestCheckExit_StdoutSyncError(t *testing.T) {
 	}
 }
 
+func TestShouldFail_SkipsSuppressedCritical(t *testing.T) {
+	result := &model.ScanResult{
+		Findings: []model.Finding{
+			{Severity: model.SeverityCritical, Suppressed: true},
+			{Severity: model.SeverityLow},
+		},
+	}
+
+	if ShouldFail(result, []string{"CRITICAL"}) {
+		t.Error("ShouldFail should skip suppressed CRITICAL findings")
+	}
+}
+
+func TestShouldFail_MixedSuppressedAndActive(t *testing.T) {
+	result := &model.ScanResult{
+		Findings: []model.Finding{
+			{Severity: model.SeverityCritical, Suppressed: true},
+			{Severity: model.SeverityHigh},
+		},
+	}
+
+	if ShouldFail(result, []string{"CRITICAL"}) {
+		t.Error("ShouldFail should not trigger on suppressed CRITICAL when only active HIGH exists")
+	}
+	if !ShouldFail(result, []string{"HIGH"}) {
+		t.Error("ShouldFail should trigger on active HIGH")
+	}
+}
+
+func TestFilterActiveFindings(t *testing.T) {
+	findings := []model.Finding{
+		{ID: "1", Suppressed: false},
+		{ID: "2", Suppressed: true},
+		{ID: "3", Suppressed: false},
+	}
+	active := FilterActiveFindings(findings)
+	if len(active) != 2 {
+		t.Fatalf("FilterActiveFindings returned %d, want 2", len(active))
+	}
+	if active[0].ID != "1" || active[1].ID != "3" {
+		t.Errorf("unexpected active IDs: %s, %s", active[0].ID, active[1].ID)
+	}
+}
+
 // TestSyncColors_Enabled verifies that SyncColors enables styling when cli colors are enabled.
 func TestSyncColors_Enabled(t *testing.T) {
 	// Enable colors via cli package

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -69,8 +69,14 @@ type sarifResult struct {
 	Message             sarifMessage           `json:"message"`
 	Locations           []sarifLocation        `json:"locations,omitempty"`
 	PartialFingerprints map[string]string      `json:"partialFingerprints,omitempty"`
+	Suppressions        []sarifSuppression     `json:"suppressions,omitempty"`
 	Fixes               []sarifFix             `json:"fixes,omitempty"`
 	Properties          *sarifResultProperties `json:"properties,omitempty"`
+}
+
+type sarifSuppression struct {
+	Kind          string `json:"kind"`
+	Justification string `json:"justification,omitempty"`
 }
 
 type sarifResultProperties struct {
@@ -391,6 +397,17 @@ func convertToSarifResults(findings []model.Finding, ruleIndexMap map[string]int
 			if finding.Validation.ValidatedSeverity != nil {
 				result.Properties.Validation.ValidatedSeverity = *finding.Validation.ValidatedSeverity
 			}
+		}
+
+		if finding.Suppressed && finding.SuppressionInfo != nil {
+			justification := fmt.Sprintf(".armisignore %s:%s", finding.SuppressionInfo.Type, finding.SuppressionInfo.Value)
+			if finding.SuppressionInfo.Reason != "" {
+				justification += " -- " + finding.SuppressionInfo.Reason
+			}
+			result.Suppressions = []sarifSuppression{{
+				Kind:          "inSource",
+				Justification: justification,
+			}}
 		}
 
 		if finding.File != "" {

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -1450,3 +1450,79 @@ func TestSARIFFormatter_FindingIDAndFingerprints(t *testing.T) {
 		t.Errorf("rule ID = %q, want CWE-79", run.Tool.Driver.Rules[0].ID)
 	}
 }
+
+func TestSARIF_SuppressedFindingHasSuppressionsArray(t *testing.T) {
+	formatter := &SARIFFormatter{}
+	result := &model.ScanResult{
+		ScanID: "test-supp",
+		Findings: []model.Finding{
+			{
+				ID:         "supp-1",
+				Severity:   model.SeverityLow,
+				Title:      "Test finding",
+				File:       "main.go",
+				Suppressed: true,
+				SuppressionInfo: &model.SuppressionInfo{
+					Type:   "severity",
+					Value:  "LOW",
+					Reason: "accepted risk",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(result, &buf); err != nil {
+		t.Fatalf("Format failed: %v", err)
+	}
+
+	var report sarifReport
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("JSON parse failed: %v", err)
+	}
+
+	if len(report.Runs[0].Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(report.Runs[0].Results))
+	}
+
+	res := report.Runs[0].Results[0]
+	if len(res.Suppressions) != 1 {
+		t.Fatalf("expected 1 suppression, got %d", len(res.Suppressions))
+	}
+	if res.Suppressions[0].Kind != "inSource" {
+		t.Errorf("suppression kind = %q, want %q", res.Suppressions[0].Kind, "inSource")
+	}
+	if res.Suppressions[0].Justification != ".armisignore severity:LOW -- accepted risk" {
+		t.Errorf("justification = %q", res.Suppressions[0].Justification)
+	}
+}
+
+func TestSARIF_NonSuppressedFindingNoSuppressionsKey(t *testing.T) {
+	formatter := &SARIFFormatter{}
+	result := &model.ScanResult{
+		ScanID: "test-nosupp",
+		Findings: []model.Finding{
+			{
+				ID:       "active-1",
+				Severity: model.SeverityHigh,
+				Title:    "Active finding",
+				File:     "main.go",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(result, &buf); err != nil {
+		t.Fatalf("Format failed: %v", err)
+	}
+
+	var report sarifReport
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("JSON parse failed: %v", err)
+	}
+
+	res := report.Runs[0].Results[0]
+	if len(res.Suppressions) != 0 {
+		t.Errorf("non-suppressed finding should have no suppressions, got %d", len(res.Suppressions))
+	}
+}

--- a/internal/scan/finding_type.go
+++ b/internal/scan/finding_type.go
@@ -26,6 +26,8 @@ func DeriveFindingType(hasCVEs bool, hasSecret bool, findingCategory string) mod
 		return model.FindingTypeMisconfig
 	case "SECRET":
 		return model.FindingTypeSecret
+	case "LICENSE_COMPLIANCE_RISK", "LICENSE":
+		return model.FindingTypeLicense
 	default:
 		return model.FindingTypeSCA
 	}

--- a/internal/scan/finding_type_test.go
+++ b/internal/scan/finding_type_test.go
@@ -119,6 +119,20 @@ func TestDeriveFindingType(t *testing.T) {
 			findingCategory: "CODE_PACKAGE_VULNERABILITY",
 			want:            model.FindingTypeVulnerability,
 		},
+		{
+			name:            "LICENSE_COMPLIANCE_RISK category results in license",
+			hasCVEs:         false,
+			hasSecret:       false,
+			findingCategory: "LICENSE_COMPLIANCE_RISK",
+			want:            model.FindingTypeLicense,
+		},
+		{
+			name:            "lowercase license category results in license",
+			hasCVEs:         false,
+			hasSecret:       false,
+			findingCategory: "license",
+			want:            model.FindingTypeLicense,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/scan/repo/ignore.go
+++ b/internal/scan/repo/ignore.go
@@ -30,6 +30,43 @@ func LoadIgnorePatterns(repoRoot string) (*IgnoreMatcher, error) {
 	return matcher, err
 }
 
+// LoadSuppressionConfig loads only suppression directives from the root .armisignore file
+// without walking the entire repository tree. Use this in targeted scan modes (--include-files,
+// --changed) where the IgnoreMatcher is not needed for tar filtering.
+func LoadSuppressionConfig(repoRoot string) (*SuppressionConfig, error) {
+	rootIgnorePath := filepath.Join(repoRoot, ".armisignore")
+
+	info, err := os.Lstat(rootIgnorePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf(".armisignore is a symlink (rejected): %s", rootIgnorePath)
+	}
+
+	_, directives, warnings, parseErr := parseArmisIgnoreFile(rootIgnorePath, repoRoot, true)
+	if parseErr != nil {
+		return nil, parseErr
+	}
+
+	for _, w := range warnings {
+		cli.PrintWarningf(".armisignore: %s", w)
+	}
+
+	if len(directives) == 0 {
+		return nil, nil
+	}
+
+	config := NewSuppressionConfig()
+	for i := range directives {
+		config.Add(directives[i])
+	}
+	return config, nil
+}
+
 // LoadArmisIgnore loads both path patterns and suppression directives from .armisignore files.
 // Path patterns are collected from all .armisignore files (root and nested).
 // Suppression directives are only collected from the root .armisignore file.

--- a/internal/scan/repo/ignore.go
+++ b/internal/scan/repo/ignore.go
@@ -34,6 +34,9 @@ func LoadIgnorePatterns(repoRoot string) (*IgnoreMatcher, error) {
 // without walking the entire repository tree. Use this in targeted scan modes (--include-files,
 // --changed) where the IgnoreMatcher is not needed for tar filtering.
 func LoadSuppressionConfig(repoRoot string) (*SuppressionConfig, error) {
+	if !filepath.IsAbs(repoRoot) {
+		return nil, fmt.Errorf("repoRoot must be an absolute path, got: %s", repoRoot)
+	}
 	rootIgnorePath := filepath.Join(filepath.Clean(repoRoot), ".armisignore") // #nosec G304
 
 	info, err := os.Lstat(rootIgnorePath)

--- a/internal/scan/repo/ignore.go
+++ b/internal/scan/repo/ignore.go
@@ -34,7 +34,7 @@ func LoadIgnorePatterns(repoRoot string) (*IgnoreMatcher, error) {
 // without walking the entire repository tree. Use this in targeted scan modes (--include-files,
 // --changed) where the IgnoreMatcher is not needed for tar filtering.
 func LoadSuppressionConfig(repoRoot string) (*SuppressionConfig, error) {
-	rootIgnorePath := filepath.Join(repoRoot, ".armisignore")
+	rootIgnorePath := filepath.Join(filepath.Clean(repoRoot), ".armisignore") // #nosec G304
 
 	info, err := os.Lstat(rootIgnorePath)
 	if err != nil {

--- a/internal/scan/repo/matcher.go
+++ b/internal/scan/repo/matcher.go
@@ -1,0 +1,130 @@
+package repo
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/ArmisSecurity/armis-cli/internal/model"
+)
+
+var cweIntPattern = regexp.MustCompile(`^CWE-(\d+)`)
+
+// categoryToFindingType maps .armisignore category directive values to FindingType.
+var categoryToFindingType = map[string]model.FindingType{
+	"sast":    model.FindingTypeVulnerability,
+	"secrets": model.FindingTypeSecret,
+	"iac":     model.FindingTypeMisconfig,
+	"sca":     model.FindingTypeSCA,
+	"license": model.FindingTypeLicense,
+}
+
+// MatchResult describes the first directive that matched a finding.
+type MatchResult struct {
+	Matched   bool
+	Directive SuppressionDirective
+}
+
+// MatchFinding returns the first matching suppression directive for a finding.
+func MatchFinding(finding model.Finding, config *SuppressionConfig) MatchResult {
+	if config == nil || config.IsEmpty() {
+		return MatchResult{}
+	}
+
+	for _, d := range config.Severities {
+		if strings.EqualFold(d.Value, string(finding.Severity)) {
+			return MatchResult{Matched: true, Directive: d}
+		}
+	}
+
+	for _, d := range config.Categories {
+		expected, ok := categoryToFindingType[d.Value]
+		if ok && finding.Type == expected {
+			return MatchResult{Matched: true, Directive: d}
+		}
+	}
+
+	for _, d := range config.CWEs {
+		if cweMatches(finding.CWEs, d.Value) {
+			return MatchResult{Matched: true, Directive: d}
+		}
+	}
+
+	// rule: directives are no-ops until scanner_rule_id is available (ADR-0007)
+
+	return MatchResult{}
+}
+
+// cweMatches checks if any of the finding's CWE identifiers match the directive value.
+// The directive value is a bare integer string (e.g. "89").
+// Finding CWEs may be in the format "CWE-89: Improper..." or just "89".
+func cweMatches(findingCWEs []string, directiveValue string) bool {
+	for _, cwe := range findingCWEs {
+		if matches := cweIntPattern.FindStringSubmatch(cwe); len(matches) == 2 {
+			if matches[1] == directiveValue {
+				return true
+			}
+		} else if strings.TrimSpace(cwe) == directiveValue {
+			return true
+		}
+	}
+	return false
+}
+
+// ApplySuppression mutates findings in-place, marking matched findings as suppressed.
+// Returns the count of suppressed findings.
+func ApplySuppression(findings []model.Finding, config *SuppressionConfig) int {
+	if config == nil || config.IsEmpty() {
+		return 0
+	}
+
+	suppressed := 0
+	for i := range findings {
+		result := MatchFinding(findings[i], config)
+		if result.Matched {
+			findings[i].Suppressed = true
+			findings[i].SuppressionInfo = &model.SuppressionInfo{
+				Type:   string(result.Directive.Type),
+				Value:  result.Directive.Value,
+				Reason: result.Directive.Reason,
+			}
+			suppressed++
+		}
+	}
+	return suppressed
+}
+
+// recomputeSummary rebuilds the Summary counting only active (non-suppressed) findings.
+func recomputeSummary(findings []model.Finding, suppressed int, filteredNonExploitable int) model.Summary {
+	summary := model.Summary{
+		BySeverity:             make(map[model.Severity]int),
+		ByType:                 make(map[model.FindingType]int),
+		ByCategory:             make(map[string]int),
+		Suppressed:             suppressed,
+		FilteredNonExploitable: filteredNonExploitable,
+	}
+
+	for _, f := range findings {
+		if f.Suppressed {
+			continue
+		}
+		summary.Total++
+		summary.BySeverity[f.Severity]++
+		summary.ByType[f.Type]++
+		if f.FindingCategory != "" {
+			summary.ByCategory[f.FindingCategory]++
+		}
+	}
+
+	return summary
+}
+
+// filterActiveFindings returns only non-suppressed findings.
+func filterActiveFindings(findings []model.Finding) []model.Finding {
+	active := make([]model.Finding, 0, len(findings))
+	for _, f := range findings {
+		if !f.Suppressed {
+			active = append(active, f)
+		}
+	}
+	return active
+}

--- a/internal/scan/repo/matcher.go
+++ b/internal/scan/repo/matcher.go
@@ -119,14 +119,3 @@ func recomputeSummary(findings []model.Finding, suppressed int, filteredNonExplo
 
 	return summary
 }
-
-// filterActiveFindings returns only non-suppressed findings.
-func filterActiveFindings(findings []model.Finding) []model.Finding {
-	active := make([]model.Finding, 0, len(findings))
-	for _, f := range findings {
-		if !f.Suppressed {
-			active = append(active, f)
-		}
-	}
-	return active
-}

--- a/internal/scan/repo/matcher.go
+++ b/internal/scan/repo/matcher.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ArmisSecurity/armis-cli/internal/model"
 )
 
-var cweIntPattern = regexp.MustCompile(`^CWE-(\d+)`)
+var cweIntPattern = regexp.MustCompile(`(?i)^CWE-(\d+)`)
 
 // categoryToFindingType maps .armisignore category directive values to FindingType.
 var categoryToFindingType = map[string]model.FindingType{
@@ -56,14 +56,16 @@ func MatchFinding(finding model.Finding, config *SuppressionConfig) MatchResult 
 
 // cweMatches checks if any of the finding's CWE identifiers match the directive value.
 // The directive value is a bare integer string (e.g. "89").
-// Finding CWEs may be in the format "CWE-89: Improper..." or just "89".
+// Finding CWEs may be in the format "CWE-89: Improper...", "cwe-89", or just "89".
+// Matching is case-insensitive and whitespace-tolerant.
 func cweMatches(findingCWEs []string, directiveValue string) bool {
 	for _, cwe := range findingCWEs {
-		if matches := cweIntPattern.FindStringSubmatch(cwe); len(matches) == 2 {
+		trimmed := strings.TrimSpace(cwe)
+		if matches := cweIntPattern.FindStringSubmatch(trimmed); len(matches) == 2 {
 			if matches[1] == directiveValue {
 				return true
 			}
-		} else if strings.TrimSpace(cwe) == directiveValue {
+		} else if trimmed == directiveValue {
 			return true
 		}
 	}

--- a/internal/scan/repo/matcher_test.go
+++ b/internal/scan/repo/matcher_test.go
@@ -155,6 +155,9 @@ func TestCweMatches(t *testing.T) {
 		{"invalid vs 89", []string{"invalid"}, "89", false},
 		{"empty cwes", []string{}, "89", false},
 		{"multiple cwes, second matches", []string{"CWE-20", "CWE-79"}, "79", true},
+		{"lowercase cwe-78 matches", []string{"cwe-78"}, "78", true},
+		{"mixed case Cwe-789 matches", []string{"Cwe-789"}, "789", true},
+		{"whitespace trimmed", []string{" CWE-89 "}, "89", true},
 	}
 
 	for _, tt := range tests {

--- a/internal/scan/repo/matcher_test.go
+++ b/internal/scan/repo/matcher_test.go
@@ -1,0 +1,270 @@
+package repo
+
+import (
+	"testing"
+
+	"github.com/ArmisSecurity/armis-cli/internal/model"
+)
+
+func TestMatchFinding(t *testing.T) {
+	tests := []struct {
+		name    string
+		finding model.Finding
+		config  *SuppressionConfig
+		matched bool
+		dirType DirectiveType
+		value   string
+	}{
+		{
+			name:    "nil config returns no match",
+			finding: model.Finding{Severity: model.SeverityCritical},
+			config:  nil,
+			matched: false,
+		},
+		{
+			name:    "empty config returns no match",
+			finding: model.Finding{Severity: model.SeverityCritical},
+			config:  NewSuppressionConfig(),
+			matched: false,
+		},
+		{
+			name:    "severity CRITICAL matches CRITICAL finding",
+			finding: model.Finding{Severity: model.SeverityCritical},
+			config: &SuppressionConfig{
+				Severities: []SuppressionDirective{{Type: DirectiveSeverity, Value: "CRITICAL"}},
+			},
+			matched: true,
+			dirType: DirectiveSeverity,
+			value:   "CRITICAL",
+		},
+		{
+			name:    "severity LOW does not match HIGH finding",
+			finding: model.Finding{Severity: model.SeverityHigh},
+			config: &SuppressionConfig{
+				Severities: []SuppressionDirective{{Type: DirectiveSeverity, Value: "LOW"}},
+			},
+			matched: false,
+		},
+		{
+			name:    "category sast matches VULNERABILITY type",
+			finding: model.Finding{Type: model.FindingTypeVulnerability},
+			config: &SuppressionConfig{
+				Categories: []SuppressionDirective{{Type: DirectiveCategory, Value: "sast"}},
+			},
+			matched: true,
+			dirType: DirectiveCategory,
+			value:   "sast",
+		},
+		{
+			name:    "category secrets matches SECRET type",
+			finding: model.Finding{Type: model.FindingTypeSecret},
+			config: &SuppressionConfig{
+				Categories: []SuppressionDirective{{Type: DirectiveCategory, Value: "secrets"}},
+			},
+			matched: true,
+			dirType: DirectiveCategory,
+			value:   "secrets",
+		},
+		{
+			name:    "category does not match unrelated type",
+			finding: model.Finding{Type: model.FindingTypeSCA},
+			config: &SuppressionConfig{
+				Categories: []SuppressionDirective{{Type: DirectiveCategory, Value: "secrets"}},
+			},
+			matched: false,
+		},
+		{
+			name:    "cwe 89 matches CWE-89 with description",
+			finding: model.Finding{CWEs: []string{"CWE-89: Improper Neutralization of SQL"}},
+			config: &SuppressionConfig{
+				CWEs: []SuppressionDirective{{Type: DirectiveCWE, Value: "89"}},
+			},
+			matched: true,
+			dirType: DirectiveCWE,
+			value:   "89",
+		},
+		{
+			name:    "cwe 79 matches bare CWE-79",
+			finding: model.Finding{CWEs: []string{"CWE-79"}},
+			config: &SuppressionConfig{
+				CWEs: []SuppressionDirective{{Type: DirectiveCWE, Value: "79"}},
+			},
+			matched: true,
+			dirType: DirectiveCWE,
+			value:   "79",
+		},
+		{
+			name:    "cwe 0 matches nothing",
+			finding: model.Finding{CWEs: []string{"CWE-89"}},
+			config: &SuppressionConfig{
+				CWEs: []SuppressionDirective{{Type: DirectiveCWE, Value: "0"}},
+			},
+			matched: false,
+		},
+		{
+			name:    "rule directive always returns no match",
+			finding: model.Finding{ID: "test-123"},
+			config: &SuppressionConfig{
+				Rules: []SuppressionDirective{{Type: DirectiveRule, Value: "some-rule"}},
+			},
+			matched: false,
+		},
+		{
+			name: "severity wins over category for same finding",
+			finding: model.Finding{
+				Severity: model.SeverityLow,
+				Type:     model.FindingTypeVulnerability,
+			},
+			config: &SuppressionConfig{
+				Severities: []SuppressionDirective{{Type: DirectiveSeverity, Value: "LOW"}},
+				Categories: []SuppressionDirective{{Type: DirectiveCategory, Value: "sast"}},
+			},
+			matched: true,
+			dirType: DirectiveSeverity,
+			value:   "LOW",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MatchFinding(tt.finding, tt.config)
+			if result.Matched != tt.matched {
+				t.Fatalf("Matched = %v, want %v", result.Matched, tt.matched)
+			}
+			if tt.matched {
+				if result.Directive.Type != tt.dirType {
+					t.Errorf("Directive.Type = %q, want %q", result.Directive.Type, tt.dirType)
+				}
+				if result.Directive.Value != tt.value {
+					t.Errorf("Directive.Value = %q, want %q", result.Directive.Value, tt.value)
+				}
+			}
+		})
+	}
+}
+
+func TestCweMatches(t *testing.T) {
+	tests := []struct {
+		name      string
+		cwes      []string
+		directive string
+		want      bool
+	}{
+		{"CWE-89 with description vs 89", []string{"CWE-89: Improper Neutralization"}, "89", true},
+		{"bare 79 vs 79", []string{"79"}, "79", true},
+		{"invalid vs 89", []string{"invalid"}, "89", false},
+		{"empty cwes", []string{}, "89", false},
+		{"multiple cwes, second matches", []string{"CWE-20", "CWE-79"}, "79", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cweMatches(tt.cwes, tt.directive)
+			if got != tt.want {
+				t.Errorf("cweMatches(%v, %q) = %v, want %v", tt.cwes, tt.directive, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplySuppression(t *testing.T) {
+	t.Run("3 findings 2 match returns 2", func(t *testing.T) {
+		findings := []model.Finding{
+			{Severity: model.SeverityCritical, Type: model.FindingTypeVulnerability},
+			{Severity: model.SeverityLow, Type: model.FindingTypeSCA},
+			{Severity: model.SeverityLow, Type: model.FindingTypeSecret},
+		}
+		config := &SuppressionConfig{
+			Severities: []SuppressionDirective{{Type: DirectiveSeverity, Value: "LOW"}},
+		}
+
+		count := ApplySuppression(findings, config)
+		if count != 2 {
+			t.Fatalf("ApplySuppression returned %d, want 2", count)
+		}
+		if findings[0].Suppressed {
+			t.Error("findings[0] should not be suppressed")
+		}
+		if !findings[1].Suppressed || !findings[2].Suppressed {
+			t.Error("findings[1] and findings[2] should be suppressed")
+		}
+		if findings[1].SuppressionInfo == nil || findings[1].SuppressionInfo.Type != "severity" {
+			t.Error("findings[1] SuppressionInfo not set correctly")
+		}
+	})
+
+	t.Run("empty config returns 0 no mutation", func(t *testing.T) {
+		findings := []model.Finding{
+			{Severity: model.SeverityCritical},
+		}
+		config := NewSuppressionConfig()
+
+		count := ApplySuppression(findings, config)
+		if count != 0 {
+			t.Fatalf("ApplySuppression returned %d, want 0", count)
+		}
+		if findings[0].Suppressed {
+			t.Error("finding should not be suppressed with empty config")
+		}
+	})
+
+	t.Run("reason propagated from directive", func(t *testing.T) {
+		findings := []model.Finding{
+			{Severity: model.SeverityLow},
+		}
+		config := &SuppressionConfig{
+			Severities: []SuppressionDirective{{
+				Type:   DirectiveSeverity,
+				Value:  "LOW",
+				Reason: "accepted risk",
+			}},
+		}
+
+		ApplySuppression(findings, config)
+		if findings[0].SuppressionInfo.Reason != "accepted risk" {
+			t.Errorf("Reason = %q, want %q", findings[0].SuppressionInfo.Reason, "accepted risk")
+		}
+	})
+}
+
+func TestRecomputeSummary(t *testing.T) {
+	findings := []model.Finding{
+		{Severity: model.SeverityCritical, Type: model.FindingTypeVulnerability, FindingCategory: "CODE_VULNERABILITY"},
+		{Severity: model.SeverityLow, Type: model.FindingTypeSCA, Suppressed: true},
+		{Severity: model.SeverityLow, Type: model.FindingTypeSCA, Suppressed: true},
+	}
+
+	summary := recomputeSummary(findings, 2, 5)
+
+	if summary.Total != 1 {
+		t.Errorf("Total = %d, want 1", summary.Total)
+	}
+	if summary.Suppressed != 2 {
+		t.Errorf("Suppressed = %d, want 2", summary.Suppressed)
+	}
+	if summary.FilteredNonExploitable != 5 {
+		t.Errorf("FilteredNonExploitable = %d, want 5", summary.FilteredNonExploitable)
+	}
+	if summary.BySeverity[model.SeverityCritical] != 1 {
+		t.Errorf("BySeverity[CRITICAL] = %d, want 1", summary.BySeverity[model.SeverityCritical])
+	}
+	if summary.BySeverity[model.SeverityLow] != 0 {
+		t.Errorf("BySeverity[LOW] = %d, want 0", summary.BySeverity[model.SeverityLow])
+	}
+}
+
+func TestFilterActiveFindings(t *testing.T) {
+	findings := []model.Finding{
+		{ID: "1", Suppressed: false},
+		{ID: "2", Suppressed: true},
+		{ID: "3", Suppressed: false},
+	}
+
+	active := filterActiveFindings(findings)
+	if len(active) != 2 {
+		t.Fatalf("filterActiveFindings returned %d findings, want 2", len(active))
+	}
+	if active[0].ID != "1" || active[1].ID != "3" {
+		t.Errorf("unexpected active findings: %v", active)
+	}
+}

--- a/internal/scan/repo/matcher_test.go
+++ b/internal/scan/repo/matcher_test.go
@@ -255,19 +255,3 @@ func TestRecomputeSummary(t *testing.T) {
 		t.Errorf("BySeverity[LOW] = %d, want 0", summary.BySeverity[model.SeverityLow])
 	}
 }
-
-func TestFilterActiveFindings(t *testing.T) {
-	findings := []model.Finding{
-		{ID: "1", Suppressed: false},
-		{ID: "2", Suppressed: true},
-		{ID: "3", Suppressed: false},
-	}
-
-	active := filterActiveFindings(findings)
-	if len(active) != 2 {
-		t.Fatalf("filterActiveFindings returned %d findings, want 2", len(active))
-	}
-	if active[0].ID != "1" || active[1].ID != "3" {
-		t.Errorf("unexpected active findings: %v", active)
-	}
-}

--- a/internal/scan/repo/repo.go
+++ b/internal/scan/repo/repo.go
@@ -102,9 +102,15 @@ func (s *Scanner) Scan(ctx context.Context, path string) (*model.ScanResult, err
 		return nil, fmt.Errorf("path is not a directory: %s", absPath)
 	}
 
+	// Load .armisignore: suppression config applies in ALL scan modes,
+	// IgnoreMatcher only used in full-scan mode for tar filtering.
+	ignoreMatcher, suppressionConfig, err := LoadArmisIgnore(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load ignore patterns: %w", err)
+	}
+
 	var size int64
 	var tarFunc func() error
-	var ignoreMatcher *IgnoreMatcher
 
 	pr, pw := io.Pipe()
 	// The pipe reader is deferred-closed to ensure cleanup on all code paths.
@@ -125,10 +131,10 @@ func (s *Scanner) Scan(ctx context.Context, path string) (*model.ScanResult, err
 			return nil, fmt.Errorf("no files to scan: all specified files are missing or are directories")
 		}
 
-		var err error
-		size, err = calculateFilesSize(absPath, existing)
-		if err != nil {
-			return nil, fmt.Errorf("failed to calculate files size: %w", err)
+		var sizeErr error
+		size, sizeErr = calculateFilesSize(absPath, existing)
+		if sizeErr != nil {
+			return nil, fmt.Errorf("failed to calculate files size: %w", sizeErr)
 		}
 
 		tarFunc = func() error {
@@ -136,16 +142,11 @@ func (s *Scanner) Scan(ctx context.Context, path string) (*model.ScanResult, err
 			return s.tarGzFiles(absPath, existing, pw)
 		}
 	} else {
-		// Full directory scanning mode (existing behavior)
-		var err error
-		ignoreMatcher, err = LoadIgnorePatterns(absPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load ignore patterns: %w", err)
-		}
-
-		size, err = calculateDirSize(absPath, s.includeTests, ignoreMatcher)
-		if err != nil {
-			return nil, fmt.Errorf("failed to calculate directory size: %w", err)
+		// Full directory scanning mode — ignoreMatcher loaded above
+		var sizeErr error
+		size, sizeErr = calculateDirSize(absPath, s.includeTests, ignoreMatcher)
+		if sizeErr != nil {
+			return nil, fmt.Errorf("failed to calculate directory size: %w", sizeErr)
 		}
 
 		tarFunc = func() error {
@@ -261,6 +262,14 @@ func (s *Scanner) Scan(ctx context.Context, path string) (*model.ScanResult, err
 	}
 
 	result := buildScanResult(scanID, findings, s.client.IsDebug(), s.includeNonExploitable)
+
+	if suppressionConfig != nil && !suppressionConfig.IsEmpty() {
+		suppCount := ApplySuppression(result.Findings, suppressionConfig)
+		if suppCount > 0 {
+			result.Summary = recomputeSummary(result.Findings, suppCount, result.Summary.FilteredNonExploitable)
+		}
+	}
+
 	return result, nil
 }
 

--- a/internal/scan/repo/repo.go
+++ b/internal/scan/repo/repo.go
@@ -102,15 +102,9 @@ func (s *Scanner) Scan(ctx context.Context, path string) (*model.ScanResult, err
 		return nil, fmt.Errorf("path is not a directory: %s", absPath)
 	}
 
-	// Load .armisignore: suppression config applies in ALL scan modes,
-	// IgnoreMatcher only used in full-scan mode for tar filtering.
-	ignoreMatcher, suppressionConfig, err := LoadArmisIgnore(absPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load ignore patterns: %w", err)
-	}
-
 	var size int64
 	var tarFunc func() error
+	var suppressionConfig *SuppressionConfig
 
 	pr, pw := io.Pipe()
 	// The pipe reader is deferred-closed to ensure cleanup on all code paths.
@@ -121,7 +115,14 @@ func (s *Scanner) Scan(ctx context.Context, path string) (*model.ScanResult, err
 	defer pr.Close() //nolint:errcheck
 
 	if s.includeFiles != nil {
-		// Targeted file scanning mode - scan only specified files
+		// Targeted file scanning mode — only load suppression directives from root
+		// .armisignore (no tree walk needed since IgnoreMatcher isn't used for tar).
+		var suppErr error
+		suppressionConfig, suppErr = LoadSuppressionConfig(absPath)
+		if suppErr != nil {
+			return nil, fmt.Errorf("failed to load suppression config: %w", suppErr)
+		}
+
 		existing, warnings := s.includeFiles.ValidateExistence()
 		for _, w := range warnings {
 			cli.PrintWarning(w)
@@ -142,7 +143,13 @@ func (s *Scanner) Scan(ctx context.Context, path string) (*model.ScanResult, err
 			return s.tarGzFiles(absPath, existing, pw)
 		}
 	} else {
-		// Full directory scanning mode — ignoreMatcher loaded above
+		// Full directory scanning mode — walk tree for both ignore patterns and directives.
+		ignoreMatcher, suppCfg, loadErr := LoadArmisIgnore(absPath)
+		if loadErr != nil {
+			return nil, fmt.Errorf("failed to load ignore patterns: %w", loadErr)
+		}
+		suppressionConfig = suppCfg
+
 		var sizeErr error
 		size, sizeErr = calculateDirSize(absPath, s.includeTests, ignoreMatcher)
 		if sizeErr != nil {

--- a/internal/scan/repo/repo.go
+++ b/internal/scan/repo/repo.go
@@ -146,7 +146,7 @@ func (s *Scanner) Scan(ctx context.Context, path string) (*model.ScanResult, err
 		// Full directory scanning mode — walk tree for both ignore patterns and directives.
 		ignoreMatcher, suppCfg, loadErr := LoadArmisIgnore(absPath)
 		if loadErr != nil {
-			return nil, fmt.Errorf("failed to load ignore patterns: %w", loadErr)
+			return nil, fmt.Errorf("failed to load .armisignore: %w", loadErr)
 		}
 		suppressionConfig = suppCfg
 
@@ -532,6 +532,9 @@ func calculateDirSize(path string, includeTests bool, ignoreMatcher *IgnoreMatch
 			size, addErr = safeAddSize(size, info.Size())
 			if addErr != nil {
 				return fmt.Errorf("calculating directory size: %w", addErr)
+			}
+			if size > MaxRepoSize {
+				return fmt.Errorf("directory size exceeds maximum allowed size (%d bytes)", MaxRepoSize)
 			}
 		}
 		return nil


### PR DESCRIPTION
## Related Issue

* [PPSC-720](https://armis-security.atlassian.net/browse/PPSC-720)

## Type of Change

* [x] New feature (non-breaking change which adds functionality)

## Problem

The `.armisignore` parser from PPSC-705 can parse suppression directives (`severity:`, `category:`, `cwe:`, `rule:`) but no downstream code consumes them. Findings matching these directives still appear in output and trigger `--fail-on` exits, making the suppression system non-functional.

## Solution

Wire the suppression directive parser into the scan results pipeline as a client-side post-filter. After findings are fetched from Armis Cloud, they're matched against suppression directives and marked as suppressed. Suppressed findings are excluded from `--fail-on` evaluation, hidden from human/JUnit output (unless `--show-suppressed`), and annotated with SARIF 2.1.0 `suppressions[]` metadata for GitHub Code Scanning integration.

Key design choices:
- **Mutate-in-place**: findings are marked with `Suppressed=true` + `SuppressionInfo` rather than removed, so all formatters can decide how to present them
- **Priority order**: severity → category → CWE → rule (rule no-ops until `scanner_rule_id` lands per ADR-0007)
- **Category matching**: matches against `finding.Type` (deterministic, set by `DeriveFindingType`) rather than the freeform `FindingCategory` API field
- **Summary recompute**: after suppression, `Summary.Total` reflects only active findings while `Summary.Suppressed` tracks the suppressed count
- **CRITICAL warning**: stderr warning when CRITICAL findings are suppressed, as a safety guardrail

## Testing

### Automated Tests

* [x] Unit tests added/updated (30+ new test cases)
* [x] All tests passing locally

### Manual Testing

1. Built binary, created test repo with `.armisignore` containing `severity:LOW`, `severity:INFO`, `cwe:79`, `category:secrets`
2. Ran scan — confirmed 3 findings suppressed, 2 active in output
3. Verified `--show-suppressed` displays all findings with `[SUPPRESSED]` labels
4. Verified `--fail-on LOW` returns exit 0 when LOW findings are suppressed
5. Verified SARIF output has `suppressions` array with `kind: "inSource"` and justification
6. Verified JSON output has `suppressed: true` + `suppression_info` on suppressed findings
7. Verified JUnit excludes suppressed findings from test cases

## Reviewer Notes

- `rule:` directive matching is intentionally a no-op — blocked on `scanner_rule_id` from ADR-0007
- SARIF `suppressions[]` will cause GitHub Code Scanning to auto-dismiss matching findings — this is intended behavior
- The `LoadArmisIgnore` call was hoisted above the if/else branch so suppression config is loaded in both full-scan and targeted-file modes
- Also fixes `DeriveFindingType` to classify `LICENSE_COMPLIANCE_RISK` as `LICENSE` (D9 from plan review), enabling `category:license` to work end-to-end

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-720]: https://armis-security.atlassian.net/browse/PPSC-720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ