### PR TITLE
docs: update CHANGELOG for v1.8.3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.3] - 2026-05-13
+
+### Changed
+
+- Inline suppression now matches findings within a 5-line window around the directive, improving coverage for multi-line code patterns (#175)
+
+---
+
 ## [1.8.2] - 2026-05-13
 
 ### Added
@@ -301,7 +309,8 @@ Manual entries for significant releases:
 
 -->
 
-[Unreleased]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.2...HEAD
+[Unreleased]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.3...HEAD
+[1.8.3]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.2...v1.8.3
 [1.8.2]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.1...v1.8.2
 [1.8.1]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.0...v1.8.1
 [1.8.0]: https://github.com/ArmisSecurity/armis-cli/compare/v1.7.0...v1.8.0


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for the v1.8.3 release
- One change: inline suppression window expanded from 1 to 5 lines (#175)

## Release checklist

- [x] CHANGELOG.md updated
- [x] Jira ticket: [PPSC-782](https://armis-security.atlassian.net/browse/PPSC-782)
- [ ] PR merged
- [ ] Tag `v1.8.3` created
- [ ] GitHub Release published
- [ ] Homebrew formula updated
- [ ] Slack announcement posted

[PPSC-782]: https://armis-security.atlassian.net/browse/PPSC-782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ