### PR TITLE
[PPSC-792] docs: update CHANGELOG for v1.8.4

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.4] - 2026-05-18
+
+### Added
+
+- Claude Desktop app as an install target for the `install` command (#179)
+
+### Fixed
+
+- Secrets no longer leak in `--help` output when default values contain credentials (#180)
+
+---
+
 ## [1.8.3] - 2026-05-13
 
 ### Changed
@@ -309,7 +321,8 @@ Manual entries for significant releases:
 
 -->
 
-[Unreleased]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.3...HEAD
+[Unreleased]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.4...HEAD
+[1.8.4]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.3...v1.8.4
 [1.8.3]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.2...v1.8.3
 [1.8.2]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.1...v1.8.2
 [1.8.1]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.0...v1.8.1


### PR DESCRIPTION
## Related Issue

* [PPSC-792](https://armis-security.atlassian.net/browse/PPSC-792)

## Type of Change

* [x] Documentation update

## Problem

The CHANGELOG needs to be updated to document what shipped in v1.8.4.

## Solution

Added a v1.8.4 entry to `docs/CHANGELOG.md` covering:
- **Added**: Claude Desktop app as an install target (`install` command, #179)
- **Fixed**: Secrets no longer leak in `--help` output when defaults contain credentials (#180)

Updated version comparison links at the bottom of the file.

## Testing

### Automated Tests

* [x] All tests passing locally (no code changes, docs only)

### Manual Testing

Verified markdown renders correctly and links point to correct comparison ranges.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-792]: https://armis-security.atlassian.net/browse/PPSC-792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ