### PR TITLE
[PPSC-812] docs: update CHANGELOG for v1.9.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.9.0] - 2026-05-21
+
+### Added
+
+- `uninstall` command for cleanly removing installed plugins, with manifest tracking and upgrade detection (#182)
+
+### Fixed
+
+- Suppressed findings are now excluded from SARIF output, allowing GitHub Code Scanning alerts to auto-close when findings are suppressed via `.armisignore` or inline directives (#185)
+- Python binary discovery now probes versioned names (`python3.11`, `python3.12`, etc.) in addition to `python3` and `python`, resolving install failures on systems without a generic `python3` symlink (#184)
+
+---
+
 ## [1.8.4] - 2026-05-18
 
 ### Added
@@ -321,7 +334,8 @@ Manual entries for significant releases:
 
 -->
 
-[Unreleased]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.4...HEAD
+[Unreleased]: https://github.com/ArmisSecurity/armis-cli/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.4...v1.9.0
 [1.8.4]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.3...v1.8.4
 [1.8.3]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.2...v1.8.3
 [1.8.2]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.1...v1.8.2


### PR DESCRIPTION
## Summary

- Updates CHANGELOG.md with the v1.9.0 release section
- Covers 3 commits since v1.8.4: uninstall command (feat), SARIF suppression fix, Python binary discovery fix

## Release checklist

- [x] CHANGELOG.md updated
- [x] Jira ticket created: [PPSC-812](https://armis-security.atlassian.net/browse/PPSC-812)
- [x] Branch renamed to `chore/PPSC-812-release-v1-9-0`
- [ ] PR merged
- [ ] Tag `v1.9.0` created
- [ ] GitHub Release published
- [ ] Homebrew formula updated
- [ ] Slack announcement posted

[PPSC-812]: https://armis-security.atlassian.net/browse/PPSC-812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ