### PR TITLE
[PPSC-765] chore: release armis-cli v1.8.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.0] - 2026-05-11
+
+### Added
+
+- JWT authentication support for the GitHub Action with `client-id`, `client-secret`, and `region` inputs as the recommended auth method (#155)
+- Suppression directive parsing in `.armisignore` for finding-level filtering by rule, category, severity, and CWE (#157)
+
+---
+
 ## [1.7.0] - 2026-05-05
 
 ### Added
@@ -259,7 +268,8 @@ Manual entries for significant releases:
 
 -->
 
-[Unreleased]: https://github.com/ArmisSecurity/armis-cli/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.0...HEAD
+[1.8.0]: https://github.com/ArmisSecurity/armis-cli/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/ArmisSecurity/armis-cli/compare/v1.6.1...v1.7.0
 [1.4.0]: https://github.com/ArmisSecurity/armis-cli/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/ArmisSecurity/armis-cli/compare/v1.2.1...v1.3.0


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v1.8.0 release

## Changes in v1.8.0

- JWT authentication support for the GitHub Action with `client-id`, `client-secret`, and `region` inputs (#155)
- Suppression directive parsing in `.armisignore` for finding-level filtering by rule, category, severity, and CWE (#157)

## Checklist

- [x] CHANGELOG.md updated
- [x] Branch renamed to release convention
- [ ] PR merged
- [ ] Tag `v1.8.0` created (post-merge)
- [ ] GitHub Release published
- [ ] Homebrew formula updated
- [ ] Slack announcement posted

Jira: [PPSC-765](https://armis-security.atlassian.net/browse/PPSC-765)

[PPSC-765]: https://armis-security.atlassian.net/browse/PPSC-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ