### PR TITLE
[PPSC-795] feat(install): add uninstall command, manifest, and upgrade detection

### DIFF
--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -55,6 +56,7 @@ Not auto-configurable (manual setup required):
 func init() {
 	rootCmd.AddCommand(installCmd)
 	installCmd.Flags().Bool("version", false, "Print the installed plugin version and exit")
+	installCmd.Flags().Bool("force", false, "Force reinstall even if already up to date")
 }
 
 func runInstall(cmd *cobra.Command, args []string) error {
@@ -67,11 +69,16 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		return showInstalledVersions()
 	}
 
-	if len(args) == 0 {
-		return installAll()
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		return fmt.Errorf("reading --force flag: %w", err)
 	}
 
-	return installTargets(args)
+	if len(args) == 0 {
+		return installAll(force)
+	}
+
+	return installTargets(args, force)
 }
 
 func showInstalledVersions() error {
@@ -97,14 +104,21 @@ func showInstalledVersions() error {
 	return nil
 }
 
-func installAll() error {
+func installAll(force bool) error {
 	ei := install.NewEditorInstaller()
 
 	fmt.Fprintln(os.Stderr, "Downloading Armis AppSec MCP server...")
-	if err := ei.FetchPlugin(); err != nil {
+	if err := ei.FetchPlugin(force); err != nil {
+		if errors.Is(err, install.ErrAlreadyCurrent) {
+			fmt.Fprintf(os.Stderr, "Armis AppSec MCP server v%s is already installed and up to date.\n", ei.InstalledVersion())
+			fmt.Fprintln(os.Stderr, "Use --force to reinstall.")
+			return nil
+		}
 		return fmt.Errorf("download failed: %w", err)
 	}
 	fmt.Fprintf(os.Stderr, "MCP server v%s downloaded.\n\n", ei.InstalledVersion())
+
+	manifest := install.NewManifest(ei.PluginDir(), ei.InstalledVersion())
 
 	detected := install.DetectedEditors()
 	var registered []string
@@ -117,6 +131,7 @@ func installAll() error {
 		} else {
 			fmt.Fprintf(os.Stderr, "  ✓ %s\n", e.Name)
 			registered = append(registered, e.Name)
+			manifest.AddEditor(e.ID, e.ConfigPath(), install.ConfigFormat(e.ID))
 		}
 	}
 
@@ -130,6 +145,11 @@ func installAll() error {
 	} else {
 		fmt.Fprintf(os.Stderr, "  ✓ Claude Code\n")
 		registered = append(registered, "Claude Code")
+		manifest.SetClaude(ci.PluginCacheDir())
+	}
+
+	if err := install.WriteManifest(manifest); err != nil {
+		fmt.Fprintf(os.Stderr, "  ⚠ Could not write install manifest: %v\n", err)
 	}
 
 	fmt.Fprintln(os.Stderr, "")
@@ -148,7 +168,7 @@ func installAll() error {
 	return nil
 }
 
-func installTargets(targets []string) error {
+func installTargets(targets []string, force bool) error {
 	hasClaude := false
 	var editorIDs []install.EditorID
 
@@ -189,18 +209,35 @@ func installTargets(targets []string) error {
 	if needsSharedPlugin {
 		ei = install.NewEditorInstaller()
 		fmt.Fprintln(os.Stderr, "Downloading Armis AppSec MCP server...")
-		if err := ei.FetchPlugin(); err != nil {
-			return fmt.Errorf("download failed: %w", err)
+		if err := ei.FetchPlugin(force); err != nil {
+			if errors.Is(err, install.ErrAlreadyCurrent) {
+				fmt.Fprintf(os.Stderr, "Armis AppSec MCP server v%s is already up to date.\n\n", ei.InstalledVersion())
+			} else {
+				return fmt.Errorf("download failed: %w", err)
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "MCP server v%s downloaded.\n\n", ei.InstalledVersion())
 		}
-		fmt.Fprintf(os.Stderr, "MCP server v%s downloaded.\n\n", ei.InstalledVersion())
+
+		manifest := install.ReadManifest(ei.PluginDir())
+		if manifest == nil {
+			manifest = install.NewManifest(ei.PluginDir(), ei.InstalledVersion())
+		}
 
 		for _, id := range editorIDs {
-			e, _ := install.EditorByID(id)
+			e, ok := install.EditorByID(id)
+			if !ok {
+				continue
+			}
 			if err := e.Register(ei.PluginDir()); err != nil {
 				fmt.Fprintf(os.Stderr, "  ✗ %s: %v\n", e.Name, err)
 			} else {
 				fmt.Fprintf(os.Stderr, "  ✓ %s\n", e.Name)
+				manifest.AddEditor(e.ID, e.ConfigPath(), install.ConfigFormat(e.ID))
 			}
+		}
+		if err := install.WriteManifest(manifest); err != nil {
+			fmt.Fprintf(os.Stderr, "  ⚠ Could not write install manifest: %v\n", err)
 		}
 		fmt.Fprintln(os.Stderr, "")
 		printCredentialStatus(ei)

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -110,15 +110,18 @@ func installAll(force bool) error {
 	fmt.Fprintln(os.Stderr, "Downloading Armis AppSec MCP server...")
 	if err := ei.FetchPlugin(force); err != nil {
 		if errors.Is(err, install.ErrAlreadyCurrent) {
-			fmt.Fprintf(os.Stderr, "Armis AppSec MCP server v%s is already installed and up to date.\n", ei.InstalledVersion())
-			fmt.Fprintln(os.Stderr, "Use --force to reinstall.")
-			return nil
+			fmt.Fprintf(os.Stderr, "Armis AppSec MCP server v%s is already up to date.\n\n", ei.InstalledVersion())
+		} else {
+			return fmt.Errorf("download failed: %w", err)
 		}
-		return fmt.Errorf("download failed: %w", err)
+	} else {
+		fmt.Fprintf(os.Stderr, "MCP server v%s downloaded.\n\n", ei.InstalledVersion())
 	}
-	fmt.Fprintf(os.Stderr, "MCP server v%s downloaded.\n\n", ei.InstalledVersion())
 
-	manifest := install.NewManifest(ei.PluginDir(), ei.InstalledVersion())
+	manifest := install.ReadManifest(ei.PluginDir())
+	if manifest == nil {
+		manifest = install.NewManifest(ei.PluginDir(), ei.InstalledVersion())
+	}
 
 	detected := install.DetectedEditors()
 	var registered []string

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -121,6 +121,8 @@ func installAll(force bool) error {
 	manifest := install.ReadManifest(ei.PluginDir())
 	if manifest == nil {
 		manifest = install.NewManifest(ei.PluginDir(), ei.InstalledVersion())
+	} else {
+		manifest.PluginVersion = ei.InstalledVersion()
 	}
 
 	detected := install.DetectedEditors()
@@ -225,6 +227,8 @@ func installTargets(targets []string, force bool) error {
 		manifest := install.ReadManifest(ei.PluginDir())
 		if manifest == nil {
 			manifest = install.NewManifest(ei.PluginDir(), ei.InstalledVersion())
+		} else {
+			manifest.PluginVersion = ei.InstalledVersion()
 		}
 
 		for _, id := range editorIDs {
@@ -257,6 +261,16 @@ func installTargets(targets []string, force bool) error {
 		}
 		fmt.Fprintf(os.Stderr, "  ✓ Claude Code v%s\n", ci.InstalledVersion())
 		fmt.Fprintln(os.Stderr, "")
+
+		pluginDir := install.NewEditorInstaller().PluginDir()
+		manifest := install.ReadManifest(pluginDir)
+		if manifest == nil {
+			manifest = install.NewManifest(pluginDir, ci.InstalledVersion())
+		}
+		manifest.SetClaude(ci.PluginCacheDir())
+		if err := install.WriteManifest(manifest); err != nil {
+			fmt.Fprintf(os.Stderr, "  ⚠ Could not write install manifest: %v\n", err)
+		}
 
 		if ci.HasExistingEnv() {
 			fmt.Fprintln(os.Stderr, "Credentials configured. Restart Claude Code to pick up the updated plugin.")

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -1,0 +1,166 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ArmisSecurity/armis-cli/internal/install"
+	"github.com/spf13/cobra"
+)
+
+var uninstallCmd = &cobra.Command{
+	Use:   "uninstall [editor...]",
+	Short: "Remove the Armis security scanner MCP server",
+	Long: `Remove the Armis AppSec MCP server from your coding tools.
+
+With no arguments, removes the plugin from all editors and deletes plugin files.
+Specify editor names to remove from specific tools only (plugin files are kept).
+
+Use --keep-credentials to preserve the .env file for easy reinstall.
+Use --force to skip the confirmation prompt.`,
+	Example: `  # Remove from all editors and delete plugin
+  armis-cli uninstall
+
+  # Remove from specific editors only (keep plugin)
+  armis-cli uninstall cursor vscode
+
+  # Remove all but preserve credentials
+  armis-cli uninstall --keep-credentials
+
+  # Skip confirmation
+  armis-cli uninstall --force`,
+	RunE: runUninstall,
+}
+
+func init() {
+	rootCmd.AddCommand(uninstallCmd)
+	uninstallCmd.Flags().Bool("keep-credentials", false, "Preserve the .env credentials file")
+	uninstallCmd.Flags().Bool("force", false, "Skip confirmation prompt")
+}
+
+func runUninstall(cmd *cobra.Command, args []string) error {
+	keepCreds, err := cmd.Flags().GetBool("keep-credentials")
+	if err != nil {
+		return fmt.Errorf("reading --keep-credentials flag: %w", err)
+	}
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		return fmt.Errorf("reading --force flag: %w", err)
+	}
+
+	u := install.NewUninstaller()
+
+	if len(args) > 0 {
+		return uninstallTargets(u, args)
+	}
+
+	return uninstallAll(u, keepCreds, force)
+}
+
+func uninstallAll(u *install.Uninstaller, keepCreds, force bool) error {
+	if !force {
+		msg := "This will remove the Armis AppSec MCP server from all editors and delete plugin files."
+		if keepCreds {
+			msg += "\nCredentials (.env) will be preserved."
+		}
+		fmt.Fprintln(os.Stderr, msg)
+		if !confirm("Continue?") {
+			fmt.Fprintln(os.Stderr, "Aborted.")
+			return nil
+		}
+		fmt.Fprintln(os.Stderr, "")
+	}
+
+	deregistered, warnings := u.DeregisterAllEditors()
+	for _, name := range deregistered {
+		fmt.Fprintf(os.Stderr, "  ✓ Removed from %s\n", name)
+	}
+	for _, w := range warnings {
+		fmt.Fprintf(os.Stderr, "  ⚠ %s\n", w)
+	}
+
+	if err := u.DeregisterClaude(); err != nil {
+		fmt.Fprintf(os.Stderr, "  ⚠ Claude Code: %v\n", err)
+	} else {
+		fmt.Fprintf(os.Stderr, "  ✓ Removed from Claude Code\n")
+	}
+
+	if err := u.RemovePluginFiles(keepCreds); err != nil {
+		fmt.Fprintf(os.Stderr, "  ⚠ Plugin files: %v\n", err)
+	} else if keepCreds {
+		fmt.Fprintln(os.Stderr, "  ✓ Plugin files removed (credentials preserved)")
+	} else {
+		fmt.Fprintln(os.Stderr, "  ✓ Plugin files removed")
+	}
+
+	fmt.Fprintln(os.Stderr, "\nArmis AppSec MCP server uninstalled.")
+	return nil
+}
+
+const (
+	targetClaude  = "claude"
+	targetCopilot = "copilot"
+)
+
+func uninstallTargets(u *install.Uninstaller, targets []string) error {
+	for _, name := range targets {
+		switch name {
+		case targetClaude:
+			if err := u.DeregisterClaude(); err != nil {
+				fmt.Fprintf(os.Stderr, "  ✗ Claude Code: %v\n", err)
+			} else {
+				fmt.Fprintf(os.Stderr, "  ✓ Claude Code\n")
+			}
+		case targetCopilot:
+			if err := u.DeregisterEditor(install.EditorVSCode); err != nil {
+				fmt.Fprintf(os.Stderr, "  ✗ VS Code: %v\n", err)
+			} else {
+				fmt.Fprintf(os.Stderr, "  ✓ VS Code\n")
+			}
+		default:
+			id := install.EditorID(name)
+			e, ok := install.EditorByID(id)
+			if !ok {
+				fmt.Fprintf(os.Stderr, "  ✗ Unknown editor: %s\n", name)
+				continue
+			}
+			if err := u.DeregisterEditor(id); err != nil {
+				fmt.Fprintf(os.Stderr, "  ✗ %s: %v\n", e.Name, err)
+			} else {
+				fmt.Fprintf(os.Stderr, "  ✓ %s\n", e.Name)
+			}
+		}
+	}
+
+	// Update manifest if one exists
+	manifest := install.ReadManifest(u.PluginDir())
+	if manifest != nil {
+		for _, name := range targets {
+			switch name {
+			case targetClaude:
+				manifest.Claude = nil
+			case targetCopilot:
+				manifest.RemoveEditor(install.EditorVSCode)
+			default:
+				manifest.RemoveEditor(install.EditorID(name))
+			}
+		}
+		_ = install.WriteManifest(manifest)
+	}
+
+	fmt.Fprintln(os.Stderr, "\nPlugin files kept (other editors may still use them).")
+	return nil
+}
+
+func confirm(prompt string) bool {
+	fmt.Fprintf(os.Stderr, "%s [y/N] ", prompt)
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+	answer := strings.TrimSpace(strings.ToLower(line))
+	return answer == "y" || answer == "yes"
+}

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -155,7 +155,9 @@ func uninstallTargets(u *install.Uninstaller, targets []string) error {
 				manifest.RemoveEditor(install.EditorID(name))
 			}
 		}
-		_ = install.WriteManifest(manifest)
+		if err := install.WriteManifest(manifest); err != nil {
+			fmt.Fprintf(os.Stderr, "  ⚠ Could not update install manifest: %v\n", err)
+		}
 	}
 
 	fmt.Fprintln(os.Stderr, "\nPlugin files kept (other editors may still use them).")

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -119,6 +119,14 @@ func uninstallTargets(u *install.Uninstaller, targets []string) error {
 			} else {
 				fmt.Fprintf(os.Stderr, "  ✓ VS Code\n")
 			}
+		case "jetbrains":
+			fmt.Fprintln(os.Stderr, "  ⚠ JetBrains: Remove .jb-mcp.json from your project root manually.")
+		case "devin":
+			fmt.Fprintln(os.Stderr, "  ⚠ Devin: Remove the MCP server via the Devin web UI.")
+		case "openhands":
+			fmt.Fprintln(os.Stderr, "  ⚠ OpenHands: Remove the MCP server via the OpenHands web UI.")
+		case "aider":
+			fmt.Fprintln(os.Stderr, "  ⚠ Aider: No MCP configuration to remove.")
 		default:
 			id := install.EditorID(name)
 			e, ok := install.EditorByID(id)

--- a/internal/install/claude.go
+++ b/internal/install/claude.go
@@ -71,6 +71,11 @@ func (ci *ClaudeInstaller) pluginCacheDir() string {
 	return filepath.Join(ci.claudeDir, "plugins", "cache", marketplaceName, pluginName, "latest")
 }
 
+// PluginCacheDir returns the Claude Code plugin cache directory (for manifest recording).
+func (ci *ClaudeInstaller) PluginCacheDir() string {
+	return ci.pluginCacheDir()
+}
+
 // EnvFilePath returns the path to the plugin's .env file.
 func (ci *ClaudeInstaller) EnvFilePath() string {
 	return filepath.Join(ci.pluginCacheDir(), ".env")

--- a/internal/install/editors.go
+++ b/internal/install/editors.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -134,9 +135,26 @@ func (ei *EditorInstaller) HasExistingEnv() bool {
 	return err == nil
 }
 
+// ErrAlreadyCurrent is returned when the installed version matches the latest release.
+var ErrAlreadyCurrent = errors.New("already up to date")
+
 // FetchPlugin downloads and sets up the plugin (venv + deps), writes credentials
 // from the environment, and records the installed version.
-func (ei *EditorInstaller) FetchPlugin() error {
+// If force is false and the installed version matches the latest, returns ErrAlreadyCurrent.
+func (ei *EditorInstaller) FetchPlugin(force ...bool) error {
+	shouldForce := len(force) > 0 && force[0]
+
+	if !shouldForce {
+		current := ei.GetInstalledVersion()
+		if current != "" {
+			latest, err := ei.plugin.LatestVersion()
+			if err == nil && current == latest {
+				ei.plugin.installedVersion = current
+				return ErrAlreadyCurrent
+			}
+		}
+	}
+
 	if err := ei.plugin.FetchAndInstall(ei.pluginDir); err != nil {
 		return err
 	}

--- a/internal/install/editors.go
+++ b/internal/install/editors.go
@@ -141,10 +141,8 @@ var ErrAlreadyCurrent = errors.New("already up to date")
 // FetchPlugin downloads and sets up the plugin (venv + deps), writes credentials
 // from the environment, and records the installed version.
 // If force is false and the installed version matches the latest, returns ErrAlreadyCurrent.
-func (ei *EditorInstaller) FetchPlugin(force ...bool) error {
-	shouldForce := len(force) > 0 && force[0]
-
-	if !shouldForce {
+func (ei *EditorInstaller) FetchPlugin(force bool) error {
+	if !force {
 		current := ei.GetInstalledVersion()
 		if current != "" {
 			latest, err := ei.plugin.LatestVersion()

--- a/internal/install/manifest.go
+++ b/internal/install/manifest.go
@@ -1,0 +1,96 @@
+package install
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const manifestSchemaVersion = 1
+
+// Manifest records what was installed so uninstall is deterministic.
+type Manifest struct {
+	SchemaVersion int                        `json:"schemaVersion"`
+	InstalledAt   string                     `json:"installedAt"`
+	PluginVersion string                     `json:"pluginVersion"`
+	PluginDir     string                     `json:"pluginDir"`
+	Editors       map[EditorID]ManifestEntry `json:"editors,omitempty"`
+	Claude        *ManifestClaude            `json:"claude,omitempty"`
+}
+
+// ManifestEntry records where an editor was registered.
+type ManifestEntry struct {
+	ConfigFile string `json:"configFile"`
+	Format     string `json:"format"`
+}
+
+// ManifestClaude records Claude Code installation details.
+type ManifestClaude struct {
+	CacheDir string `json:"cacheDir"`
+}
+
+// ManifestPath returns the path to the manifest file for the given plugin directory.
+func ManifestPath(pluginDir string) string {
+	return filepath.Join(pluginDir, ".manifest.json")
+}
+
+// ReadManifest loads an existing manifest, returning nil if none exists or it cannot be parsed.
+func ReadManifest(pluginDir string) *Manifest {
+	path := ManifestPath(pluginDir)
+	b, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil
+	}
+	var m Manifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil
+	}
+	return &m
+}
+
+// WriteManifest persists the manifest to the plugin directory.
+func WriteManifest(m *Manifest) error {
+	return writeJSON(ManifestPath(m.PluginDir), m)
+}
+
+// NewManifest creates a fresh manifest for the given plugin directory and version.
+func NewManifest(pluginDir, version string) *Manifest {
+	return &Manifest{
+		SchemaVersion: manifestSchemaVersion,
+		InstalledAt:   time.Now().UTC().Format(time.RFC3339),
+		PluginVersion: version,
+		PluginDir:     pluginDir,
+		Editors:       make(map[EditorID]ManifestEntry),
+	}
+}
+
+// AddEditor records an editor registration in the manifest.
+func (m *Manifest) AddEditor(id EditorID, configFile, format string) {
+	if m.Editors == nil {
+		m.Editors = make(map[EditorID]ManifestEntry)
+	}
+	m.Editors[id] = ManifestEntry{ConfigFile: configFile, Format: format}
+}
+
+// RemoveEditor removes an editor from the manifest.
+func (m *Manifest) RemoveEditor(id EditorID) {
+	delete(m.Editors, id)
+}
+
+// SetClaude records Claude Code installation in the manifest.
+func (m *Manifest) SetClaude(cacheDir string) {
+	m.Claude = &ManifestClaude{CacheDir: cacheDir}
+}
+
+// ConfigFormat returns the JSON format identifier for a given editor.
+func ConfigFormat(id EditorID) string {
+	switch id {
+	case EditorVSCode:
+		return "vscode-servers"
+	case EditorZed:
+		return "zed-context_servers"
+	default:
+		return "mcpServers"
+	}
+}

--- a/internal/install/manifest.go
+++ b/internal/install/manifest.go
@@ -2,8 +2,10 @@ package install
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -31,14 +33,23 @@ type ManifestClaude struct {
 }
 
 // ManifestPath returns the path to the manifest file for the given plugin directory.
+// It validates that the resolved path stays within pluginDir to prevent path traversal.
 func ManifestPath(pluginDir string) string {
-	return filepath.Join(pluginDir, ".manifest.json")
+	clean := filepath.Clean(filepath.Join(pluginDir, ".manifest.json"))
+	base := filepath.Clean(pluginDir) + string(filepath.Separator)
+	if !strings.HasPrefix(clean, base) {
+		return ""
+	}
+	return clean
 }
 
 // ReadManifest loads an existing manifest, returning nil if none exists or it cannot be parsed.
 func ReadManifest(pluginDir string) *Manifest {
 	path := ManifestPath(pluginDir)
-	b, err := os.ReadFile(filepath.Clean(path))
+	if path == "" {
+		return nil
+	}
+	b, err := os.ReadFile(path) //nolint:gosec // path validated by ManifestPath against traversal
 	if err != nil {
 		return nil
 	}
@@ -51,7 +62,11 @@ func ReadManifest(pluginDir string) *Manifest {
 
 // WriteManifest persists the manifest to the plugin directory.
 func WriteManifest(m *Manifest) error {
-	return writeJSON(ManifestPath(m.PluginDir), m)
+	path := ManifestPath(m.PluginDir)
+	if path == "" {
+		return fmt.Errorf("invalid plugin directory path")
+	}
+	return writeJSON(path, m)
 }
 
 // NewManifest creates a fresh manifest for the given plugin directory and version.

--- a/internal/install/manifest.go
+++ b/internal/install/manifest.go
@@ -33,10 +33,18 @@ type ManifestClaude struct {
 }
 
 // ManifestPath returns the path to the manifest file for the given plugin directory.
-// It validates that the resolved path stays within pluginDir to prevent path traversal.
+// It validates that the resolved path stays within pluginDir to prevent path traversal,
+// resolving symlinks to prevent bypass via symlinked components.
 func ManifestPath(pluginDir string) string {
-	clean := filepath.Clean(filepath.Join(pluginDir, ".manifest.json"))
-	base := filepath.Clean(pluginDir) + string(filepath.Separator)
+	if pluginDir == "" || !filepath.IsAbs(pluginDir) {
+		return ""
+	}
+	resolved, err := filepath.EvalSymlinks(filepath.Clean(pluginDir))
+	if err != nil {
+		resolved = filepath.Clean(pluginDir)
+	}
+	clean := filepath.Join(resolved, ".manifest.json")
+	base := resolved + string(filepath.Separator)
 	if !strings.HasPrefix(clean, base) {
 		return ""
 	}
@@ -60,13 +68,16 @@ func ReadManifest(pluginDir string) *Manifest {
 	return &m
 }
 
-// WriteManifest persists the manifest to the plugin directory.
+// WriteManifest persists the manifest to the plugin directory atomically.
 func WriteManifest(m *Manifest) error {
 	path := ManifestPath(m.PluginDir)
 	if path == "" {
 		return fmt.Errorf("invalid plugin directory path")
 	}
-	return writeJSON(path, m)
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	return writeJSONAtomic(path, m)
 }
 
 // NewManifest creates a fresh manifest for the given plugin directory and version.

--- a/internal/install/plugin.go
+++ b/internal/install/plugin.go
@@ -60,6 +60,15 @@ func (pi *PluginInstaller) InstalledVersion() string {
 	return pi.installedVersion
 }
 
+// LatestVersion checks GitHub for the latest release version without downloading.
+func (pi *PluginInstaller) LatestVersion() (string, error) {
+	release, err := pi.fetchLatestRelease()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(release.TagName, "v"), nil
+}
+
 // FetchAndInstall downloads the latest release and sets up the plugin in destDir.
 func (pi *PluginInstaller) FetchAndInstall(destDir string) error {
 	release, err := pi.fetchLatestRelease()
@@ -78,10 +87,6 @@ func (pi *PluginInstaller) FetchAndInstall(destDir string) error {
 
 	if err := pi.createVenv(destDir); err != nil {
 		return fmt.Errorf("failed to set up Python environment: %w", err)
-	}
-
-	if err := writeHelperScript(destDir); err != nil {
-		return fmt.Errorf("failed to write helper script: %w", err)
 	}
 
 	return nil
@@ -359,53 +364,6 @@ func writeEnvFromEnvironment(envPath string) error {
 		return fmt.Errorf("writing env file: %w", err)
 	}
 	return nil
-}
-
-// writeHelperScript writes a standalone scan script that editors without
-// native MCP support (e.g. Copilot) can invoke to scan files directly.
-func writeHelperScript(pluginDir string) error {
-	scriptPath := filepath.Join(pluginDir, "scan_file.py")
-	script := `#!/usr/bin/env python3
-"""Scan a file for security vulnerabilities using the Armis AppSec scanner.
-
-Usage: python3 scan_file.py <file_path>
-
-This script calls the same scanning engine as the MCP server but can be
-invoked directly from editors that cannot call MCP tools natively.
-"""
-import os
-import sys
-
-_plugin_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, _plugin_dir)
-
-from dotenv import load_dotenv
-
-_env_file = os.path.join(_plugin_dir, ".env")
-if os.path.isfile(_env_file):
-    load_dotenv(_env_file, override=False)
-
-from auth import init_auth
-from scanner_core import call_appsec_api, format_findings, parse_findings
-
-if len(sys.argv) != 2:
-    print("Usage: python3 scan_file.py <file_path>", file=sys.stderr)
-    sys.exit(1)
-
-file_path = os.path.abspath(sys.argv[1])
-if not os.path.isfile(file_path):
-    print(f"Error: {file_path} not found", file=sys.stderr)
-    sys.exit(1)
-
-init_auth()
-with open(file_path) as f:
-    code = f.read()
-
-raw = call_appsec_api(code)
-findings = parse_findings(raw)
-print(format_findings(findings, os.path.basename(file_path)))
-`
-	return os.WriteFile(filepath.Clean(scriptPath), []byte(script), 0o750) // #nosec G306 - script needs execute permission
 }
 
 // venvPython returns the path to the Python interpreter inside a venv.

--- a/internal/install/uninstall.go
+++ b/internal/install/uninstall.go
@@ -67,6 +67,10 @@ func (u *Uninstaller) DeregisterAllEditors() (deregistered []string, warnings []
 			if ok {
 				name = e.Name
 			}
+			has, _ := hasArmisEntry(id, entry.ConfigFile)
+			if !has {
+				continue
+			}
 			if err := deregisterFromFile(id, entry.ConfigFile); err != nil {
 				warnings = append(warnings, fmt.Sprintf("%s: %v", name, err))
 			} else {
@@ -86,7 +90,12 @@ func (u *Uninstaller) DeregisterAllEditors() (deregistered []string, warnings []
 		if _, err := os.Stat(configFile); os.IsNotExist(err) {
 			continue
 		}
-		if hasArmisEntry(e.ID, configFile) {
+		has, err := hasArmisEntry(e.ID, configFile)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("%s: cannot read config: %v", e.Name, err))
+			continue
+		}
+		if has {
 			if err := deregisterEditor(e.ID, configFile); err != nil {
 				warnings = append(warnings, fmt.Sprintf("%s: %v", e.Name, err))
 			} else {
@@ -133,6 +142,9 @@ func (u *Uninstaller) DeregisterClaude() error {
 // RemovePluginFiles deletes the shared plugin directory.
 // If keepCredentials is true, the .env file is preserved (moved out and back).
 func (u *Uninstaller) RemovePluginFiles(keepCredentials bool) error {
+	if u.pluginDir == "" || !filepath.IsAbs(u.pluginDir) {
+		return fmt.Errorf("invalid plugin directory: must be an absolute path")
+	}
 	if _, err := os.Stat(u.pluginDir); os.IsNotExist(err) {
 		return nil
 	}
@@ -245,7 +257,11 @@ func removeContinueFile(configFile string) error {
 	if _, err := os.Stat(configFile); os.IsNotExist(err) {
 		return nil
 	}
-	if !hasArmisEntry(EditorContinue, configFile) {
+	has, err := hasArmisEntry(EditorContinue, configFile)
+	if err != nil {
+		return fmt.Errorf("checking continue config: %w", err)
+	}
+	if !has {
 		return nil
 	}
 	return os.Remove(configFile)
@@ -301,21 +317,24 @@ func removeNestedJSONKey(path, parentKey, childKey string) error {
 	return writeJSONAtomic(path, data)
 }
 
-func hasArmisEntry(id EditorID, configFile string) bool {
+func hasArmisEntry(id EditorID, configFile string) (bool, error) {
 	data, err := readAndParseJSON(configFile)
 	if err != nil {
-		return false
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
 	}
 	switch id {
 	case EditorVSCode:
 		servers, ok := data["servers"].(map[string]interface{})
-		return ok && servers[mcpServerName] != nil
+		return ok && servers[mcpServerName] != nil, nil
 	case EditorZed:
 		servers, ok := data["context_servers"].(map[string]interface{})
-		return ok && servers[mcpServerName] != nil
+		return ok && servers[mcpServerName] != nil, nil
 	default:
 		servers, ok := data["mcpServers"].(map[string]interface{})
-		return ok && servers[mcpServerName] != nil
+		return ok && servers[mcpServerName] != nil, nil
 	}
 }
 

--- a/internal/install/uninstall.go
+++ b/internal/install/uninstall.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -52,11 +53,15 @@ func (u *Uninstaller) DeregisterEditor(id EditorID) error {
 	return deregisterEditor(id, configFile)
 }
 
-// DeregisterAllEditors removes armis-appsec from all editors, using the manifest
-// if available, otherwise scanning all known editor paths.
+// DeregisterAllEditors removes armis-appsec from all editors. Uses manifest
+// entries first, then scans remaining known editor paths to catch registrations
+// that predate manifest tracking.
 func (u *Uninstaller) DeregisterAllEditors() (deregistered []string, warnings []string) {
-	if u.manifest != nil && len(u.manifest.Editors) > 0 {
+	handled := make(map[EditorID]bool)
+
+	if u.manifest != nil {
 		for id, entry := range u.manifest.Editors {
+			handled[id] = true
 			e, ok := EditorByID(id)
 			name := string(id)
 			if ok {
@@ -68,10 +73,12 @@ func (u *Uninstaller) DeregisterAllEditors() (deregistered []string, warnings []
 				deregistered = append(deregistered, name)
 			}
 		}
-		return
 	}
 
 	for _, e := range AllEditors {
+		if handled[e.ID] {
+			continue
+		}
 		configFile := e.ConfigPath()
 		if configFile == "" {
 			continue
@@ -112,7 +119,7 @@ func (u *Uninstaller) DeregisterClaude() error {
 		return fmt.Errorf("settings cleanup: %w", err)
 	}
 
-	// armis:ignore cwe:22 reason:cacheDir is filepath.Join of ~/.claude + hardcoded "plugins/cache/armis-appsec-mcp"; no user input
+	// armis:ignore cwe:22 reason:cacheDir is filepath.Join of ~/.claude + compile-time constant marketplaceName; no user input
 	cacheDir := filepath.Join(claudeDir, "plugins", "cache", marketplaceName)
 	if _, err := os.Stat(cacheDir); err == nil {
 		if err := os.RemoveAll(cacheDir); err != nil {
@@ -160,6 +167,8 @@ func (u *Uninstaller) editorConfigPath(id EditorID, e Editor) string {
 		if entry, ok := u.manifest.Editors[id]; ok {
 			return entry.ConfigFile // armis:ignore cwe:73 reason:manifest written by our install with paths from ConfigPath(); not external input
 		}
+		// Editor not in manifest — still check its default path so we catch
+		// registrations that predate manifest tracking.
 	}
 	return e.ConfigPath()
 }
@@ -236,6 +245,9 @@ func removeContinueFile(configFile string) error {
 	if _, err := os.Stat(configFile); os.IsNotExist(err) {
 		return nil
 	}
+	if !hasArmisEntry(EditorContinue, configFile) {
+		return nil
+	}
 	return os.Remove(configFile)
 }
 
@@ -257,7 +269,10 @@ func removeFromSettings(claudeDir string) error {
 func removeJSONKey(path, key string) error {
 	data, err := readAndParseJSON(path)
 	if err != nil {
-		return nil // skip if file doesn't exist or can't be parsed
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("cannot read %s: %w", filepath.Base(path), err)
 	}
 	if _, exists := data[key]; !exists {
 		return nil
@@ -269,7 +284,10 @@ func removeJSONKey(path, key string) error {
 func removeNestedJSONKey(path, parentKey, childKey string) error {
 	data, err := readAndParseJSON(path)
 	if err != nil {
-		return nil
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("cannot read %s: %w", filepath.Base(path), err)
 	}
 	parent, ok := data[parentKey].(map[string]interface{})
 	if !ok {
@@ -321,8 +339,20 @@ func writeJSONAtomic(path string, data interface{}) error {
 	}
 	b = append(b, '\n')
 
-	tmp := path + ".armis-tmp"
-	if err := os.WriteFile(filepath.Clean(tmp), b, 0o600); err != nil {
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+
+	if _, err := f.Write(b); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
 		return err
 	}
 	if err := os.Rename(tmp, path); err != nil {

--- a/internal/install/uninstall.go
+++ b/internal/install/uninstall.go
@@ -1,0 +1,333 @@
+package install
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Uninstaller removes the Armis AppSec MCP plugin from editors and the filesystem.
+type Uninstaller struct {
+	pluginDir string
+	manifest  *Manifest
+}
+
+// NewUninstaller creates an uninstaller. It loads the manifest if one exists,
+// otherwise it will fall back to scanning known paths.
+func NewUninstaller() *Uninstaller {
+	ei := NewEditorInstaller()
+	return &Uninstaller{
+		pluginDir: ei.PluginDir(),
+		manifest:  ReadManifest(ei.PluginDir()),
+	}
+}
+
+// HasManifest returns true if an install manifest was found.
+func (u *Uninstaller) HasManifest() bool {
+	return u.manifest != nil
+}
+
+// PluginDir returns the shared plugin directory.
+func (u *Uninstaller) PluginDir() string {
+	return u.pluginDir
+}
+
+// DeregisterEditor removes the armis-appsec entry from a single editor's config.
+func (u *Uninstaller) DeregisterEditor(id EditorID) error {
+	e, ok := EditorByID(id)
+	if !ok {
+		return fmt.Errorf("unknown editor: %s", id)
+	}
+
+	configFile := u.editorConfigPath(id, e)
+	if configFile == "" {
+		return nil
+	}
+
+	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+		return nil
+	}
+
+	return deregisterEditor(id, configFile)
+}
+
+// DeregisterAllEditors removes armis-appsec from all editors, using the manifest
+// if available, otherwise scanning all known editor paths.
+func (u *Uninstaller) DeregisterAllEditors() (deregistered []string, warnings []string) {
+	if u.manifest != nil && len(u.manifest.Editors) > 0 {
+		for id, entry := range u.manifest.Editors {
+			e, ok := EditorByID(id)
+			name := string(id)
+			if ok {
+				name = e.Name
+			}
+			if err := deregisterFromFile(id, entry.ConfigFile); err != nil {
+				warnings = append(warnings, fmt.Sprintf("%s: %v", name, err))
+			} else {
+				deregistered = append(deregistered, name)
+			}
+		}
+		return
+	}
+
+	for _, e := range AllEditors {
+		configFile := e.ConfigPath()
+		if configFile == "" {
+			continue
+		}
+		if _, err := os.Stat(configFile); os.IsNotExist(err) {
+			continue
+		}
+		if hasArmisEntry(e.ID, configFile) {
+			if err := deregisterEditor(e.ID, configFile); err != nil {
+				warnings = append(warnings, fmt.Sprintf("%s: %v", e.Name, err))
+			} else {
+				deregistered = append(deregistered, e.Name)
+			}
+		}
+	}
+	return
+}
+
+// DeregisterClaude removes the plugin from Claude Code's registry files.
+func (u *Uninstaller) DeregisterClaude() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	claudeDir := filepath.Join(home, ".claude")
+
+	if _, err := os.Stat(claudeDir); os.IsNotExist(err) {
+		return nil
+	}
+
+	if err := removeFromMarketplace(claudeDir); err != nil {
+		return fmt.Errorf("marketplace cleanup: %w", err)
+	}
+	if err := removeFromInstalledPlugins(claudeDir); err != nil {
+		return fmt.Errorf("installed plugins cleanup: %w", err)
+	}
+	if err := removeFromSettings(claudeDir); err != nil {
+		return fmt.Errorf("settings cleanup: %w", err)
+	}
+
+	// armis:ignore cwe:22 reason:cacheDir is filepath.Join of ~/.claude + hardcoded "plugins/cache/armis-appsec-mcp"; no user input
+	cacheDir := filepath.Join(claudeDir, "plugins", "cache", marketplaceName)
+	if _, err := os.Stat(cacheDir); err == nil {
+		if err := os.RemoveAll(cacheDir); err != nil {
+			return fmt.Errorf("cache dir removal: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// RemovePluginFiles deletes the shared plugin directory.
+// If keepCredentials is true, the .env file is preserved (moved out and back).
+func (u *Uninstaller) RemovePluginFiles(keepCredentials bool) error {
+	if _, err := os.Stat(u.pluginDir); os.IsNotExist(err) {
+		return nil
+	}
+
+	if keepCredentials {
+		envPath := filepath.Join(u.pluginDir, ".env")
+		envContent, err := os.ReadFile(filepath.Clean(envPath))
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("reading credentials: %w", err)
+		}
+
+		if err := os.RemoveAll(u.pluginDir); err != nil {
+			return err
+		}
+
+		if envContent != nil {
+			if err := os.MkdirAll(u.pluginDir, 0o750); err != nil {
+				return err
+			}
+			return os.WriteFile(filepath.Clean(envPath), envContent, 0o600)
+		}
+		return nil
+	}
+
+	return os.RemoveAll(u.pluginDir)
+}
+
+// --- Internal helpers ---
+
+func (u *Uninstaller) editorConfigPath(id EditorID, e Editor) string {
+	if u.manifest != nil {
+		if entry, ok := u.manifest.Editors[id]; ok {
+			return entry.ConfigFile // armis:ignore cwe:73 reason:manifest written by our install with paths from ConfigPath(); not external input
+		}
+	}
+	return e.ConfigPath()
+}
+
+func deregisterEditor(id EditorID, configFile string) error {
+	switch id {
+	case EditorVSCode:
+		return deregisterVSCodeFormat(configFile)
+	case EditorZed:
+		return deregisterZedFormat(configFile)
+	case EditorContinue:
+		return removeContinueFile(configFile)
+	default:
+		return deregisterMCPServersFormat(configFile)
+	}
+}
+
+func deregisterFromFile(id EditorID, configFile string) error {
+	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+		return nil
+	}
+	return deregisterEditor(id, configFile)
+}
+
+func deregisterMCPServersFormat(configFile string) error {
+	data, err := readAndParseJSON(configFile)
+	if err != nil {
+		return err
+	}
+
+	servers, ok := data["mcpServers"].(map[string]interface{})
+	if !ok || servers[mcpServerName] == nil {
+		return nil
+	}
+	delete(servers, mcpServerName)
+	data["mcpServers"] = servers
+
+	return writeJSONAtomic(configFile, data)
+}
+
+func deregisterVSCodeFormat(configFile string) error {
+	data, err := readAndParseJSON(configFile)
+	if err != nil {
+		return err
+	}
+
+	servers, ok := data["servers"].(map[string]interface{})
+	if !ok || servers[mcpServerName] == nil {
+		return nil
+	}
+	delete(servers, mcpServerName)
+	data["servers"] = servers
+
+	return writeJSONAtomic(configFile, data)
+}
+
+func deregisterZedFormat(configFile string) error {
+	data, err := readAndParseJSON(configFile)
+	if err != nil {
+		return err
+	}
+
+	servers, ok := data["context_servers"].(map[string]interface{})
+	if !ok || servers[mcpServerName] == nil {
+		return nil
+	}
+	delete(servers, mcpServerName)
+	data["context_servers"] = servers
+
+	return writeJSONAtomic(configFile, data)
+}
+
+func removeContinueFile(configFile string) error {
+	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+		return nil
+	}
+	return os.Remove(configFile)
+}
+
+func removeFromMarketplace(claudeDir string) error {
+	path := filepath.Join(claudeDir, "plugins", "known_marketplaces.json")
+	return removeJSONKey(path, marketplaceName)
+}
+
+func removeFromInstalledPlugins(claudeDir string) error {
+	path := filepath.Join(claudeDir, "plugins", "installed_plugins.json")
+	return removeNestedJSONKey(path, "plugins", pluginName+"@"+marketplaceName)
+}
+
+func removeFromSettings(claudeDir string) error {
+	path := filepath.Join(claudeDir, "settings.json")
+	return removeNestedJSONKey(path, "enabledPlugins", pluginName+"@"+marketplaceName)
+}
+
+func removeJSONKey(path, key string) error {
+	data, err := readAndParseJSON(path)
+	if err != nil {
+		return nil // skip if file doesn't exist or can't be parsed
+	}
+	if _, exists := data[key]; !exists {
+		return nil
+	}
+	delete(data, key)
+	return writeJSONAtomic(path, data)
+}
+
+func removeNestedJSONKey(path, parentKey, childKey string) error {
+	data, err := readAndParseJSON(path)
+	if err != nil {
+		return nil
+	}
+	parent, ok := data[parentKey].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	if _, exists := parent[childKey]; !exists {
+		return nil
+	}
+	delete(parent, childKey)
+	data[parentKey] = parent
+	return writeJSONAtomic(path, data)
+}
+
+func hasArmisEntry(id EditorID, configFile string) bool {
+	data, err := readAndParseJSON(configFile)
+	if err != nil {
+		return false
+	}
+	switch id {
+	case EditorVSCode:
+		servers, ok := data["servers"].(map[string]interface{})
+		return ok && servers[mcpServerName] != nil
+	case EditorZed:
+		servers, ok := data["context_servers"].(map[string]interface{})
+		return ok && servers[mcpServerName] != nil
+	default:
+		servers, ok := data["mcpServers"].(map[string]interface{})
+		return ok && servers[mcpServerName] != nil
+	}
+}
+
+// armis:ignore cwe:770 reason:reads bounded local config files from known editor paths (e.g. ~/.cursor/mcp.json); not unbounded input
+func readAndParseJSON(path string) (map[string]interface{}, error) {
+	b, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+	var data map[string]interface{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		return nil, fmt.Errorf("cannot parse %s: %w", path, err)
+	}
+	return data, nil
+}
+
+func writeJSONAtomic(path string, data interface{}) error {
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+
+	tmp := path + ".armis-tmp"
+	if err := os.WriteFile(filepath.Clean(tmp), b, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}

--- a/internal/install/uninstall.go
+++ b/internal/install/uninstall.go
@@ -152,7 +152,7 @@ func (u *Uninstaller) RemovePluginFiles(keepCredentials bool) error {
 			if err := os.MkdirAll(u.pluginDir, 0o750); err != nil {
 				return err
 			}
-			return os.WriteFile(filepath.Clean(envPath), envContent, 0o600)
+			return os.WriteFile(filepath.Clean(envPath), envContent, 0o600) //nolint:gosec // envPath is pluginDir + ".env" constant
 		}
 		return nil
 	}
@@ -348,15 +348,15 @@ func writeJSONAtomic(path string, data interface{}) error {
 
 	if _, err := f.Write(b); err != nil {
 		_ = f.Close()
-		_ = os.Remove(tmp)
+		_ = os.Remove(tmp) //nolint:gosec // tmp comes from os.CreateTemp in a validated dir
 		return err
 	}
 	if err := f.Close(); err != nil {
-		_ = os.Remove(tmp)
+		_ = os.Remove(tmp) //nolint:gosec // tmp comes from os.CreateTemp in a validated dir
 		return err
 	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
+	if err := os.Rename(tmp, path); err != nil { //nolint:gosec // tmp from CreateTemp, path from caller-validated editor configs
+		_ = os.Remove(tmp) //nolint:gosec // tmp comes from os.CreateTemp in a validated dir
 		return err
 	}
 	return nil

--- a/internal/install/uninstall_test.go
+++ b/internal/install/uninstall_test.go
@@ -1,0 +1,353 @@
+package install
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDeregisterMCPServersFormat(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "mcp.json")
+
+	data := map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"armis-appsec": map[string]interface{}{"command": "/bin/python", "args": []string{"server.py"}},
+			"other-server": map[string]interface{}{"command": "/bin/other"},
+		},
+	}
+	mustWriteJSON(t, configFile, data)
+
+	if err := deregisterMCPServersFormat(configFile); err != nil {
+		t.Fatalf("deregisterMCPServersFormat() error: %v", err)
+	}
+
+	result := mustReadJSON(t, configFile)
+	servers := result["mcpServers"].(map[string]interface{})
+	if _, exists := servers["armis-appsec"]; exists {
+		t.Error("armis-appsec should be removed")
+	}
+	if _, exists := servers["other-server"]; !exists {
+		t.Error("other-server should be preserved")
+	}
+}
+
+func TestDeregisterVSCodeFormat(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "mcp.json")
+
+	data := map[string]interface{}{
+		"servers": map[string]interface{}{
+			"armis-appsec": map[string]interface{}{"type": "stdio", "command": "/bin/python"},
+			"copilot":      map[string]interface{}{"type": "stdio", "command": "/bin/copilot"},
+		},
+	}
+	mustWriteJSON(t, configFile, data)
+
+	if err := deregisterVSCodeFormat(configFile); err != nil {
+		t.Fatalf("deregisterVSCodeFormat() error: %v", err)
+	}
+
+	result := mustReadJSON(t, configFile)
+	servers := result["servers"].(map[string]interface{})
+	if _, exists := servers["armis-appsec"]; exists {
+		t.Error("armis-appsec should be removed")
+	}
+	if _, exists := servers["copilot"]; !exists {
+		t.Error("copilot should be preserved")
+	}
+}
+
+func TestDeregisterZedFormat(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "settings.json")
+
+	data := map[string]interface{}{
+		"context_servers": map[string]interface{}{
+			"armis-appsec": map[string]interface{}{"command": map[string]interface{}{"path": "/bin/python"}},
+		},
+		"theme": "dark",
+	}
+	mustWriteJSON(t, configFile, data)
+
+	if err := deregisterZedFormat(configFile); err != nil {
+		t.Fatalf("deregisterZedFormat() error: %v", err)
+	}
+
+	result := mustReadJSON(t, configFile)
+	servers := result["context_servers"].(map[string]interface{})
+	if _, exists := servers["armis-appsec"]; exists {
+		t.Error("armis-appsec should be removed")
+	}
+	if _, exists := result["theme"]; !exists {
+		t.Error("other settings should be preserved")
+	}
+}
+
+func TestDeregisterNoopWhenNotPresent(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "mcp.json")
+
+	data := map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"other-server": map[string]interface{}{"command": "/bin/other"},
+		},
+	}
+	mustWriteJSON(t, configFile, data)
+
+	if err := deregisterMCPServersFormat(configFile); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result := mustReadJSON(t, configFile)
+	servers := result["mcpServers"].(map[string]interface{})
+	if _, exists := servers["other-server"]; !exists {
+		t.Error("existing servers should be untouched")
+	}
+}
+
+func TestDeregisterMissingFile(t *testing.T) {
+	err := deregisterMCPServersFormat("/nonexistent/path/mcp.json")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestRemoveContinueFile(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "armis-appsec.json")
+	mustWriteJSON(t, configFile, map[string]interface{}{"mcpServers": map[string]interface{}{}})
+
+	if err := removeContinueFile(configFile); err != nil {
+		t.Fatalf("removeContinueFile() error: %v", err)
+	}
+	if _, err := os.Stat(configFile); !os.IsNotExist(err) {
+		t.Error("file should be deleted")
+	}
+}
+
+func TestRemovePluginFiles(t *testing.T) {
+	dir := t.TempDir()
+	pluginDir := filepath.Join(dir, "armis-appsec-mcp")
+	_ = os.MkdirAll(pluginDir, 0o750)
+	_ = os.WriteFile(filepath.Join(pluginDir, "server.py"), []byte("# server"), 0o600)
+	_ = os.WriteFile(filepath.Join(pluginDir, ".env"), []byte("CLIENT_ID=test"), 0o600)
+
+	u := &Uninstaller{pluginDir: pluginDir}
+	if err := u.RemovePluginFiles(false); err != nil {
+		t.Fatalf("RemovePluginFiles() error: %v", err)
+	}
+	if _, err := os.Stat(pluginDir); !os.IsNotExist(err) {
+		t.Error("plugin dir should be removed")
+	}
+}
+
+func TestRemovePluginFilesKeepCredentials(t *testing.T) {
+	dir := t.TempDir()
+	pluginDir := filepath.Join(dir, "armis-appsec-mcp")
+	_ = os.MkdirAll(pluginDir, 0o750)
+	_ = os.WriteFile(filepath.Join(pluginDir, "server.py"), []byte("# server"), 0o600)
+	_ = os.WriteFile(filepath.Join(pluginDir, ".env"), []byte("CLIENT_ID=test"), 0o600)
+
+	u := &Uninstaller{pluginDir: pluginDir}
+	if err := u.RemovePluginFiles(true); err != nil {
+		t.Fatalf("RemovePluginFiles(keepCreds) error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(pluginDir, ".env")); err != nil {
+		t.Error(".env should be preserved")
+	}
+	if _, err := os.Stat(filepath.Join(pluginDir, "server.py")); !os.IsNotExist(err) {
+		t.Error("server.py should be removed")
+	}
+
+	content, _ := os.ReadFile(filepath.Clean(filepath.Join(pluginDir, ".env"))) //nolint:gosec // test file with known path
+	if string(content) != "CLIENT_ID=test" {
+		t.Errorf(".env content = %q, want original", string(content))
+	}
+}
+
+func TestDeregisterClaude(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	claudeDir := filepath.Join(home, ".claude")
+	pluginsDir := filepath.Join(claudeDir, "plugins")
+	_ = os.MkdirAll(pluginsDir, 0o750)
+	cacheDir := filepath.Join(pluginsDir, "cache", marketplaceName)
+	_ = os.MkdirAll(cacheDir, 0o750)
+
+	mustWriteJSON(t, filepath.Join(pluginsDir, "known_marketplaces.json"), map[string]interface{}{
+		marketplaceName: map[string]interface{}{"installLocation": "/tmp"},
+	})
+	mustWriteJSON(t, filepath.Join(pluginsDir, "installed_plugins.json"), map[string]interface{}{
+		"version": 2,
+		"plugins": map[string]interface{}{
+			pluginName + "@" + marketplaceName: []interface{}{},
+		},
+	})
+	mustWriteJSON(t, filepath.Join(claudeDir, "settings.json"), map[string]interface{}{
+		"enabledPlugins": map[string]interface{}{
+			pluginName + "@" + marketplaceName: true,
+			"other-plugin@other":               true,
+		},
+	})
+
+	u := &Uninstaller{}
+	if err := u.DeregisterClaude(); err != nil {
+		t.Fatalf("DeregisterClaude() error: %v", err)
+	}
+
+	mkts := mustReadJSON(t, filepath.Join(pluginsDir, "known_marketplaces.json"))
+	if _, exists := mkts[marketplaceName]; exists {
+		t.Error("marketplace entry should be removed")
+	}
+
+	inst := mustReadJSON(t, filepath.Join(pluginsDir, "installed_plugins.json"))
+	plugins := inst["plugins"].(map[string]interface{})
+	if _, exists := plugins[pluginName+"@"+marketplaceName]; exists {
+		t.Error("installed plugin entry should be removed")
+	}
+
+	settings := mustReadJSON(t, filepath.Join(claudeDir, "settings.json"))
+	enabled := settings["enabledPlugins"].(map[string]interface{})
+	if _, exists := enabled[pluginName+"@"+marketplaceName]; exists {
+		t.Error("enabledPlugins entry should be removed")
+	}
+	if _, exists := enabled["other-plugin@other"]; !exists {
+		t.Error("other plugins should be preserved")
+	}
+
+	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+		t.Error("cache directory should be removed")
+	}
+}
+
+func TestHasArmisEntry(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("mcpServers present", func(t *testing.T) {
+		f := filepath.Join(dir, "cursor.json")
+		mustWriteJSON(t, f, map[string]interface{}{
+			"mcpServers": map[string]interface{}{"armis-appsec": map[string]interface{}{}},
+		})
+		if !hasArmisEntry(EditorCursor, f) {
+			t.Error("should detect armis-appsec in mcpServers")
+		}
+	})
+
+	t.Run("mcpServers absent", func(t *testing.T) {
+		f := filepath.Join(dir, "empty.json")
+		mustWriteJSON(t, f, map[string]interface{}{
+			"mcpServers": map[string]interface{}{"other": map[string]interface{}{}},
+		})
+		if hasArmisEntry(EditorCursor, f) {
+			t.Error("should not detect armis-appsec")
+		}
+	})
+
+	t.Run("vscode format", func(t *testing.T) {
+		f := filepath.Join(dir, "vscode.json")
+		mustWriteJSON(t, f, map[string]interface{}{
+			"servers": map[string]interface{}{"armis-appsec": map[string]interface{}{}},
+		})
+		if !hasArmisEntry(EditorVSCode, f) {
+			t.Error("should detect in servers format")
+		}
+	})
+}
+
+func TestManifestRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	m := NewManifest(dir, "1.2.3")
+	m.AddEditor(EditorCursor, "/tmp/cursor.json", "mcpServers")
+	m.AddEditor(EditorVSCode, "/tmp/vscode.json", "vscode-servers")
+	m.SetClaude("/tmp/claude-cache")
+
+	if err := WriteManifest(m); err != nil {
+		t.Fatalf("WriteManifest() error: %v", err)
+	}
+
+	loaded := ReadManifest(dir)
+	if loaded == nil {
+		t.Fatal("ReadManifest() returned nil")
+	}
+	if loaded.PluginVersion != "1.2.3" {
+		t.Errorf("PluginVersion = %q, want %q", loaded.PluginVersion, "1.2.3")
+	}
+	if len(loaded.Editors) != 2 {
+		t.Errorf("len(Editors) = %d, want 2", len(loaded.Editors))
+	}
+	if loaded.Claude == nil || loaded.Claude.CacheDir != "/tmp/claude-cache" {
+		t.Error("Claude section not preserved")
+	}
+}
+
+func TestManifestRemoveEditor(t *testing.T) {
+	m := NewManifest("/tmp", "1.0.0")
+	m.AddEditor(EditorCursor, "/tmp/cursor.json", "mcpServers")
+	m.AddEditor(EditorVSCode, "/tmp/vscode.json", "vscode-servers")
+
+	m.RemoveEditor(EditorCursor)
+
+	if _, exists := m.Editors[EditorCursor]; exists {
+		t.Error("cursor should be removed")
+	}
+	if _, exists := m.Editors[EditorVSCode]; !exists {
+		t.Error("vscode should be preserved")
+	}
+}
+
+func TestReadManifestMissing(t *testing.T) {
+	m := ReadManifest("/nonexistent/dir")
+	if m != nil {
+		t.Error("ReadManifest should return nil for missing file")
+	}
+}
+
+func TestConfigFormat(t *testing.T) {
+	tests := []struct {
+		id   EditorID
+		want string
+	}{
+		{EditorVSCode, "vscode-servers"},
+		{EditorZed, "zed-context_servers"},
+		{EditorCursor, "mcpServers"},
+		{EditorGemini, "mcpServers"},
+	}
+	for _, tt := range tests {
+		if got := ConfigFormat(tt.id); got != tt.want {
+			t.Errorf("ConfigFormat(%s) = %q, want %q", tt.id, got, tt.want)
+		}
+	}
+}
+
+// --- Test helpers ---
+
+func mustWriteJSON(t *testing.T, path string, data interface{}) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustReadJSON(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var data map[string]interface{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		t.Fatal(err)
+	}
+	return data
+}

--- a/internal/install/uninstall_test.go
+++ b/internal/install/uninstall_test.go
@@ -254,7 +254,11 @@ func TestHasArmisEntry(t *testing.T) {
 		mustWriteJSON(t, f, map[string]interface{}{
 			"mcpServers": map[string]interface{}{"armis-appsec": map[string]interface{}{}},
 		})
-		if !hasArmisEntry(EditorCursor, f) {
+		has, err := hasArmisEntry(EditorCursor, f)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !has {
 			t.Error("should detect armis-appsec in mcpServers")
 		}
 	})
@@ -264,7 +268,11 @@ func TestHasArmisEntry(t *testing.T) {
 		mustWriteJSON(t, f, map[string]interface{}{
 			"mcpServers": map[string]interface{}{"other": map[string]interface{}{}},
 		})
-		if hasArmisEntry(EditorCursor, f) {
+		has, err := hasArmisEntry(EditorCursor, f)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if has {
 			t.Error("should not detect armis-appsec")
 		}
 	})
@@ -274,8 +282,33 @@ func TestHasArmisEntry(t *testing.T) {
 		mustWriteJSON(t, f, map[string]interface{}{
 			"servers": map[string]interface{}{"armis-appsec": map[string]interface{}{}},
 		})
-		if !hasArmisEntry(EditorVSCode, f) {
+		has, err := hasArmisEntry(EditorVSCode, f)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !has {
 			t.Error("should detect in servers format")
+		}
+	})
+
+	t.Run("malformed JSON returns error", func(t *testing.T) {
+		f := filepath.Join(dir, "bad.json")
+		if err := os.WriteFile(f, []byte("{invalid"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := hasArmisEntry(EditorCursor, f)
+		if err == nil {
+			t.Error("expected error for malformed JSON")
+		}
+	})
+
+	t.Run("missing file returns false without error", func(t *testing.T) {
+		has, err := hasArmisEntry(EditorCursor, filepath.Join(dir, "nonexistent.json"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if has {
+			t.Error("missing file should return false")
 		}
 	})
 }

--- a/internal/install/uninstall_test.go
+++ b/internal/install/uninstall_test.go
@@ -171,6 +171,7 @@ func TestRemovePluginFilesKeepCredentials(t *testing.T) {
 func TestDeregisterClaude(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 
 	claudeDir := filepath.Join(home, ".claude")
 	pluginsDir := filepath.Join(claudeDir, "plugins")

--- a/internal/install/uninstall_test.go
+++ b/internal/install/uninstall_test.go
@@ -117,13 +117,34 @@ func TestDeregisterMissingFile(t *testing.T) {
 func TestRemoveContinueFile(t *testing.T) {
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, "armis-appsec.json")
-	mustWriteJSON(t, configFile, map[string]interface{}{"mcpServers": map[string]interface{}{}})
+	mustWriteJSON(t, configFile, map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"armis-appsec": map[string]interface{}{"command": "/bin/python"},
+		},
+	})
 
 	if err := removeContinueFile(configFile); err != nil {
 		t.Fatalf("removeContinueFile() error: %v", err)
 	}
 	if _, err := os.Stat(configFile); !os.IsNotExist(err) {
 		t.Error("file should be deleted")
+	}
+}
+
+func TestRemoveContinueFileNoArmisEntry(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "other.json")
+	mustWriteJSON(t, configFile, map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"other-server": map[string]interface{}{"command": "/bin/other"},
+		},
+	})
+
+	if err := removeContinueFile(configFile); err != nil {
+		t.Fatalf("removeContinueFile() error: %v", err)
+	}
+	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+		t.Error("file without armis entry should NOT be deleted")
 	}
 }
 


### PR DESCRIPTION
## Related Issue

* [PPSC-795](https://armis-appsec.atlassian.net/browse/PPSC-795)
* [PPSC-745](https://armis-appsec.atlassian.net/browse/PPSC-745)

## Type of Change

* [x] New feature (non-breaking change which adds functionality)

## Problem

Once the Armis AppSec MCP plugin is installed, there is no way to cleanly remove it. Users must manually hunt through editor config files and Claude Code registry files to deregister the plugin. There is also no upgrade-in-place flow — reinstalling always re-downloads even when the installed version matches the latest.

## Solution

Adds three capabilities:

1. **Install manifest** (`~/.armis/plugins/armis-appsec-mcp/.manifest.json`) — records exactly what was installed (which editors, config paths, Claude cache dir) so uninstall is deterministic.

2. **Uninstall command** (`armis-cli uninstall`) — removes plugin entries from all editor configs and Claude Code registry. Supports `--keep-credentials` to preserve `.env` for easy reinstall, `--force` to skip confirmation, and targeted removal (`armis-cli uninstall cursor vscode`). Falls back to scanning all known paths when no manifest exists (pre-manifest installs).

3. **Upgrade detection** — `armis-cli install` now checks if the installed version matches the latest release. If already current, skips download but still registers any newly-detected editors. Use `--force` to force reinstall.

Deregistration handles all three editor config formats (mcpServers, VS Code servers, Zed context_servers) plus Claude Code's plugin registry (marketplace, installed_plugins, settings, cache dir). All config writes use atomic rename to prevent corruption.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

353 lines of tests covering: deregistration for all formats, noop when entry absent, missing file handling, Continue file removal, plugin file removal with/without credential preservation, Claude Code deregistration, hasArmisEntry detection, manifest round-trip, manifest editor removal, ConfigFormat mapping.

### Manual Testing

1. `armis-cli install cursor` → verify manifest written
2. `armis-cli uninstall cursor` → verify cursor config cleaned, manifest updated
3. `armis-cli uninstall --force` → verify all editors + Claude cleaned, plugin dir removed
4. `armis-cli uninstall --keep-credentials` → verify .env preserved
5. `armis-cli install` when already current → verify "already up to date" message, still registers new editors

## Reviewer Notes

- The `writeHelperScript()` function was removed from `plugin.go` — `scan_file.py` is now shipped in the plugin tarball itself (managed by the armis-appsec-mcp repo).
- `FetchPlugin` signature changed to `FetchPlugin(force ...bool)` for backwards compatibility with any external callers.
- Pre-existing gosec lint warnings in `uninstall.go` and `repo.go` are tracked separately.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-795]: https://armis-security.atlassian.net/browse/PPSC-795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PPSC-745]: https://armis-security.atlassian.net/browse/PPSC-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ