### PR TITLE
[PPSC-789] feat(install): add Claude Desktop app as install target

### DIFF
--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -18,19 +18,20 @@ With no arguments, installs the plugin and registers it in all detected editors.
 Specify one or more editor names to target specific tools.
 
 Supported editors:
-  claude     Claude Code (uses plugin system)
-  vscode     VS Code / GitHub Copilot
-  copilot    Alias for vscode
-  cursor     Cursor
-  windsurf   Windsurf (Codeium)
-  zed        Zed
-  cline      Cline (VS Code extension)
-  amazonq    Amazon Q Developer
-  continue      Continue
-  antigravity   Antigravity
-  gemini        Gemini CLI
-  roocode       Roo Code
-  junie         Junie
+  claude          Claude Code (uses plugin system)
+  claude-desktop  Claude Desktop app (macOS/Windows)
+  vscode          VS Code / GitHub Copilot
+  copilot         Alias for vscode
+  cursor          Cursor
+  windsurf        Windsurf (Codeium)
+  zed             Zed
+  cline           Cline (VS Code extension)
+  amazonq         Amazon Q Developer
+  continue        Continue
+  antigravity     Antigravity
+  gemini          Gemini CLI
+  roocode         Roo Code
+  junie           Junie
 
 Not auto-configurable (manual setup required):
   jetbrains  JetBrains IDEs (per-project .jb-mcp.json)

--- a/internal/install/editors.go
+++ b/internal/install/editors.go
@@ -195,7 +195,7 @@ func defaultConfigPath(id EditorID) string {
 	case EditorJunie:
 		return homeDir(".junie", "mcp", "mcp.json")
 	case EditorClaudeDesktop:
-		if runtime.GOOS == "linux" {
+		if runtime.GOOS != osDarwin && runtime.GOOS != osWindows {
 			return ""
 		}
 		return appSupportPath("Claude", "claude_desktop_config.json")
@@ -214,13 +214,13 @@ func homeDir(parts ...string) string {
 func appSupportPath(parts ...string) string {
 	var base string
 	switch runtime.GOOS {
-	case "darwin":
+	case osDarwin:
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return ""
 		}
 		base = filepath.Join(home, "Library", "Application Support")
-	case "linux":
+	case osLinux:
 		base = os.Getenv("XDG_CONFIG_HOME")
 		if base == "" {
 			home, err := os.UserHomeDir()
@@ -249,13 +249,13 @@ func registerEditor(id EditorID, pluginDir, configFile string) error {
 	case EditorZed:
 		return registerZedFormat(pluginDir, configFile)
 	default:
-		// Cursor, Windsurf, Cline, Amazon Q, Continue, Antigravity all use mcpServers map
+		// Shared by the standard mcpServers editors.
 		return registerMCPServersFormat(pluginDir, configFile)
 	}
 }
 
 // registerMCPServersFormat handles {"mcpServers": {"name": {command, args}}}.
-// Used by Cursor, Windsurf, Cline, Amazon Q, JetBrains.
+// Shared by the standard mcpServers editors (and JetBrains via RegisterJetBrains).
 func registerMCPServersFormat(pluginDir, configFile string) error {
 	data := readJSONFileAsMap(configFile)
 

--- a/internal/install/editors.go
+++ b/internal/install/editors.go
@@ -14,17 +14,18 @@ const mcpServerName = "armis-appsec"
 type EditorID string
 
 const (
-	EditorVSCode      EditorID = "vscode"
-	EditorCursor      EditorID = "cursor"
-	EditorWindsurf    EditorID = "windsurf"
-	EditorZed         EditorID = "zed"
-	EditorCline       EditorID = "cline"
-	EditorAmazonQ     EditorID = "amazonq"
-	EditorContinue    EditorID = "continue"
-	EditorAntigravity EditorID = "antigravity"
-	EditorGemini      EditorID = "gemini"
-	EditorRooCode     EditorID = "roocode"
-	EditorJunie       EditorID = "junie"
+	EditorVSCode        EditorID = "vscode"
+	EditorCursor        EditorID = "cursor"
+	EditorWindsurf      EditorID = "windsurf"
+	EditorZed           EditorID = "zed"
+	EditorCline         EditorID = "cline"
+	EditorAmazonQ       EditorID = "amazonq"
+	EditorContinue      EditorID = "continue"
+	EditorAntigravity   EditorID = "antigravity"
+	EditorGemini        EditorID = "gemini"
+	EditorRooCode       EditorID = "roocode"
+	EditorJunie         EditorID = "junie"
+	EditorClaudeDesktop EditorID = "claude-desktop"
 )
 
 // Editor represents a code editor with MCP server support.
@@ -46,6 +47,7 @@ var AllEditors = []Editor{
 	{EditorGemini, "Gemini CLI"},
 	{EditorRooCode, "Roo Code"},
 	{EditorJunie, "Junie"},
+	{EditorClaudeDesktop, "Claude Desktop"},
 }
 
 // EditorByID returns the editor with the given ID.
@@ -192,6 +194,11 @@ func defaultConfigPath(id EditorID) string {
 		return homeDir(".roo-cline", "mcp_settings.json")
 	case EditorJunie:
 		return homeDir(".junie", "mcp", "mcp.json")
+	case EditorClaudeDesktop:
+		if runtime.GOOS == "linux" {
+			return ""
+		}
+		return appSupportPath("Claude", "claude_desktop_config.json")
 	}
 	return ""
 }

--- a/internal/install/editors_test.go
+++ b/internal/install/editors_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -32,6 +33,25 @@ func TestEditorConfigPath(t *testing.T) {
 		if !filepath.IsAbs(p) {
 			t.Errorf("%s config path %q is not absolute", e.Name, p)
 		}
+	}
+}
+
+func TestClaudeDesktopUnsupportedOS(t *testing.T) {
+	e, ok := EditorByID(EditorClaudeDesktop)
+	if !ok {
+		t.Fatal("EditorByID(EditorClaudeDesktop) not found")
+	}
+	if runtime.GOOS == osDarwin || runtime.GOOS == osWindows {
+		if e.ConfigPath() == "" {
+			t.Errorf("ConfigPath() unexpectedly empty on %s", runtime.GOOS)
+		}
+		return
+	}
+	if got := e.ConfigPath(); got != "" {
+		t.Errorf("ConfigPath() on %s = %q, want empty (Claude Desktop only ships on macOS/Windows)", runtime.GOOS, got)
+	}
+	if e.IsDetected() {
+		t.Errorf("IsDetected() on %s = true, want false", runtime.GOOS)
 	}
 }
 

--- a/internal/install/editors_test.go
+++ b/internal/install/editors_test.go
@@ -87,7 +87,7 @@ func TestDetectedEditors(t *testing.T) {
 }
 
 func TestRegisterMCPServersFormat(t *testing.T) {
-	editors := []EditorID{EditorCursor, EditorWindsurf, EditorCline, EditorAmazonQ, EditorAntigravity, EditorContinue, EditorGemini}
+	editors := []EditorID{EditorCursor, EditorWindsurf, EditorCline, EditorAmazonQ, EditorAntigravity, EditorContinue, EditorGemini, EditorClaudeDesktop}
 	for _, id := range editors {
 		t.Run(string(id), func(t *testing.T) {
 			dir := t.TempDir()

--- a/internal/install/plugin.go
+++ b/internal/install/plugin.go
@@ -19,7 +19,11 @@ import (
 
 const githubAPIHost = "api.github.com"
 
-const osWindows = "windows"
+const (
+	osWindows = "windows"
+	osDarwin  = "darwin"
+	osLinux   = "linux"
+)
 
 const (
 	pluginRepo        = "ArmisSecurity/armis-appsec-mcp"


### PR DESCRIPTION
## Summary
- Adds `claude-desktop` as a new editor target for `armis-cli install`
- Writes the Armis AppSec MCP entry into Claude Desktop's `claude_desktop_config.json` using the standard `mcpServers` format (same as Cursor/Windsurf)
- Supported on macOS (`~/Library/Application Support/Claude/claude_desktop_config.json`) and Windows (`%APPDATA%\Claude\claude_desktop_config.json`); Linux returns empty (Claude Desktop is not shipped on Linux)

## Test plan
- [ ] `go test ./internal/install/...` passes
- [ ] `golangci-lint run ./internal/install/... ./internal/cmd/...` passes
- [ ] `armis-cli install --help` lists `claude-desktop`
- [ ] `armis-cli install claude-desktop` writes/merges the MCP entry into `claude_desktop_config.json` without clobbering existing servers
- [ ] `armis-cli install` (no args) detects an installed Claude Desktop and registers it

🤖 Generated with [Claude Code](https://claude.com/claude-code)