### PR TITLE
[PPSC-778] fix(ci): add missing inline suppressions and fix stale alert closure

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -53,7 +53,9 @@ jobs:
       #   authentication CLI implementations.
       # Push to main: Don't fail (code already merged, just visibility)
       fail-on: ${{ github.event_name == 'pull_request' && 'CRITICAL' || '' }}
-      include-files: ${{ needs.get-changed-files.outputs.files }}
+      # PRs: scan only changed files for faster feedback
+      # Push to main: full scan so SARIF upload can close stale alerts in this category
+      include-files: ${{ github.event_name == 'pull_request' && needs.get-changed-files.outputs.files || '' }}
       build-from-source: false
       category: armis-pr-scan
       # PR comment only makes sense for pull_request events

--- a/internal/agentdetect/detector.go
+++ b/internal/agentdetect/detector.go
@@ -64,6 +64,7 @@ func hasExtensionPrefix(resolvedHome, extDir, prefix string) bool {
 	if !isUnderDir(resolvedHome, extDir) {
 		return false
 	}
+	// armis:ignore cwe:770 reason:reads bounded directory (e.g. ~/.vscode/extensions); extDir validated via isUnderDir above
 	entries, err := os.ReadDir(extDir)
 	if err != nil {
 		return false

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -295,6 +295,7 @@ type jwtClaims struct {
 // 3. This function only extracts claims for local caching/refresh logic
 //
 // armis:ignore cwe:287 reason:JWT signature verification delegated to server; CLI only extracts claims for caching
+// armis:ignore cwe:327 reason:no cryptographic operations; base64-decodes JWT payload for claim extraction only
 // #nosec G104 -- JWT signature verification delegated to backend
 func parseJWTClaims(token string) (*jwtClaims, error) {
 	parts := strings.Split(token, ".")

--- a/internal/install/claude.go
+++ b/internal/install/claude.go
@@ -79,6 +79,7 @@ func (ci *ClaudeInstaller) EnvFilePath() string {
 // GetInstalledVersion reads the installed plugin version from the registry.
 func (ci *ClaudeInstaller) GetInstalledVersion() string {
 	instFile := filepath.Join(ci.claudeDir, "plugins", "installed_plugins.json")
+	// armis:ignore cwe:770 reason:reads bounded JSON config file from user's ~/.claude dir; not unbounded input
 	b, err := os.ReadFile(filepath.Clean(instFile))
 	if err != nil {
 		return ""
@@ -116,6 +117,7 @@ func (ci *ClaudeInstaller) HasExistingEnv() bool {
 func (ci *ClaudeInstaller) registerMarketplace(pluginDir string) error {
 	mktsFile := filepath.Join(ci.claudeDir, "plugins", "known_marketplaces.json")
 	data := make(map[string]interface{})
+	// armis:ignore cwe:770 reason:reads bounded JSON config file from user's ~/.claude dir; not unbounded input
 	if b, err := os.ReadFile(filepath.Clean(mktsFile)); err == nil {
 		_ = json.Unmarshal(b, &data)
 	}
@@ -132,6 +134,7 @@ func (ci *ClaudeInstaller) registerMarketplace(pluginDir string) error {
 func (ci *ClaudeInstaller) registerPlugin(pluginDir string) error {
 	instFile := filepath.Join(ci.claudeDir, "plugins", "installed_plugins.json")
 	data := map[string]interface{}{"version": 2, "plugins": map[string]interface{}{}}
+	// armis:ignore cwe:770 reason:reads bounded JSON config file from user's ~/.claude dir; not unbounded input
 	if b, err := os.ReadFile(filepath.Clean(instFile)); err == nil {
 		_ = json.Unmarshal(b, &data)
 	}
@@ -160,6 +163,7 @@ func (ci *ClaudeInstaller) registerPlugin(pluginDir string) error {
 func (ci *ClaudeInstaller) enablePlugin() error {
 	settingsFile := filepath.Join(ci.claudeDir, "settings.json")
 	data := make(map[string]interface{})
+	// armis:ignore cwe:770 reason:reads bounded JSON config file from user's ~/.claude dir; not unbounded input
 	if b, err := os.ReadFile(filepath.Clean(settingsFile)); err == nil {
 		_ = json.Unmarshal(b, &data)
 	}

--- a/internal/install/editors.go
+++ b/internal/install/editors.go
@@ -310,6 +310,7 @@ func stdServerEntry(pluginDir string) map[string]interface{} {
 
 func readJSONFileAsMap(path string) map[string]interface{} {
 	data := make(map[string]interface{})
+	// armis:ignore cwe:22 reason:path is constructed from filepath.Join with known base dirs; filepath.Clean applied
 	if b, err := os.ReadFile(filepath.Clean(path)); err == nil {
 		_ = json.Unmarshal(b, &data)
 	}

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -217,6 +217,7 @@ func (s *Spinner) Start() {
 		// even when --color=never. This matches clearLine() which uses \033[K.
 		hideCursor := isTerminalWriter(s.writer)
 		if hideCursor {
+			// armis:ignore cwe:253 reason:fmt.Fprint to terminal for cursor control; return value not actionable
 			_, _ = fmt.Fprint(s.writer, cursorHide)
 			defer func() { _, _ = fmt.Fprint(s.writer, cursorShow) }()
 		}
@@ -237,11 +238,11 @@ func (s *Spinner) Start() {
 		for {
 			select {
 			case <-s.stopChan:
-				// Explicit stop requested
+				// armis:ignore cwe:253 reason:fmt.Fprint to terminal for line clearing; return value not actionable
 				_, _ = fmt.Fprint(s.writer, clearLine())
 				return
 			case <-ctx.Done():
-				// Context canceled or timeout reached
+				// armis:ignore cwe:253 reason:fmt.Fprint to terminal for line clearing; return value not actionable
 				_, _ = fmt.Fprint(s.writer, clearLine())
 				return
 			case <-ticker.C:
@@ -254,8 +255,10 @@ func (s *Spinner) Start() {
 				text := styles.SpinnerText.Render(msg)
 				if s.showTimer {
 					timer := styles.SpinnerTimer.Render("[" + formatDuration(elapsed) + "]")
+					// armis:ignore cwe:253 reason:fmt.Fprintf to terminal for spinner output; return value not actionable
 					_, _ = fmt.Fprintf(s.writer, "%s%s %s %s", clearLine(), char, text, timer)
 				} else {
+					// armis:ignore cwe:253 reason:fmt.Fprintf to terminal for spinner output; return value not actionable
 					_, _ = fmt.Fprintf(s.writer, "%s%s %s", clearLine(), char, text)
 				}
 				i++

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -219,6 +219,7 @@ func (s *Spinner) Start() {
 		if hideCursor {
 			// armis:ignore cwe:253 reason:fmt.Fprint to terminal for cursor control; return value not actionable
 			_, _ = fmt.Fprint(s.writer, cursorHide)
+			// armis:ignore cwe:253 reason:deferred fmt.Fprint for cursor restore; return value not actionable
 			defer func() { _, _ = fmt.Fprint(s.writer, cursorShow) }()
 		}
 

--- a/internal/scan/repo/gitchanges.go
+++ b/internal/scan/repo/gitchanges.go
@@ -119,6 +119,7 @@ func gitRepoRoot(path string) (string, error) {
 		return resolved, nil
 	}
 
+	// armis:ignore cwe:22 reason:repoRoot from git rev-parse --show-toplevel; filepath.Clean applied above
 	return repoRoot, nil
 }
 

--- a/internal/scan/repo/ignore.go
+++ b/internal/scan/repo/ignore.go
@@ -37,6 +37,7 @@ func LoadSuppressionConfig(repoRoot string) (*SuppressionConfig, error) {
 	if !filepath.IsAbs(repoRoot) {
 		return nil, fmt.Errorf("repoRoot must be an absolute path, got: %s", repoRoot)
 	}
+	// armis:ignore cwe:73 reason:filepath.Join with hardcoded ".armisignore" filename; repoRoot validated as absolute above
 	rootIgnorePath := filepath.Join(filepath.Clean(repoRoot), ".armisignore") // #nosec G304
 
 	info, err := os.Lstat(rootIgnorePath)

--- a/internal/util/mask.go
+++ b/internal/util/mask.go
@@ -111,12 +111,12 @@ func MaskSecretInLine(line string) string {
 		return line
 	}
 
+	// armis:ignore cwe:522 reason:this IS the secret masking function; it processes secrets to redact them from output
 	// Defense against ReDoS (CWE-770): skip regex processing for extremely long lines
 	if len(line) > maxLineLength {
 		return line
 	}
 
-	// armis:ignore cwe:522 reason:this IS the secret masking function; it processes secrets to redact them from output
 	result := line
 
 	for _, pattern := range secretPatterns {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -363,6 +363,7 @@ main() {
     if [ "$OS" = "windows" ]; then
         unzip -q "$ARCHIVE_FILE" -d "$TMP_DIR"
     else
+        # armis:ignore cwe:22 reason:ARCHIVE_FILE downloaded from verified GitHub release URL with checksum; TMP_DIR is mktemp -d
         tar -xzf "$ARCHIVE_FILE" -C "$TMP_DIR"
     fi
 
@@ -386,14 +387,14 @@ main() {
             echo "📦 Replacing existing installation..."
         fi
     else
-        # armis:ignore cwe:367 reason:TOCTOU on fi-to-mv path is benign for local installer; no security boundary crossed
+        # armis:ignore cwe:367 reason:TOCTOU between if-block and mv is benign for local installer; no security boundary crossed
         echo "📦 Installing to $INSTALL_DIR..."
     fi
 
     # armis:ignore cwe:367 reason:TOCTOU between writable-check and mv is acceptable for installer; no security boundary crossed
     if [ -w "$INSTALL_DIR" ]; then
-        # armis:ignore cwe:367 reason:mv after writable-check; acceptable TOCTOU for local installer binary placement
         # armis:ignore cwe:73 reason:INSTALL_DIR validated by validate_install_dir() when user-set; defaults are hardcoded safe paths
+        # armis:ignore cwe:367 reason:mv after writable-check; acceptable TOCTOU for local installer binary placement
         mv "$BINARY_FILE" "$TARGET_PATH" || fail "Failed to move binary to $TARGET_PATH"
     else
         echo "   (requires sudo privileges)"
@@ -401,8 +402,8 @@ main() {
         sudo mv "$BINARY_FILE" "$TARGET_PATH" || fail "Failed to move binary to $TARGET_PATH (sudo mv failed)"
     fi
 
+    # armis:ignore cwe:367 reason:TOCTOU between writable-check and chmod; acceptable for local installer
     if [ -w "$TARGET_PATH" ]; then
-        # armis:ignore cwe:367 reason:chmod after writable-check; acceptable TOCTOU for local installer
         # armis:ignore cwe:285 reason:installer must set executable permission on installed binary
         chmod +x "$TARGET_PATH" 2>/dev/null || true
     else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -386,11 +386,13 @@ main() {
             echo "📦 Replacing existing installation..."
         fi
     else
+        # armis:ignore cwe:367 reason:TOCTOU on fi-to-mv path is benign for local installer; no security boundary crossed
         echo "📦 Installing to $INSTALL_DIR..."
     fi
 
     # armis:ignore cwe:367 reason:TOCTOU between writable-check and mv is acceptable for installer; no security boundary crossed
     if [ -w "$INSTALL_DIR" ]; then
+        # armis:ignore cwe:367 reason:mv after writable-check; acceptable TOCTOU for local installer binary placement
         # armis:ignore cwe:73 reason:INSTALL_DIR validated by validate_install_dir() when user-set; defaults are hardcoded safe paths
         mv "$BINARY_FILE" "$TARGET_PATH" || fail "Failed to move binary to $TARGET_PATH"
     else
@@ -400,6 +402,7 @@ main() {
     fi
 
     if [ -w "$TARGET_PATH" ]; then
+        # armis:ignore cwe:367 reason:chmod after writable-check; acceptable TOCTOU for local installer
         # armis:ignore cwe:285 reason:installer must set executable permission on installed binary
         chmod +x "$TARGET_PATH" 2>/dev/null || true
     else


### PR DESCRIPTION
## Related Issue

* [PPSC-778](https://armis-security.atlassian.net/browse/PPSC-778)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

PR #172 added inline `armis:ignore` suppressions for 26 false positive findings, but 21 alerts remain open on the GitHub Code Scanning tab because:
1. Many comments were placed too far from the finding line (the inline system only checks the finding line itself + one line above)
2. Two findings had CWE mismatches (auth.go: suppressed CWE-287 but alert was CWE-327; install.sh: suppressed CWE-285 but alert was CWE-367)
3. The `pr-security-scan` workflow used `include-files` on push-to-main, so its SARIF upload only covered changed files and could never close stale alerts in other files

## Solution

- Add correctly-placed `armis:ignore` comments for all 16 unsuppressed findings (directly above or on the finding line)
- Add missing CWE-327 suppression to `auth.go` and CWE-367 to `install.sh`
- Move `mask.go` suppression from below to above the finding line
- Change the `pr-security-scan` workflow to do a **full scan** on push-to-main (empty `include-files`) so the complete SARIF can close stale alerts in the `armis-pr-scan` category

## Testing

### Automated Tests

* [ ] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

- Verified all suppression comments are exactly on or one line above their respective finding lines
- Confirmed build passes, all tests pass, all pre-commit hooks pass (shellcheck, golangci-lint, yamllint)
- After merge: push-to-main scan will upload a full SARIF that should close all 18 `armis-pr-scan` alerts; next scheduled scan will close the 3 `armis-scheduled-scan` alerts

## Reviewer Notes

The inline suppression system (`internal/scan/repo/inline.go`) checks **only the finding line and one line above** — this is a strict proximity requirement that the previous PR didn't account for. The workflow change means push-to-main scans will take longer (full repo vs. changed files only) but this is necessary for alert lifecycle management.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] Documentation updated (if needed)
* [x] Breaking changes documented (if applicable)
* [x] No new warnings generated

[PPSC-778]: https://armis-security.atlassian.net/browse/PPSC-778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ