### PR TITLE
[PPSC-790] fix(cmd): prevent secrets from leaking in --help output

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -114,6 +114,23 @@ var rootCmd = &cobra.Command{
 
 		output.SyncColors()
 
+		// Resolve credentials from environment when not provided via flags
+		if token == "" {
+			token = os.Getenv("ARMIS_API_TOKEN")
+		}
+		if tenantID == "" {
+			tenantID = os.Getenv("ARMIS_TENANT_ID")
+		}
+		if clientID == "" {
+			clientID = os.Getenv("ARMIS_CLIENT_ID")
+		}
+		if clientSecret == "" {
+			clientSecret = os.Getenv("ARMIS_CLIENT_SECRET")
+		}
+		if region == "" {
+			region = os.Getenv("ARMIS_REGION")
+		}
+
 		// Warn if the removed ARMIS_AUTH_ENDPOINT env var is set
 		if os.Getenv("ARMIS_AUTH_ENDPOINT") != "" {
 			cli.PrintWarning("ARMIS_AUTH_ENDPOINT is no longer supported. " +
@@ -164,13 +181,13 @@ func init() {
 	SetupHelp(rootCmd)
 
 	// Legacy Basic authentication
-	rootCmd.PersistentFlags().StringVarP(&token, "token", "t", os.Getenv("ARMIS_API_TOKEN"), "API token for Basic authentication (env: ARMIS_API_TOKEN)")
-	rootCmd.PersistentFlags().StringVar(&tenantID, "tenant-id", os.Getenv("ARMIS_TENANT_ID"), "Tenant identifier for Armis Cloud (env: ARMIS_TENANT_ID)")
+	rootCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "API token for Basic authentication (env: ARMIS_API_TOKEN)")
+	rootCmd.PersistentFlags().StringVar(&tenantID, "tenant-id", "", "Tenant identifier for Armis Cloud (env: ARMIS_TENANT_ID)")
 
 	// JWT authentication
-	rootCmd.PersistentFlags().StringVar(&clientID, "client-id", os.Getenv("ARMIS_CLIENT_ID"), "Client ID for JWT authentication (env: ARMIS_CLIENT_ID)")
-	rootCmd.PersistentFlags().StringVar(&clientSecret, "client-secret", os.Getenv("ARMIS_CLIENT_SECRET"), "Client secret for JWT authentication (env: ARMIS_CLIENT_SECRET)")
-	rootCmd.PersistentFlags().StringVar(&region, "region", os.Getenv("ARMIS_REGION"), "Override region for authentication (bypasses auto-discovery) (env: ARMIS_REGION)")
+	rootCmd.PersistentFlags().StringVar(&clientID, "client-id", "", "Client ID for JWT authentication (env: ARMIS_CLIENT_ID)")
+	rootCmd.PersistentFlags().StringVar(&clientSecret, "client-secret", "", "Client secret for JWT authentication (env: ARMIS_CLIENT_SECRET)")
+	rootCmd.PersistentFlags().StringVar(&region, "region", "", "Override region for authentication (bypasses auto-discovery) (env: ARMIS_REGION)")
 
 	// General options
 	rootCmd.PersistentFlags().BoolVar(&useDev, "dev", false, "Use development environment instead of production")

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -114,20 +114,22 @@ var rootCmd = &cobra.Command{
 
 		output.SyncColors()
 
-		// Resolve credentials from environment when not provided via flags
-		if token == "" {
+		// Resolve credentials from environment when not explicitly provided via flags.
+		// Using cmd.Flags().Changed() ensures that an explicit --flag="" can override
+		// an env var (i.e. intentionally clear a credential).
+		if !cmd.Flags().Changed("token") {
 			token = os.Getenv("ARMIS_API_TOKEN")
 		}
-		if tenantID == "" {
+		if !cmd.Flags().Changed("tenant-id") {
 			tenantID = os.Getenv("ARMIS_TENANT_ID")
 		}
-		if clientID == "" {
+		if !cmd.Flags().Changed("client-id") {
 			clientID = os.Getenv("ARMIS_CLIENT_ID")
 		}
-		if clientSecret == "" {
+		if !cmd.Flags().Changed("client-secret") {
 			clientSecret = os.Getenv("ARMIS_CLIENT_SECRET")
 		}
-		if region == "" {
+		if !cmd.Flags().Changed("region") {
 			region = os.Getenv("ARMIS_REGION")
 		}
 

--- a/internal/cmd/scan_repo_test.go
+++ b/internal/cmd/scan_repo_test.go
@@ -32,6 +32,8 @@ func TestScanRepoRunE_SuccessfulScan(t *testing.T) {
 	// Save and restore global state
 	originalToken := token
 	originalTenantID := tenantID
+	originalClientID := clientID
+	originalClientSecret := clientSecret
 	originalFormat := format
 	originalColorFlag := colorFlag
 	originalThemeFlag := themeFlag
@@ -41,6 +43,8 @@ func TestScanRepoRunE_SuccessfulScan(t *testing.T) {
 	t.Cleanup(func() {
 		token = originalToken
 		tenantID = originalTenantID
+		clientID = originalClientID
+		clientSecret = originalClientSecret
 		format = originalFormat
 		colorFlag = originalColorFlag
 		themeFlag = originalThemeFlag
@@ -51,8 +55,12 @@ func TestScanRepoRunE_SuccessfulScan(t *testing.T) {
 
 	// Set up test environment
 	_ = os.Setenv("ARMIS_API_URL", serverURL)
+	t.Setenv("ARMIS_CLIENT_ID", "")
+	t.Setenv("ARMIS_CLIENT_SECRET", "")
 	token = testToken
 	tenantID = testTenantID
+	clientID = ""
+	clientSecret = ""
 	format = "json"
 	colorFlag = testColorNever
 	themeFlag = themeAuto
@@ -72,6 +80,8 @@ func TestScanRepoRunE_IncludeFilesValidation(t *testing.T) {
 	// Save and restore global state
 	originalToken := token
 	originalTenantID := tenantID
+	originalClientID := clientID
+	originalClientSecret := clientSecret
 	originalColorFlag := colorFlag
 	originalThemeFlag := themeFlag
 	originalNoUpdateCheck := noUpdateCheck
@@ -80,6 +90,8 @@ func TestScanRepoRunE_IncludeFilesValidation(t *testing.T) {
 	t.Cleanup(func() {
 		token = originalToken
 		tenantID = originalTenantID
+		clientID = originalClientID
+		clientSecret = originalClientSecret
 		colorFlag = originalColorFlag
 		themeFlag = originalThemeFlag
 		noUpdateCheck = originalNoUpdateCheck
@@ -89,8 +101,12 @@ func TestScanRepoRunE_IncludeFilesValidation(t *testing.T) {
 
 	// Set up mock server URL (even though we won't reach it)
 	_ = os.Setenv("ARMIS_API_URL", "http://localhost:8080")
+	t.Setenv("ARMIS_CLIENT_ID", "")
+	t.Setenv("ARMIS_CLIENT_SECRET", "")
 	token = testToken
 	tenantID = testTenantID
+	clientID = ""
+	clientSecret = ""
 	colorFlag = testColorNever
 	themeFlag = themeAuto
 	noUpdateCheck = true
@@ -119,6 +135,8 @@ func TestScanRepoRunE_InvalidPath(t *testing.T) {
 	// Save and restore global state
 	originalToken := token
 	originalTenantID := tenantID
+	originalClientID := clientID
+	originalClientSecret := clientSecret
 	originalColorFlag := colorFlag
 	originalThemeFlag := themeFlag
 	originalNoUpdateCheck := noUpdateCheck
@@ -126,6 +144,8 @@ func TestScanRepoRunE_InvalidPath(t *testing.T) {
 	t.Cleanup(func() {
 		token = originalToken
 		tenantID = originalTenantID
+		clientID = originalClientID
+		clientSecret = originalClientSecret
 		colorFlag = originalColorFlag
 		themeFlag = originalThemeFlag
 		noUpdateCheck = originalNoUpdateCheck
@@ -133,8 +153,12 @@ func TestScanRepoRunE_InvalidPath(t *testing.T) {
 	})
 
 	_ = os.Setenv("ARMIS_API_URL", "http://localhost:8080")
+	t.Setenv("ARMIS_CLIENT_ID", "")
+	t.Setenv("ARMIS_CLIENT_SECRET", "")
 	token = testToken
 	tenantID = testTenantID
+	clientID = ""
+	clientSecret = ""
 	colorFlag = testColorNever
 	themeFlag = themeAuto
 	noUpdateCheck = true
@@ -154,6 +178,8 @@ func TestScanRepoRunE_ChangedFlagNonGitRepo(t *testing.T) {
 	// Save and restore global state
 	originalToken := token
 	originalTenantID := tenantID
+	originalClientID := clientID
+	originalClientSecret := clientSecret
 	originalColorFlag := colorFlag
 	originalThemeFlag := themeFlag
 	originalNoUpdateCheck := noUpdateCheck
@@ -162,6 +188,8 @@ func TestScanRepoRunE_ChangedFlagNonGitRepo(t *testing.T) {
 	t.Cleanup(func() {
 		token = originalToken
 		tenantID = originalTenantID
+		clientID = originalClientID
+		clientSecret = originalClientSecret
 		colorFlag = originalColorFlag
 		themeFlag = originalThemeFlag
 		noUpdateCheck = originalNoUpdateCheck
@@ -177,8 +205,12 @@ func TestScanRepoRunE_ChangedFlagNonGitRepo(t *testing.T) {
 	})
 
 	_ = os.Setenv("ARMIS_API_URL", "http://localhost:8080")
+	t.Setenv("ARMIS_CLIENT_ID", "")
+	t.Setenv("ARMIS_CLIENT_SECRET", "")
 	token = testToken
 	tenantID = testTenantID
+	clientID = ""
+	clientSecret = ""
 	colorFlag = testColorNever
 	themeFlag = themeAuto
 	noUpdateCheck = true
@@ -213,6 +245,8 @@ func TestScanRepoRunE_ChangedFlagNoChanges(t *testing.T) {
 	// Save and restore global state
 	originalToken := token
 	originalTenantID := tenantID
+	originalClientID := clientID
+	originalClientSecret := clientSecret
 	originalColorFlag := colorFlag
 	originalThemeFlag := themeFlag
 	originalNoUpdateCheck := noUpdateCheck
@@ -221,6 +255,8 @@ func TestScanRepoRunE_ChangedFlagNoChanges(t *testing.T) {
 	t.Cleanup(func() {
 		token = originalToken
 		tenantID = originalTenantID
+		clientID = originalClientID
+		clientSecret = originalClientSecret
 		colorFlag = originalColorFlag
 		themeFlag = originalThemeFlag
 		noUpdateCheck = originalNoUpdateCheck
@@ -236,8 +272,12 @@ func TestScanRepoRunE_ChangedFlagNoChanges(t *testing.T) {
 	})
 
 	_ = os.Setenv("ARMIS_API_URL", "http://localhost:8080")
+	t.Setenv("ARMIS_CLIENT_ID", "")
+	t.Setenv("ARMIS_CLIENT_SECRET", "")
 	token = testToken
 	tenantID = testTenantID
+	clientID = ""
+	clientSecret = ""
 	colorFlag = testColorNever
 	themeFlag = themeAuto
 	noUpdateCheck = true

--- a/internal/cmd/scan_test.go
+++ b/internal/cmd/scan_test.go
@@ -102,10 +102,17 @@ func TestScanRepoCmd(t *testing.T) {
 
 	t.Run("repo command fails without token", func(t *testing.T) {
 		token = ""
+		clientID = ""
+		clientSecret = ""
 		tenantID = "test-tenant"
 		useDev = true
+		t.Setenv("ARMIS_API_TOKEN", "")
+		t.Setenv("ARMIS_CLIENT_ID", "")
+		t.Setenv("ARMIS_CLIENT_SECRET", "")
 		defer func() {
 			token = ""
+			clientID = ""
+			clientSecret = ""
 			tenantID = ""
 			useDev = false
 		}()
@@ -122,10 +129,17 @@ func TestScanRepoCmd(t *testing.T) {
 
 	t.Run("repo command fails without tenant ID", func(t *testing.T) {
 		token = testToken
+		clientID = ""
+		clientSecret = ""
 		tenantID = ""
 		useDev = true
+		t.Setenv("ARMIS_TENANT_ID", "")
+		t.Setenv("ARMIS_CLIENT_ID", "")
+		t.Setenv("ARMIS_CLIENT_SECRET", "")
 		defer func() {
 			token = ""
+			clientID = ""
+			clientSecret = ""
 			tenantID = ""
 			useDev = false
 		}()


### PR DESCRIPTION
## Related Issue

* [PPSC-790](https://armis-security.atlassian.net/browse/PPSC-790)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

When environment variables like `ARMIS_CLIENT_ID`, `ARMIS_CLIENT_SECRET`, `ARMIS_API_TOKEN`, `ARMIS_TENANT_ID`, or `ARMIS_REGION` are set, their values appear as flag defaults in `armis-cli --help` output. This leaks secrets to anyone who can view terminal output, logs, or CI job artifacts.

## Solution

Move environment variable resolution from Cobra flag default values to the `PersistentPreRunE` handler. Flag defaults are now empty strings — env vars are resolved at runtime only when no flag value was provided. The help text still documents which env var maps to which flag, but no longer displays actual values.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

1. Set `ARMIS_CLIENT_SECRET=super-secret`
2. Run `armis-cli --help`
3. Verify `--client-secret` shows default `""` (not `super-secret`)
4. Run `armis-cli scan repo .` — verify credentials still resolve correctly

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-790]: https://armis-security.atlassian.net/browse/PPSC-790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ