### PR TITLE
[PPSC-718] feat(scan): add inline armis:ignore comment suppression

### DIFF
--- a/internal/model/finding.go
+++ b/internal/model/finding.go
@@ -33,11 +33,12 @@ const (
 	FindingTypeMisconfig FindingType = "MISCONFIG"
 )
 
-// SuppressionInfo describes why a finding was suppressed by .armisignore.
+// SuppressionInfo describes why a finding was suppressed.
 type SuppressionInfo struct {
-	Type   string `json:"type"`             // "severity", "category", "cwe", "rule"
+	Type   string `json:"type"`             // "severity", "category", "cwe", "rule", "inline"
 	Value  string `json:"value"`            // the directive value that matched
-	Reason string `json:"reason,omitempty"` // user-provided reason from " -- " delimiter
+	Reason string `json:"reason,omitempty"` // user-provided reason
+	Source string `json:"source,omitempty"` // "armisignore" or "inline"
 }
 
 // Finding represents a single security finding from a scan.

--- a/internal/output/human.go
+++ b/internal/output/human.go
@@ -354,7 +354,7 @@ func (f *HumanFormatter) FormatWithOptions(result *model.ScanResult, w io.Writer
 			}
 		}
 		if criticalSuppressed > 0 {
-			cli.PrintWarningf("%d CRITICAL %s suppressed by .armisignore",
+			cli.PrintWarningf("%d CRITICAL %s suppressed",
 				criticalSuppressed, pluralize("finding", criticalSuppressed))
 		}
 	}
@@ -694,6 +694,34 @@ func pluralize(word string, count int) string {
 	return word + "s"
 }
 
+// suppressionSummaryText builds a human-readable summary splitting counts by source.
+// Example: "3 suppressed by .armisignore, 2 by inline comments"
+func suppressionSummaryText(findings []model.Finding) string {
+	var armisignore, inline int
+	for _, f := range findings {
+		if !f.Suppressed {
+			continue
+		}
+		if f.SuppressionInfo != nil && f.SuppressionInfo.Source == suppressionSourceInline {
+			inline++
+		} else {
+			armisignore++
+		}
+	}
+
+	var parts []string
+	if armisignore > 0 {
+		parts = append(parts, fmt.Sprintf("%d suppressed by .armisignore", armisignore))
+	}
+	if inline > 0 {
+		parts = append(parts, fmt.Sprintf("%d suppressed by inline comments", inline))
+	}
+	if len(parts) == 0 {
+		return "0 suppressed"
+	}
+	return strings.Join(parts, ", ")
+}
+
 // renderBriefStatus renders a concise one-line summary of findings count by severity.
 // Example output: "Found 5 issues: 2 critical, 1 high, 2 medium"
 func renderBriefStatus(w io.Writer, result *model.ScanResult) error {
@@ -713,7 +741,7 @@ func renderBriefStatus(w io.Writer, result *model.ScanResult) error {
 	if total == 0 && suppressed > 0 {
 		successStyle := s.SuccessText
 		ew.write("%s %s\n", IconSuccess, successStyle.Render(
-			fmt.Sprintf("No active issues (%d suppressed by .armisignore)", suppressed)))
+			fmt.Sprintf("No active issues (%s)", suppressionSummaryText(result.Findings))))
 		return ew.err
 	}
 
@@ -736,10 +764,10 @@ func renderBriefStatus(w io.Writer, result *model.ScanResult) error {
 	}
 
 	if suppressed > 0 {
-		// Format: "N issues (M suppressed by .armisignore)  ·  X critical, Y high"
+		// Format: "N issues (M suppressed by .armisignore, K by inline comments)  ·  X critical, Y high"
 		ew.write("%s  %s  %s\n",
 			s.Bold.Render(fmt.Sprintf("%d %s", total, pluralize("issue", total)))+
-				s.MutedText.Render(fmt.Sprintf(" (%d suppressed by .armisignore)", suppressed)),
+				s.MutedText.Render(fmt.Sprintf(" (%s)", suppressionSummaryText(result.Findings))),
 			s.MutedText.Render("·"),
 			strings.Join(parts, s.MutedText.Render(", ")))
 	} else {
@@ -781,7 +809,7 @@ func renderSummaryDashboard(w io.Writer, result *model.ScanResult) error {
 
 	// Suppressed count if any
 	if result.Summary.Suppressed > 0 {
-		suppressed := s.MutedText.Render(fmt.Sprintf("(%d suppressed by .armisignore)", result.Summary.Suppressed))
+		suppressed := s.MutedText.Render(fmt.Sprintf("(%s)", suppressionSummaryText(result.Findings)))
 		content.WriteString(suppressed + "\n")
 	}
 
@@ -875,7 +903,11 @@ func renderFinding(w io.Writer, finding model.Finding, opts FormatOptions) {
 	// Show suppression label whenever a suppressed finding is rendered (callers
 	// are responsible for filtering suppressed findings when --show-suppressed is off).
 	if finding.Suppressed {
-		suppLabel := s.MutedText.Render("[SUPPRESSED]")
+		label := "[SUPPRESSED]"
+		if finding.SuppressionInfo != nil && finding.SuppressionInfo.Source == suppressionSourceInline {
+			label = "[SUPPRESSED by armis:ignore]"
+		}
+		suppLabel := s.MutedText.Render(label)
 		var reason string
 		if finding.SuppressionInfo != nil {
 			reason = fmt.Sprintf("%s:%s", finding.SuppressionInfo.Type, finding.SuppressionInfo.Value)

--- a/internal/output/human_test.go
+++ b/internal/output/human_test.go
@@ -1023,6 +1023,13 @@ func TestRenderBriefStatus_WithSuppressed(t *testing.T) {
 			BySeverity: map[model.Severity]int{model.SeverityHigh: 2, model.SeverityMedium: 1},
 			Suppressed: 2,
 		},
+		Findings: []model.Finding{
+			{ID: "a", Severity: model.SeverityHigh},
+			{ID: "b", Severity: model.SeverityHigh},
+			{ID: "c", Severity: model.SeverityMedium},
+			{ID: "d", Suppressed: true, SuppressionInfo: &model.SuppressionInfo{Source: "armisignore", Type: "severity", Value: "LOW"}},
+			{ID: "e", Suppressed: true, SuppressionInfo: &model.SuppressionInfo{Source: "armisignore", Type: "severity", Value: "LOW"}},
+		},
 	}
 
 	var buf bytes.Buffer
@@ -1071,6 +1078,16 @@ func TestRenderSummaryDashboard_ShowsSuppressionLine(t *testing.T) {
 			Total:      5,
 			BySeverity: map[model.Severity]int{model.SeverityHigh: 5},
 			Suppressed: 3,
+		},
+		Findings: []model.Finding{
+			{ID: "1", Severity: model.SeverityHigh},
+			{ID: "2", Severity: model.SeverityHigh},
+			{ID: "3", Severity: model.SeverityHigh},
+			{ID: "4", Severity: model.SeverityHigh},
+			{ID: "5", Severity: model.SeverityHigh},
+			{ID: "s1", Suppressed: true, SuppressionInfo: &model.SuppressionInfo{Source: "armisignore", Type: "severity", Value: "LOW"}},
+			{ID: "s2", Suppressed: true, SuppressionInfo: &model.SuppressionInfo{Source: "armisignore", Type: "severity", Value: "LOW"}},
+			{ID: "s3", Suppressed: true, SuppressionInfo: &model.SuppressionInfo{Source: "armisignore", Type: "severity", Value: "LOW"}},
 		},
 	}
 
@@ -1122,7 +1139,7 @@ func TestHumanFormatter_CriticalSuppressionWarning(t *testing.T) {
 	os.Stderr = oldStderr
 
 	stderrOutput := stderrBuf.String()
-	if !strings.Contains(stderrOutput, "1 CRITICAL finding suppressed by .armisignore") {
+	if !strings.Contains(stderrOutput, "1 CRITICAL finding suppressed") {
 		t.Errorf("expected CRITICAL suppression warning on stderr, got:\n%s", stderrOutput)
 	}
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ArmisSecurity/armis-cli/internal/model"
 )
 
+const suppressionSourceInline = "inline"
+
 // Package-level variables for testability
 var (
 	stdoutSyncer           = func() error { return os.Stdout.Sync() }

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -400,12 +400,19 @@ func convertToSarifResults(findings []model.Finding, ruleIndexMap map[string]int
 		}
 
 		if finding.Suppressed && finding.SuppressionInfo != nil {
-			justification := fmt.Sprintf(".armisignore %s:%s", finding.SuppressionInfo.Type, finding.SuppressionInfo.Value)
+			kind := "external"
+			var justification string
+			if finding.SuppressionInfo.Source == suppressionSourceInline {
+				kind = "inSource"
+				justification = fmt.Sprintf("armis:ignore %s:%s", finding.SuppressionInfo.Type, finding.SuppressionInfo.Value)
+			} else {
+				justification = fmt.Sprintf(".armisignore %s:%s", finding.SuppressionInfo.Type, finding.SuppressionInfo.Value)
+			}
 			if finding.SuppressionInfo.Reason != "" {
 				justification += " -- " + finding.SuppressionInfo.Reason
 			}
 			result.Suppressions = []sarifSuppression{{
-				Kind:          "inSource",
+				Kind:          kind,
 				Justification: justification,
 			}}
 		}

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -1466,6 +1466,7 @@ func TestSARIF_SuppressedFindingHasSuppressionsArray(t *testing.T) {
 					Type:   "severity",
 					Value:  "LOW",
 					Reason: "accepted risk",
+					Source: "armisignore",
 				},
 			},
 		},
@@ -1489,10 +1490,53 @@ func TestSARIF_SuppressedFindingHasSuppressionsArray(t *testing.T) {
 	if len(res.Suppressions) != 1 {
 		t.Fatalf("expected 1 suppression, got %d", len(res.Suppressions))
 	}
+	if res.Suppressions[0].Kind != "external" {
+		t.Errorf("suppression kind = %q, want %q", res.Suppressions[0].Kind, "external")
+	}
+	if res.Suppressions[0].Justification != ".armisignore severity:LOW -- accepted risk" {
+		t.Errorf("justification = %q", res.Suppressions[0].Justification)
+	}
+}
+
+func TestSARIF_InlineSuppressedFindingUsesInSourceKind(t *testing.T) {
+	formatter := &SARIFFormatter{}
+	result := &model.ScanResult{
+		ScanID: "test-inline-supp",
+		Findings: []model.Finding{
+			{
+				ID:         "inline-1",
+				Severity:   model.SeverityHigh,
+				Title:      "Inline suppressed",
+				File:       "main.py",
+				Suppressed: true,
+				SuppressionInfo: &model.SuppressionInfo{
+					Type:   "cwe",
+					Value:  "798",
+					Reason: "test token",
+					Source: "inline",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(result, &buf); err != nil {
+		t.Fatalf("Format failed: %v", err)
+	}
+
+	var report sarifReport
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("JSON parse failed: %v", err)
+	}
+
+	res := report.Runs[0].Results[0]
+	if len(res.Suppressions) != 1 {
+		t.Fatalf("expected 1 suppression, got %d", len(res.Suppressions))
+	}
 	if res.Suppressions[0].Kind != "inSource" {
 		t.Errorf("suppression kind = %q, want %q", res.Suppressions[0].Kind, "inSource")
 	}
-	if res.Suppressions[0].Justification != ".armisignore severity:LOW -- accepted risk" {
+	if res.Suppressions[0].Justification != "armis:ignore cwe:798 -- test token" {
 		t.Errorf("justification = %q", res.Suppressions[0].Justification)
 	}
 }

--- a/internal/scan/repo/inline.go
+++ b/internal/scan/repo/inline.go
@@ -33,20 +33,21 @@ var commentPrefixes = map[string][]string{
 	".yaml": {"#"}, ".yml": {"#"}, ".tf": {"#"}, ".toml": {"#"}, ".r": {"#"},
 	".dockerfile": {"#"},
 
-	".js": {"//"}, ".ts": {"//"}, ".jsx": {"//"}, ".tsx": {"//"}, ".java": {"//"},
-	".c": {"//"}, ".h": {"//"}, ".cpp": {"//"}, ".hpp": {"//"}, ".cs": {"//"},
-	".go": {"//"}, ".rs": {"//"}, ".swift": {"//"}, ".kt": {"//"}, ".scala": {"//"},
-	".dart": {"//"}, ".groovy": {"//"},
+	".js": {"//", "/*"}, ".ts": {"//", "/*"}, ".jsx": {"//", "/*"}, ".tsx": {"//", "/*"},
+	".java": {"//", "/*"}, ".c": {"//", "/*"}, ".h": {"//", "/*"},
+	".cpp": {"//", "/*"}, ".hpp": {"//", "/*"}, ".cs": {"//", "/*"},
+	".go": {"//"}, ".rs": {"//"}, ".swift": {"//", "/*"}, ".kt": {"//", "/*"},
+	".scala": {"//", "/*"}, ".dart": {"//", "/*"}, ".groovy": {"//", "/*"},
 
-	".php": {"//", "#"},
+	".php": {"//", "#", "/*"},
 
-	".sql": {"--"}, ".lua": {"--"}, ".hs": {"--"},
+	".sql": {"--", "/*"}, ".lua": {"--"}, ".hs": {"--"},
 
 	".ini": {";"}, ".cfg": {";"},
 
 	".html": {"<!--"}, ".xml": {"<!--"}, ".svg": {"<!--"},
 
-	".css": {"/*"}, ".scss": {"/*"}, ".less": {"/*"},
+	".css": {"/*"}, ".scss": {"/*", "//"}, ".less": {"/*", "//"},
 }
 
 var inlineDirectivePrefix = regexp.MustCompile(`(?i)armis:ignore\b`)
@@ -80,6 +81,7 @@ func ApplyInlineSuppression(findings []model.Finding, repoRoot string) int {
 		defer f.Close() //nolint:errcheck
 
 		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		for scanner.Scan() {
 			entry.lines = append(entry.lines, scanner.Text())
 		}
@@ -183,10 +185,12 @@ func parseInlineComment(line string, prefixes []string) *InlineDirective {
 }
 
 // findCommentStart finds the first occurrence of prefix that is not inside a
-// quoted string. Returns -1 if not found or only found inside quotes.
+// quoted string (single, double, or backtick). Returns -1 if not found or
+// only found inside quotes.
 func findCommentStart(line, prefix string) int {
 	inSingle := false
 	inDouble := false
+	inBacktick := false
 	escaped := false
 
 	for i := 0; i <= len(line)-len(prefix); i++ {
@@ -196,20 +200,24 @@ func findCommentStart(line, prefix string) int {
 			escaped = false
 			continue
 		}
-		if ch == '\\' {
+		if ch == '\\' && !inBacktick {
 			escaped = true
 			continue
 		}
-		if ch == '\'' && !inDouble {
+		if ch == '\'' && !inDouble && !inBacktick {
 			inSingle = !inSingle
 			continue
 		}
-		if ch == '"' && !inSingle {
+		if ch == '"' && !inSingle && !inBacktick {
 			inDouble = !inDouble
 			continue
 		}
+		if ch == '`' && !inSingle && !inDouble {
+			inBacktick = !inBacktick
+			continue
+		}
 
-		if !inSingle && !inDouble && line[i:i+len(prefix)] == prefix {
+		if !inSingle && !inDouble && !inBacktick && line[i:i+len(prefix)] == prefix {
 			return i
 		}
 	}
@@ -218,6 +226,7 @@ func findCommentStart(line, prefix string) int {
 
 // parseDirectiveParams extracts key:value pairs from the text after "armis:ignore".
 // Parameters may appear in any order. "reason:" captures the rest of the line.
+// Returns nil if params are provided but none are recognized (likely a typo).
 func parseDirectiveParams(text string) *InlineDirective {
 	d := &InlineDirective{}
 
@@ -231,46 +240,45 @@ func parseDirectiveParams(text string) *InlineDirective {
 		return d
 	}
 
-	// Parse key:value pairs; "reason:" is special - it consumes the rest
-	for remainder != "" {
-		remainder = strings.TrimSpace(remainder)
-		if remainder == "" {
-			break
-		}
+	// Handle "reason:" as rest-of-line before field splitting
+	lower := strings.ToLower(remainder)
+	if idx := strings.Index(lower, "reason:"); idx != -1 {
+		d.Reason = strings.TrimSpace(remainder[idx+7:])
+		remainder = strings.TrimSpace(remainder[:idx])
+	}
 
-		// Check for reason: which consumes everything after it
-		lower := strings.ToLower(remainder)
-		if strings.HasPrefix(lower, "reason:") {
-			d.Reason = strings.TrimSpace(remainder[7:])
-			break
-		}
+	hasParams := false
+	recognized := false
 
-		// Try to match key:value
-		parts := strings.SplitN(remainder, " ", 2)
-		token := parts[0]
-		if len(parts) > 1 {
-			remainder = parts[1]
-		} else {
-			remainder = ""
-		}
-
+	tokens := strings.Fields(remainder)
+	for _, token := range tokens {
 		colonIdx := strings.Index(token, ":")
 		if colonIdx == -1 {
 			continue
 		}
+		hasParams = true
 		key := strings.ToLower(token[:colonIdx])
 		value := token[colonIdx+1:]
 
 		switch key {
 		case string(DirectiveCategory):
 			d.Category = strings.ToLower(value)
+			recognized = true
 		case string(DirectiveRule):
 			d.Rule = value
+			recognized = true
 		case string(DirectiveCWE):
 			d.CWE = value
+			recognized = true
 		case string(DirectiveSeverity):
 			d.Severity = strings.ToUpper(value)
+			recognized = true
 		}
+	}
+
+	// If params were provided but none recognized, treat as invalid directive
+	if hasParams && !recognized && d.Reason == "" {
+		return nil
 	}
 
 	return d

--- a/internal/scan/repo/inline.go
+++ b/internal/scan/repo/inline.go
@@ -1,0 +1,345 @@
+package repo
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/ArmisSecurity/armis-cli/internal/model"
+	"github.com/ArmisSecurity/armis-cli/internal/util"
+)
+
+const (
+	maxInlineFileSize   = 10 * 1024 * 1024 // 10MB
+	suppressionInline   = "inline"
+	suppressionTypeCWE  = "cwe"
+	suppressionTypeRule = "rule"
+)
+
+// InlineDirective represents a parsed armis:ignore comment.
+type InlineDirective struct {
+	Category string
+	Rule     string
+	CWE      string
+	Severity string
+	Reason   string
+}
+
+// commentPrefixes maps file extensions to their line comment prefixes.
+var commentPrefixes = map[string][]string{
+	".py": {"#"}, ".rb": {"#"}, ".sh": {"#"}, ".bash": {"#"}, ".zsh": {"#"},
+	".yaml": {"#"}, ".yml": {"#"}, ".tf": {"#"}, ".toml": {"#"}, ".r": {"#"},
+	".dockerfile": {"#"},
+
+	".js": {"//"}, ".ts": {"//"}, ".jsx": {"//"}, ".tsx": {"//"}, ".java": {"//"},
+	".c": {"//"}, ".h": {"//"}, ".cpp": {"//"}, ".hpp": {"//"}, ".cs": {"//"},
+	".go": {"//"}, ".rs": {"//"}, ".swift": {"//"}, ".kt": {"//"}, ".scala": {"//"},
+	".dart": {"//"}, ".groovy": {"//"},
+
+	".php": {"//", "#"},
+
+	".sql": {"--"}, ".lua": {"--"}, ".hs": {"--"},
+
+	".ini": {";"}, ".cfg": {";"},
+
+	".html": {"<!--"}, ".xml": {"<!--"}, ".svg": {"<!--"},
+
+	".css": {"/*"}, ".scss": {"/*"}, ".less": {"/*"},
+}
+
+var inlineDirectivePrefix = regexp.MustCompile(`(?i)armis:ignore\b`)
+
+// ApplyInlineSuppression scans source files for armis:ignore comments
+// and marks matching findings as suppressed. Returns count of findings suppressed.
+func ApplyInlineSuppression(findings []model.Finding, repoRoot string) int {
+	type fileLines struct {
+		lines []string
+		valid bool
+	}
+	cache := make(map[string]*fileLines)
+
+	loadFile := func(filePath string) *fileLines {
+		if cached, ok := cache[filePath]; ok {
+			return cached
+		}
+
+		entry := &fileLines{}
+		cache[filePath] = entry
+
+		info, err := os.Stat(filePath)
+		if err != nil || info.IsDir() || info.Size() > maxInlineFileSize {
+			return entry
+		}
+
+		f, err := os.Open(filePath) // #nosec G304 - path validated via SafeJoinPath
+		if err != nil {
+			return entry
+		}
+		defer f.Close() //nolint:errcheck
+
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			entry.lines = append(entry.lines, scanner.Text())
+		}
+		if scanner.Err() == nil {
+			entry.valid = true
+		}
+		return entry
+	}
+
+	suppressed := 0
+	for i := range findings {
+		if findings[i].Suppressed {
+			continue
+		}
+		if findings[i].StartLine == 0 || findings[i].File == "" {
+			continue
+		}
+
+		absPath, err := util.SafeJoinPath(repoRoot, findings[i].File)
+		if err != nil {
+			continue
+		}
+
+		fl := loadFile(absPath)
+		if !fl.valid {
+			continue
+		}
+
+		lineIdx := findings[i].StartLine - 1
+		if lineIdx < 0 || lineIdx >= len(fl.lines) {
+			continue
+		}
+
+		ext := strings.ToLower(filepath.Ext(findings[i].File))
+		if ext == "" {
+			base := strings.ToLower(filepath.Base(findings[i].File))
+			if base == "dockerfile" {
+				ext = ".dockerfile"
+			}
+		}
+
+		prefixes, ok := commentPrefixes[ext]
+		if !ok {
+			continue
+		}
+
+		// Check the finding line itself and the line above
+		linesToCheck := []string{fl.lines[lineIdx]}
+		if lineIdx > 0 {
+			linesToCheck = append(linesToCheck, fl.lines[lineIdx-1])
+		}
+
+		var directive *InlineDirective
+		for _, line := range linesToCheck {
+			if d := parseInlineComment(line, prefixes); d != nil {
+				directive = d
+				break
+			}
+		}
+
+		if directive == nil {
+			continue
+		}
+
+		if matchesInlineDirective(findings[i], directive) { //nolint:gosec // G602 false positive: i is bounded by range
+			findings[i].Suppressed = true                                       //nolint:gosec // G602 false positive: i is bounded by range
+			findings[i].SuppressionInfo = buildInlineSuppressionInfo(directive) //nolint:gosec // G602 false positive: i is bounded by range
+			suppressed++
+		}
+	}
+
+	return suppressed
+}
+
+// parseInlineComment checks if a line contains a valid armis:ignore comment
+// after a recognized comment prefix that is not inside a string literal.
+func parseInlineComment(line string, prefixes []string) *InlineDirective {
+	trimmed := strings.TrimSpace(line)
+
+	for _, prefix := range prefixes {
+		idx := findCommentStart(trimmed, prefix)
+		if idx == -1 {
+			continue
+		}
+
+		after := trimmed[idx+len(prefix):]
+		after = strings.TrimSpace(after)
+		// Strip trailing comment closers for block comment syntaxes
+		after = strings.TrimSuffix(after, "-->")
+		after = strings.TrimSuffix(after, "*/")
+		after = strings.TrimSpace(after)
+
+		if !inlineDirectivePrefix.MatchString(after) {
+			continue
+		}
+
+		d := parseDirectiveParams(after)
+		return d
+	}
+	return nil
+}
+
+// findCommentStart finds the first occurrence of prefix that is not inside a
+// quoted string. Returns -1 if not found or only found inside quotes.
+func findCommentStart(line, prefix string) int {
+	inSingle := false
+	inDouble := false
+	escaped := false
+
+	for i := 0; i <= len(line)-len(prefix); i++ {
+		ch := line[i]
+
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+		if ch == '\'' && !inDouble {
+			inSingle = !inSingle
+			continue
+		}
+		if ch == '"' && !inSingle {
+			inDouble = !inDouble
+			continue
+		}
+
+		if !inSingle && !inDouble && line[i:i+len(prefix)] == prefix {
+			return i
+		}
+	}
+	return -1
+}
+
+// parseDirectiveParams extracts key:value pairs from the text after "armis:ignore".
+// Parameters may appear in any order. "reason:" captures the rest of the line.
+func parseDirectiveParams(text string) *InlineDirective {
+	d := &InlineDirective{}
+
+	// Strip the "armis:ignore" prefix
+	loc := inlineDirectivePrefix.FindStringIndex(text)
+	if loc == nil {
+		return d
+	}
+	remainder := strings.TrimSpace(text[loc[1]:])
+	if remainder == "" {
+		return d
+	}
+
+	// Parse key:value pairs; "reason:" is special - it consumes the rest
+	for remainder != "" {
+		remainder = strings.TrimSpace(remainder)
+		if remainder == "" {
+			break
+		}
+
+		// Check for reason: which consumes everything after it
+		lower := strings.ToLower(remainder)
+		if strings.HasPrefix(lower, "reason:") {
+			d.Reason = strings.TrimSpace(remainder[7:])
+			break
+		}
+
+		// Try to match key:value
+		parts := strings.SplitN(remainder, " ", 2)
+		token := parts[0]
+		if len(parts) > 1 {
+			remainder = parts[1]
+		} else {
+			remainder = ""
+		}
+
+		colonIdx := strings.Index(token, ":")
+		if colonIdx == -1 {
+			continue
+		}
+		key := strings.ToLower(token[:colonIdx])
+		value := token[colonIdx+1:]
+
+		switch key {
+		case string(DirectiveCategory):
+			d.Category = strings.ToLower(value)
+		case string(DirectiveRule):
+			d.Rule = value
+		case string(DirectiveCWE):
+			d.CWE = value
+		case string(DirectiveSeverity):
+			d.Severity = strings.ToUpper(value)
+		}
+	}
+
+	return d
+}
+
+// matchesInlineDirective applies AND logic: all non-empty scope params must match.
+func matchesInlineDirective(finding model.Finding, d *InlineDirective) bool {
+	if d.Category != "" {
+		expected, ok := categoryToFindingType[d.Category]
+		if !ok || finding.Type != expected {
+			return false
+		}
+	}
+
+	if d.Rule != "" {
+		if !strings.EqualFold(finding.ID, d.Rule) {
+			return false
+		}
+	}
+
+	if d.CWE != "" {
+		if !cweMatches(finding.CWEs, d.CWE) {
+			return false
+		}
+	}
+
+	if d.Severity != "" {
+		if !strings.EqualFold(string(finding.Severity), d.Severity) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func buildInlineSuppressionInfo(d *InlineDirective) *model.SuppressionInfo {
+	info := &model.SuppressionInfo{
+		Source: suppressionInline,
+		Reason: d.Reason,
+	}
+
+	switch {
+	case d.CWE != "":
+		info.Type = suppressionTypeCWE
+		info.Value = d.CWE
+	case d.Rule != "":
+		info.Type = suppressionTypeRule
+		info.Value = d.Rule
+	case d.Category != "":
+		info.Type = string(DirectiveCategory)
+		info.Value = d.Category
+	case d.Severity != "":
+		info.Type = string(DirectiveSeverity)
+		info.Value = d.Severity
+	default:
+		info.Type = suppressionInline
+		info.Value = "armis:ignore"
+	}
+
+	return info
+}
+
+// countSuppressed counts the total number of suppressed findings.
+func countSuppressed(findings []model.Finding) int {
+	count := 0
+	for _, f := range findings {
+		if f.Suppressed {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/scan/repo/inline_test.go
+++ b/internal/scan/repo/inline_test.go
@@ -167,6 +167,48 @@ func TestParseInlineComment(t *testing.T) {
 			want:     &InlineDirective{Rule: "CKV_AWS_18", Severity: "HIGH", CWE: "798"},
 		},
 		{
+			name:     "prefix inside backtick string rejected",
+			line:     "x := `// armis:ignore`",
+			prefixes: []string{"//"},
+			want:     nil,
+		},
+		{
+			name:     "real comment after backtick string accepted",
+			line:     "x := `value` // armis:ignore cwe:79",
+			prefixes: []string{"//"},
+			want:     &InlineDirective{CWE: "79"},
+		},
+		{
+			name:     "tabs between params handled",
+			line:     "# armis:ignore\tcategory:sast\tcwe:79",
+			prefixes: []string{"#"},
+			want:     &InlineDirective{Category: "sast", CWE: "79"},
+		},
+		{
+			name:     "multiple spaces between params handled",
+			line:     "# armis:ignore  category:sast   cwe:79",
+			prefixes: []string{"#"},
+			want:     &InlineDirective{Category: "sast", CWE: "79"},
+		},
+		{
+			name:     "unknown key only - returns nil",
+			line:     "# armis:ignore catgory:sast",
+			prefixes: []string{"#"},
+			want:     nil,
+		},
+		{
+			name:     "unknown key with valid key - keeps valid",
+			line:     "# armis:ignore catgory:sast cwe:79",
+			prefixes: []string{"#"},
+			want:     &InlineDirective{CWE: "79"},
+		},
+		{
+			name:     "block comment in JS",
+			line:     "/* armis:ignore cwe:79 */",
+			prefixes: []string{"//", "/*"},
+			want:     &InlineDirective{CWE: "79"},
+		},
+		{
 			name:     "leading whitespace",
 			line:     "    // armis:ignore severity:CRITICAL",
 			prefixes: []string{"//"},

--- a/internal/scan/repo/inline_test.go
+++ b/internal/scan/repo/inline_test.go
@@ -1,0 +1,604 @@
+package repo
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ArmisSecurity/armis-cli/internal/model"
+)
+
+func TestParseInlineComment(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		prefixes []string
+		want     *InlineDirective
+	}{
+		{
+			name:     "bare armis:ignore with hash comment",
+			line:     "# armis:ignore",
+			prefixes: []string{"#"},
+			want:     &InlineDirective{},
+		},
+		{
+			name:     "bare armis:ignore with slash comment",
+			line:     "// armis:ignore",
+			prefixes: []string{"//"},
+			want:     &InlineDirective{},
+		},
+		{
+			name:     "bare armis:ignore with double-dash comment",
+			line:     "-- armis:ignore",
+			prefixes: []string{"--"},
+			want:     &InlineDirective{},
+		},
+		{
+			name:     "bare armis:ignore with HTML comment",
+			line:     "<!-- armis:ignore -->",
+			prefixes: []string{"<!--"},
+			want:     &InlineDirective{},
+		},
+		{
+			name:     "bare armis:ignore with CSS comment",
+			line:     "/* armis:ignore */",
+			prefixes: []string{"/*"},
+			want:     &InlineDirective{},
+		},
+		{
+			name:     "bare armis:ignore with semicolon comment",
+			line:     "; armis:ignore",
+			prefixes: []string{";"},
+			want:     &InlineDirective{},
+		},
+		{
+			name:     "category scope",
+			line:     "# armis:ignore category:sast",
+			prefixes: []string{"#"},
+			want:     &InlineDirective{Category: "sast"},
+		},
+		{
+			name:     "rule scope",
+			line:     "// armis:ignore rule:CKV_AWS_18",
+			prefixes: []string{"//"},
+			want:     &InlineDirective{Rule: "CKV_AWS_18"},
+		},
+		{
+			name:     "cwe scope",
+			line:     "# armis:ignore cwe:798",
+			prefixes: []string{"#"},
+			want:     &InlineDirective{CWE: "798"},
+		},
+		{
+			name:     "severity scope",
+			line:     "// armis:ignore severity:HIGH",
+			prefixes: []string{"//"},
+			want:     &InlineDirective{Severity: "HIGH"},
+		},
+		{
+			name:     "multiple params",
+			line:     "# armis:ignore category:sast cwe:79",
+			prefixes: []string{"#"},
+			want:     &InlineDirective{Category: "sast", CWE: "79"},
+		},
+		{
+			name:     "with reason",
+			line:     "// armis:ignore cwe:798 reason: this is a test token",
+			prefixes: []string{"//"},
+			want:     &InlineDirective{CWE: "798", Reason: "this is a test token"},
+		},
+		{
+			name:     "case insensitive ARMIS:IGNORE",
+			line:     "# ARMIS:IGNORE severity:low",
+			prefixes: []string{"#"},
+			want:     &InlineDirective{Severity: "LOW"},
+		},
+		{
+			name:     "inline after code",
+			line:     "password = 'test' # armis:ignore category:secrets",
+			prefixes: []string{"#"},
+			want:     &InlineDirective{Category: "secrets"},
+		},
+		{
+			name:     "no comment prefix - not a directive",
+			line:     "armis:ignore",
+			prefixes: []string{"#"},
+			want:     nil,
+		},
+		{
+			name:     "wrong comment prefix",
+			line:     "// armis:ignore",
+			prefixes: []string{"#"},
+			want:     nil,
+		},
+		{
+			name:     "php allows both hash and slash",
+			line:     "# armis:ignore",
+			prefixes: []string{"//", "#"},
+			want:     &InlineDirective{},
+		},
+		{
+			name:     "in string literal no prefix match",
+			line:     `msg := "armis:ignore this"`,
+			prefixes: []string{"//"},
+			want:     nil,
+		},
+		{ //nolint:gosec // G101 false positive: test fixture URL, not a credential
+			name:     "prefix inside string literal URL rejected",
+			line:     `url := "http://armis:ignore@example.com"`,
+			prefixes: []string{"//"},
+			want:     nil,
+		},
+		{
+			name:     "prefix inside double-quoted string rejected",
+			line:     `x := "// armis:ignore"`,
+			prefixes: []string{"//"},
+			want:     nil,
+		},
+		{
+			name:     "prefix inside single-quoted string rejected",
+			line:     `x := '// armis:ignore'`,
+			prefixes: []string{"//"},
+			want:     nil,
+		},
+		{
+			name:     "real comment after string literal accepted",
+			line:     `x := "value" // armis:ignore cwe:798`,
+			prefixes: []string{"//"},
+			want:     &InlineDirective{CWE: "798"},
+		},
+		{
+			name:     "params in any order - severity then category",
+			line:     "# armis:ignore severity:HIGH category:sast",
+			prefixes: []string{"#"},
+			want:     &InlineDirective{Severity: "HIGH", Category: "sast"},
+		},
+		{
+			name:     "params in any order - cwe then category",
+			line:     "# armis:ignore cwe:79 category:sast",
+			prefixes: []string{"#"},
+			want:     &InlineDirective{CWE: "79", Category: "sast"},
+		},
+		{
+			name:     "params in any order - rule then severity then cwe",
+			line:     "// armis:ignore rule:CKV_AWS_18 severity:HIGH cwe:798",
+			prefixes: []string{"//"},
+			want:     &InlineDirective{Rule: "CKV_AWS_18", Severity: "HIGH", CWE: "798"},
+		},
+		{
+			name:     "leading whitespace",
+			line:     "    // armis:ignore severity:CRITICAL",
+			prefixes: []string{"//"},
+			want:     &InlineDirective{Severity: "CRITICAL"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseInlineComment(tt.line, tt.prefixes)
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected directive, got nil")
+			}
+			if got.Category != tt.want.Category {
+				t.Errorf("Category = %q, want %q", got.Category, tt.want.Category)
+			}
+			if got.Rule != tt.want.Rule {
+				t.Errorf("Rule = %q, want %q", got.Rule, tt.want.Rule)
+			}
+			if got.CWE != tt.want.CWE {
+				t.Errorf("CWE = %q, want %q", got.CWE, tt.want.CWE)
+			}
+			if got.Severity != tt.want.Severity {
+				t.Errorf("Severity = %q, want %q", got.Severity, tt.want.Severity)
+			}
+			if got.Reason != tt.want.Reason {
+				t.Errorf("Reason = %q, want %q", got.Reason, tt.want.Reason)
+			}
+		})
+	}
+}
+
+func TestMatchesInlineDirective(t *testing.T) {
+	tests := []struct {
+		name      string
+		finding   model.Finding
+		directive *InlineDirective
+		want      bool
+	}{
+		{
+			name:      "bare directive matches any finding",
+			finding:   model.Finding{Type: model.FindingTypeSecret, Severity: model.SeverityHigh},
+			directive: &InlineDirective{},
+			want:      true,
+		},
+		{
+			name:      "category matches",
+			finding:   model.Finding{Type: model.FindingTypeSecret},
+			directive: &InlineDirective{Category: "secrets"},
+			want:      true,
+		},
+		{
+			name:      "category does not match",
+			finding:   model.Finding{Type: model.FindingTypeVulnerability},
+			directive: &InlineDirective{Category: "secrets"},
+			want:      false,
+		},
+		{
+			name:      "cwe matches",
+			finding:   model.Finding{CWEs: []string{"CWE-79: Cross-site Scripting"}},
+			directive: &InlineDirective{CWE: "79"},
+			want:      true,
+		},
+		{
+			name:      "cwe does not match",
+			finding:   model.Finding{CWEs: []string{"CWE-89"}},
+			directive: &InlineDirective{CWE: "79"},
+			want:      false,
+		},
+		{
+			name:      "severity matches",
+			finding:   model.Finding{Severity: model.SeverityHigh},
+			directive: &InlineDirective{Severity: "HIGH"},
+			want:      true,
+		},
+		{
+			name:      "severity does not match",
+			finding:   model.Finding{Severity: model.SeverityLow},
+			directive: &InlineDirective{Severity: "HIGH"},
+			want:      false,
+		},
+		{
+			name:      "AND logic: both category and cwe must match - both match",
+			finding:   model.Finding{Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-79"}},
+			directive: &InlineDirective{Category: "sast", CWE: "79"},
+			want:      true,
+		},
+		{
+			name:      "AND logic: category matches but cwe does not",
+			finding:   model.Finding{Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-89"}},
+			directive: &InlineDirective{Category: "sast", CWE: "79"},
+			want:      false,
+		},
+		{
+			name:      "AND logic: cwe matches but category does not",
+			finding:   model.Finding{Type: model.FindingTypeSecret, CWEs: []string{"CWE-79"}},
+			directive: &InlineDirective{Category: "sast", CWE: "79"},
+			want:      false,
+		},
+		{
+			name:      "rule matches finding ID",
+			finding:   model.Finding{ID: "CKV_AWS_18"},
+			directive: &InlineDirective{Rule: "CKV_AWS_18"},
+			want:      true,
+		},
+		{
+			name:      "rule does not match",
+			finding:   model.Finding{ID: "CKV_AWS_20"},
+			directive: &InlineDirective{Rule: "CKV_AWS_18"},
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchesInlineDirective(tt.finding, tt.directive)
+			if got != tt.want {
+				t.Errorf("matchesInlineDirective() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyInlineSuppression(t *testing.T) {
+	t.Run("suppresses finding on same line", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "main.py", "import os\npassword = 'test' # armis:ignore\nprint(password)\n")
+
+		findings := []model.Finding{
+			{File: "main.py", StartLine: 2, Type: model.FindingTypeSecret, Severity: model.SeverityHigh},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 1 {
+			t.Fatalf("expected 1 suppressed, got %d", count)
+		}
+		if !findings[0].Suppressed {
+			t.Error("finding should be suppressed")
+		}
+		if findings[0].SuppressionInfo.Source != suppressionInline { //nolint:goconst // test assertion clarity
+			t.Errorf("source = %q, want inline", findings[0].SuppressionInfo.Source)
+		}
+	})
+
+	t.Run("suppresses finding on line below comment", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "main.go", "package main\n// armis:ignore\nvar secret = \"abc\"\n")
+
+		findings := []model.Finding{
+			{File: "main.go", StartLine: 3, Type: model.FindingTypeSecret, Severity: model.SeverityHigh},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 1 {
+			t.Fatalf("expected 1 suppressed, got %d", count)
+		}
+	})
+
+	t.Run("skips findings already suppressed by armisignore", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "main.py", "# armis:ignore\npassword = 'x'\n")
+
+		findings := []model.Finding{
+			{
+				File: "main.py", StartLine: 2, Type: model.FindingTypeSecret, Severity: model.SeverityHigh,
+				Suppressed:      true,
+				SuppressionInfo: &model.SuppressionInfo{Type: string(DirectiveSeverity), Value: "HIGH", Source: "armisignore"},
+			},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 0 {
+			t.Fatalf("expected 0 suppressed (already suppressed), got %d", count)
+		}
+	})
+
+	t.Run("skips findings with StartLine 0", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "go.mod", "module test\n# armis:ignore\n")
+
+		findings := []model.Finding{
+			{File: "go.mod", StartLine: 0, Type: model.FindingTypeSCA},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 0 {
+			t.Fatalf("expected 0, got %d", count)
+		}
+	})
+
+	t.Run("skips missing files", func(t *testing.T) {
+		dir := t.TempDir()
+
+		findings := []model.Finding{
+			{File: "missing.py", StartLine: 1, Type: model.FindingTypeSecret},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 0 {
+			t.Fatalf("expected 0, got %d", count)
+		}
+		if findings[0].Suppressed {
+			t.Error("finding should not be suppressed for missing file")
+		}
+	})
+
+	t.Run("skips files larger than 10MB", func(t *testing.T) {
+		dir := t.TempDir()
+		// Create a file just over the limit
+		large := strings.Repeat("x", maxInlineFileSize+1)
+		writeFile(t, dir, "big.py", large)
+
+		findings := []model.Finding{
+			{File: "big.py", StartLine: 1, Type: model.FindingTypeSecret},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 0 {
+			t.Fatalf("expected 0 for large file, got %d", count)
+		}
+	})
+
+	t.Run("path traversal blocked", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "safe.py", "# armis:ignore\npassword='x'\n")
+
+		findings := []model.Finding{
+			{File: "../../../etc/passwd", StartLine: 1, Type: model.FindingTypeSecret},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 0 {
+			t.Fatalf("expected 0 for traversal path, got %d", count)
+		}
+	})
+
+	t.Run("line beyond file length", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "short.py", "# just one line\n")
+
+		findings := []model.Finding{
+			{File: "short.py", StartLine: 99, Type: model.FindingTypeSecret},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 0 {
+			t.Fatalf("expected 0, got %d", count)
+		}
+	})
+
+	t.Run("CRLF line endings handled", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "main.py", "import os\r\n# armis:ignore\r\npassword = 'x'\r\n")
+
+		findings := []model.Finding{
+			{File: "main.py", StartLine: 3, Type: model.FindingTypeSecret, Severity: model.SeverityHigh},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 1 {
+			t.Fatalf("expected 1 (CRLF), got %d", count)
+		}
+	})
+
+	t.Run("scoped directive with AND logic rejects mismatch", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "app.py", "# armis:ignore category:sast cwe:79\ninjection = user_input\n")
+
+		findings := []model.Finding{
+			{File: "app.py", StartLine: 2, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-89"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 0 {
+			t.Fatalf("expected 0 (CWE mismatch), got %d", count)
+		}
+	})
+
+	t.Run("scoped directive with AND logic accepts full match", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "app.py", "# armis:ignore category:sast cwe:79\ninjection = user_input\n")
+
+		findings := []model.Finding{
+			{File: "app.py", StartLine: 2, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-79"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 1 {
+			t.Fatalf("expected 1, got %d", count)
+		}
+	})
+
+	t.Run("caches file reads across multiple findings", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "main.py", "# armis:ignore\nfirst = 'secret'\nsecond = 'secret'\n")
+
+		findings := []model.Finding{
+			{File: "main.py", StartLine: 2, Type: model.FindingTypeSecret, Severity: model.SeverityHigh},
+			{File: "main.py", StartLine: 3, Type: model.FindingTypeSecret, Severity: model.SeverityHigh},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		// Only line 2 has the directive above it; line 3 does not
+		if count != 1 {
+			t.Fatalf("expected 1 (only line 2 has directive above), got %d", count)
+		}
+	})
+
+	t.Run("dockerfile without extension recognized", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "Dockerfile", "FROM ubuntu\n# armis:ignore\nRUN echo secret\n")
+
+		findings := []model.Finding{
+			{File: "Dockerfile", StartLine: 3, Type: model.FindingTypeMisconfig, Severity: model.SeverityMedium},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 1 {
+			t.Fatalf("expected 1 for Dockerfile, got %d", count)
+		}
+	})
+
+	t.Run("unknown extension skipped", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "data.bin", "# armis:ignore\nsecret data\n")
+
+		findings := []model.Finding{
+			{File: "data.bin", StartLine: 2, Type: model.FindingTypeSecret},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 0 {
+			t.Fatalf("expected 0 for unknown ext, got %d", count)
+		}
+	})
+
+	t.Run("suppression info populated correctly", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "main.py", "# armis:ignore cwe:798 reason: test token only\npassword = 'test'\n")
+
+		findings := []model.Finding{
+			{File: "main.py", StartLine: 2, Type: model.FindingTypeSecret, CWEs: []string{"CWE-798"}},
+		}
+
+		ApplyInlineSuppression(findings, dir)
+		info := findings[0].SuppressionInfo
+		if info == nil {
+			t.Fatal("SuppressionInfo is nil")
+		}
+		if info.Type != string(DirectiveCWE) {
+			t.Errorf("Type = %q, want cwe", info.Type)
+		}
+		if info.Value != "798" {
+			t.Errorf("Value = %q, want 798", info.Value)
+		}
+		if info.Reason != "test token only" {
+			t.Errorf("Reason = %q, want 'test token only'", info.Reason)
+		}
+		if info.Source != suppressionInline {
+			t.Errorf("Source = %q, want inline", info.Source)
+		}
+	})
+}
+
+func TestBuildInlineSuppressionInfo(t *testing.T) {
+	tests := []struct {
+		name      string
+		directive *InlineDirective
+		wantType  string
+		wantValue string
+	}{
+		{
+			name:      "bare directive",
+			directive: &InlineDirective{},
+			wantType:  suppressionInline,
+			wantValue: "armis:ignore",
+		},
+		{
+			name:      "cwe takes priority",
+			directive: &InlineDirective{CWE: "79", Category: "sast"},
+			wantType:  "cwe",
+			wantValue: "79",
+		},
+		{
+			name:      "rule takes priority over category",
+			directive: &InlineDirective{Rule: "CKV_AWS_18", Category: "iac"},
+			wantType:  "rule",
+			wantValue: "CKV_AWS_18",
+		},
+		{
+			name:      "category alone",
+			directive: &InlineDirective{Category: "secrets"},
+			wantType:  "category",
+			wantValue: "secrets",
+		},
+		{
+			name:      "severity alone",
+			directive: &InlineDirective{Severity: "LOW"},
+			wantType:  string(DirectiveSeverity),
+			wantValue: "LOW",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := buildInlineSuppressionInfo(tt.directive)
+			if info.Type != tt.wantType {
+				t.Errorf("Type = %q, want %q", info.Type, tt.wantType)
+			}
+			if info.Value != tt.wantValue {
+				t.Errorf("Value = %q, want %q", info.Value, tt.wantValue)
+			}
+			if info.Source != suppressionInline {
+				t.Errorf("Source = %q, want inline", info.Source)
+			}
+		})
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/scan/repo/matcher.go
+++ b/internal/scan/repo/matcher.go
@@ -88,6 +88,7 @@ func ApplySuppression(findings []model.Finding, config *SuppressionConfig) int {
 				Type:   string(result.Directive.Type),
 				Value:  result.Directive.Value,
 				Reason: result.Directive.Reason,
+				Source: "armisignore",
 			}
 			suppressed++
 		}

--- a/internal/scan/repo/repo.go
+++ b/internal/scan/repo/repo.go
@@ -277,6 +277,13 @@ func (s *Scanner) Scan(ctx context.Context, path string) (*model.ScanResult, err
 		}
 	}
 
+	// Inline armis:ignore comment suppression (runs on non-suppressed findings only)
+	inlineSuppCount := ApplyInlineSuppression(result.Findings, absPath)
+	if inlineSuppCount > 0 {
+		totalSuppressed := countSuppressed(result.Findings)
+		result.Summary = recomputeSummary(result.Findings, totalSuppressed, result.Summary.FilteredNonExploitable)
+	}
+
 	return result, nil
 }
 


### PR DESCRIPTION
## Related Issue

* [PPSC-718](https://armis-security.atlassian.net/browse/PPSC-718)

## Type of Change

* [x] New feature (non-breaking change which adds functionality)

## Problem

Developers need a way to suppress individual findings at the source line level, similar to how `// nolint` or `# nosec` work in other tools. The existing `.armisignore` file only supports project-wide suppression by severity, category, CWE, or rule ID.

## Solution

Add inline `armis:ignore` comment directives that suppress findings on the annotated line (or the line below). Supports all major comment syntaxes (`//`, `#`, `--`, `<!--`, `/*`, `;`), accepts scope parameters (`category:`, `rule:`, `cwe:`, `severity:`, `reason:`) in any order with AND logic, and integrates with both human and SARIF output formatters.

Security hardening includes quote-aware parsing to reject directives inside string literals (prevents bypass via URLs like `"http://armis:ignore@..."`), path traversal protection via `SafeJoinPath`, and a 10MB file size cap.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

Verified via `go test ./internal/scan/repo/... ./internal/output/...` — all pass. Linter passes for changed files.

## Reviewer Notes

- The inline suppression runs after `.armisignore` suppression, only on non-suppressed findings
- SARIF uses `kind: "inSource"` for inline and `kind: "external"` for `.armisignore` to differentiate suppression sources
- Parameters are parsed order-independently (unlike a single ordered regex) to avoid silent scope-broadening when users write params in different order

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-718]: https://armis-security.atlassian.net/browse/PPSC-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ