### PR TITLE
Added symlink eval before path traversal

### DIFF
--- a/internal/scan/repo/gitchanges.go
+++ b/internal/scan/repo/gitchanges.go
@@ -218,6 +218,12 @@ func filterToScanPath(repoRoot, scanPath string, changedPaths []string) ([]strin
 		prefix += "/"
 	}
 
+	// Resolve symlinks on scanPath so containment checks compare real paths (CWE-22).
+	resolvedScanPath, err := filepath.EvalSymlinks(scanPath)
+	if err != nil {
+		resolvedScanPath = scanPath
+	}
+
 	var filtered []string
 	for _, p := range changedPaths {
 		// Normalize path components (e.g., "subdir/../secret" -> "../secret")
@@ -228,6 +234,16 @@ func filterToScanPath(repoRoot, scanPath string, changedPaths []string) ([]strin
 		if strings.HasPrefix(slashP, prefix) {
 			rel := strings.TrimPrefix(slashP, prefix)
 			if rel != "" {
+				// Resolve symlinks to reject paths that escape scanPath (CWE-22).
+				// Only reject when resolution succeeds and proves escape; if the file
+				// doesn't exist on disk (common for deleted files), the string-based
+				// prefix check above is sufficient since Clean already rejected "..".
+				absCandidate := filepath.Join(repoRoot, p)
+				if resolved, err := filepath.EvalSymlinks(absCandidate); err == nil {
+					if !strings.HasPrefix(resolved, resolvedScanPath+string(filepath.Separator)) && resolved != resolvedScanPath {
+						continue
+					}
+				}
 				filtered = append(filtered, rel)
 			}
 		}

--- a/internal/scan/repo/gitchanges_test.go
+++ b/internal/scan/repo/gitchanges_test.go
@@ -424,10 +424,18 @@ func TestFilterToScanPath_SymlinkEscape(t *testing.T) {
 	scanPath := filepath.Join(repoRoot, "src")
 	outsideDir := filepath.Join(tmpDir, "outside")
 
-	os.MkdirAll(scanPath, 0o755)
-	os.MkdirAll(outsideDir, 0o755)
-	os.WriteFile(filepath.Join(scanPath, "legit.go"), []byte("package main"), 0o644)
-	os.WriteFile(filepath.Join(outsideDir, "leaked.go"), []byte("leaked"), 0o644)
+	if err := os.MkdirAll(scanPath, 0o750); err != nil {
+		t.Fatalf("failed to create scan path: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0o750); err != nil {
+		t.Fatalf("failed to create outside dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scanPath, "legit.go"), []byte("package main"), 0o600); err != nil {
+		t.Fatalf("failed to write legit.go: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outsideDir, "leaked.go"), []byte("leaked"), 0o600); err != nil {
+		t.Fatalf("failed to write leaked.go: %v", err)
+	}
 
 	// Create symlink: repo/src/evil -> outside/
 	evilLink := filepath.Join(scanPath, "evil")

--- a/internal/scan/repo/gitchanges_test.go
+++ b/internal/scan/repo/gitchanges_test.go
@@ -413,6 +413,46 @@ func TestFilterToScanPath(t *testing.T) {
 	}
 }
 
+func TestFilterToScanPath_SymlinkEscape(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Structure:
+	// tmpDir/repo/src/legit.go      (real file)
+	// tmpDir/repo/src/evil/         (symlink -> tmpDir/outside/)
+	// tmpDir/outside/leaked.go      (file outside repo)
+	repoRoot := filepath.Join(tmpDir, "repo")
+	scanPath := filepath.Join(repoRoot, "src")
+	outsideDir := filepath.Join(tmpDir, "outside")
+
+	os.MkdirAll(scanPath, 0o755)
+	os.MkdirAll(outsideDir, 0o755)
+	os.WriteFile(filepath.Join(scanPath, "legit.go"), []byte("package main"), 0o644)
+	os.WriteFile(filepath.Join(outsideDir, "leaked.go"), []byte("leaked"), 0o644)
+
+	// Create symlink: repo/src/evil -> outside/
+	evilLink := filepath.Join(scanPath, "evil")
+	if err := os.Symlink(outsideDir, evilLink); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	changedPaths := []string{
+		"src/legit.go",       // legitimate file inside scan path
+		"src/evil/leaked.go", // traverses via symlink to outside
+	}
+
+	filtered, err := filterToScanPath(repoRoot, scanPath, changedPaths)
+	if err != nil {
+		t.Fatalf("filterToScanPath error: %v", err)
+	}
+
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 result, got %d: %v", len(filtered), filtered)
+	}
+	if filtered[0] != "legit.go" {
+		t.Errorf("expected 'legit.go', got %q", filtered[0])
+	}
+}
+
 func TestValidateRef(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Related Issue

<!-- Link to Jira ticket or GitHub issue. Delete the one you don't use. -->

* [PPSC-754](https://your-jira.atlassian.net/browse/PPSC-754)
* Fixes (https://github.com/ArmisSecurity/armis-cli/security/code-scanning/1476)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Refactoring (no functional changes)
* [ ] Performance improvement

## Problem

filterToScanPath in internal/scan/repo/gitchanges.go used only string-based prefix matching (after filepath.Clean) to determine whether a git-reported file path belongs within the scan directory. This is insufficient when the repository contains symlinks - a symlinked path (e.g., src/evil -> /etc/) would pass the textual prefix check because its name lives inside the allowed folder, but the actual filesystem target resolves outside the scan boundary.

While downstream validation via ParseFileList → SafeJoinPath provides a second layer of defense, the filterToScanPath function itself lacked symlink-aware containment checking (CWE-22).

## Solution

Added filepath.EvalSymlinks resolution in filterToScanPath as defense-in-depth:
- Resolve symlinks on scanPath once upfront to get the canonical scan directory path
- For each candidate path that passes the string prefix check, attempt EvalSymlinks on the absolute path
- If resolution succeeds and the real path is outside scanPath → reject (symlink-based escape)
- If resolution fails (file doesn't exist on disk, e.g., deleted in working tree) → allow it through, since the existing filepath.Clean + prefix check already rejected .. traversals, and downstream ParseFileList provides further validation

This approach avoids breaking existing behavior for non-existent files (common in git diff output for deleted files) while
blocking the specific symlink-based traversal attack vector.

## Testing

### Automated Tests

* [ ] Unit tests added/updated
* [ ] Integration tests added/updated
* [x] All tests passing locally

### Manual Testing

Ran go test ./internal/scan/repo/ -v - all 6 TestFilterToScanPath subcases pass including:
- path_traversal_via_dotdot_excluded - confirms .. paths are still rejected
- path_traversal_that_resolves_inside_included - confirms paths like src/pkg/../helper.go that resolve inside the scan dir are still included
- subdirectory_filter, nested_subdirectory - confirms normal filtering still works for paths that don't exist on disk (EvalSymlinks fails gracefully)

## Reviewer Notes

<!-- Anything specific reviewers should focus on? -->
<!-- Any trade-offs, technical debt, or follow-up work? -->

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [ ] Documentation updated (if needed)
* [ ] Breaking changes documented (if applicable)
* [x] No new warnings generated

## Screenshots (if applicable)

<!-- Add screenshots to help explain visual changes -->


[PPSC-754]: https://armis-security.atlassian.net/browse/PPSC-754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ