### PR TITLE
[PPSC-797] fix(install): probe versioned Python binaries in findPython

### DIFF
--- a/internal/install/plugin.go
+++ b/internal/install/plugin.go
@@ -35,6 +35,8 @@ const (
 	maxArchiveEntries = 10000             // max tar entries to prevent resource exhaustion
 )
 
+var pythonCandidates = []string{"python3.13", "python3.12", "python3.11", "python3", "python"}
+
 type githubRelease struct {
 	TagName    string `json:"tag_name"`
 	TarballURL string `json:"tarball_url"`
@@ -246,7 +248,7 @@ func (pi *PluginInstaller) downloadAndExtract(tarballURL, destDir string) error 
 func (pi *PluginInstaller) createVenv(pluginDir string) error {
 	python := findPython()
 	if python == "" {
-		return fmt.Errorf("Python 3.11+ is required but not found in PATH (tried python3.13, python3.12, python3.11, python3, python)") //nolint:staticcheck // proper noun
+		return fmt.Errorf("Python 3.11+ is required but not found in PATH (tried %s)", strings.Join(pythonCandidates, ", ")) //nolint:staticcheck // proper noun
 	}
 
 	venvDir := filepath.Join(pluginDir, ".venv")
@@ -311,7 +313,7 @@ func writeJSON(path string, data interface{}) error {
 }
 
 func findPython() string {
-	for _, name := range []string{"python3.13", "python3.12", "python3.11", "python3", "python"} {
+	for _, name := range pythonCandidates {
 		resolved, err := exec.LookPath(name)
 		if err != nil {
 			continue

--- a/internal/install/plugin.go
+++ b/internal/install/plugin.go
@@ -246,7 +246,7 @@ func (pi *PluginInstaller) downloadAndExtract(tarballURL, destDir string) error 
 func (pi *PluginInstaller) createVenv(pluginDir string) error {
 	python := findPython()
 	if python == "" {
-		return fmt.Errorf("Python 3.11+ is required but not found in PATH") //nolint:staticcheck // proper noun
+		return fmt.Errorf("Python 3.11+ is required but not found in PATH (tried python3.13, python3.12, python3.11, python3, python)") //nolint:staticcheck // proper noun
 	}
 
 	venvDir := filepath.Join(pluginDir, ".venv")
@@ -311,7 +311,7 @@ func writeJSON(path string, data interface{}) error {
 }
 
 func findPython() string {
-	for _, name := range []string{"python3", "python"} {
+	for _, name := range []string{"python3.13", "python3.12", "python3.11", "python3", "python"} {
 		resolved, err := exec.LookPath(name)
 		if err != nil {
 			continue


### PR DESCRIPTION
## Related Issue

* [PPSC-797](https://armis-security.atlassian.net/browse/PPSC-797)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

`armis-cli install claude-desktop` fails with "Python 3.11+ is required but not found in PATH" on systems where Homebrew installs Python as a versioned binary (e.g. `python3.11`, `python3.12`) without creating an unversioned `python3` symlink. The `findPython()` function only probed `python3` and `python`.

## Solution

Expand the candidate list to include `python3.13`, `python3.12`, `python3.11` (newest first) before falling back to `python3` and `python`. The existing version validation (`sys.version_info >= (3, 11)`) already ensures any found binary meets the minimum requirement. Also improved the error message to list all candidates tried.

## Testing

### Automated Tests

* [x] All tests passing locally

### Manual Testing

Verified `findPython()` resolves correctly on macOS with Homebrew Python (versioned binary only in PATH).

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-797]: https://armis-security.atlassian.net/browse/PPSC-797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ