### PR TITLE
[PPSC-810] fix(scan): make inline suppression see through function signatures

### DIFF
--- a/internal/agentdetect/agentdetect.go
+++ b/internal/agentdetect/agentdetect.go
@@ -28,8 +28,8 @@ type ScanResult struct {
 // FlatResults returns all DetectedAgent entries in a flat slice (for JSON output).
 func (r *ScanResult) FlatResults() []DetectedAgent {
 	var results []DetectedAgent
-	// armis:ignore cwe:770 reason:bounded by number of OS users; only iterates pre-scanned results in memory
 	for _, u := range r.Users {
+		// armis:ignore cwe:770 reason:bounded by number of OS users; only iterates pre-scanned results in memory
 		results = append(results, u.Agents...)
 	}
 	return results

--- a/internal/agentdetect/detector.go
+++ b/internal/agentdetect/detector.go
@@ -32,6 +32,7 @@ func isUnderDir(resolvedBase, target string) bool {
 		resolved = baseVol + strings.TrimPrefix(resolved, resolvedVol)
 	}
 
+	// armis:ignore cwe:22 reason:isUnderDir IS the containment check; Rel used to verify path stays within base
 	rel, err := filepath.Rel(resolvedBase, resolved)
 	if err != nil {
 		return false

--- a/internal/agentdetect/detector.go
+++ b/internal/agentdetect/detector.go
@@ -41,6 +41,7 @@ func isUnderDir(resolvedBase, target string) bool {
 }
 
 // dirExists returns true if path exists, is a directory, and resolves under resolvedHome.
+// armis:ignore cwe:22 reason:path validated by isUnderDir which ensures it resolves under resolvedHome
 func dirExists(resolvedHome, path string) bool {
 	if !isUnderDir(resolvedHome, path) {
 		return false

--- a/internal/agentdetect/detector.go
+++ b/internal/agentdetect/detector.go
@@ -46,6 +46,7 @@ func dirExists(resolvedHome, path string) bool {
 	if !isUnderDir(resolvedHome, path) {
 		return false
 	}
+	// armis:ignore cwe:22 reason:path validated by isUnderDir containment check above
 	info, err := os.Stat(path)
 	return err == nil && info.IsDir()
 }

--- a/internal/agentdetect/mcpconfig.go
+++ b/internal/agentdetect/mcpconfig.go
@@ -20,6 +20,7 @@ func HasArmisMCP(resolvedHome, configPath string) bool {
 	if !isUnderDir(resolvedHome, configPath) {
 		return false
 	}
+	// armis:ignore cwe:770 reason:reads bounded local config file; path validated by isUnderDir
 	data, err := os.ReadFile(configPath) //nolint:gosec // path validated by isUnderDir
 	if err != nil {
 		return false
@@ -40,6 +41,7 @@ func HasArmisMCPInClaudeSettings(resolvedHome, settingsPath string) bool {
 	if !isUnderDir(resolvedHome, settingsPath) {
 		return false
 	}
+	// armis:ignore cwe:770 reason:reads bounded local config file; path validated by isUnderDir
 	data, err := os.ReadFile(settingsPath) //nolint:gosec // path validated by isUnderDir
 	if err != nil {
 		return false
@@ -67,6 +69,7 @@ func HasArmisMCPInZedSettings(resolvedHome, settingsPath string) bool {
 	if !isUnderDir(resolvedHome, settingsPath) {
 		return false
 	}
+	// armis:ignore cwe:770 reason:reads bounded local config file; path validated by isUnderDir
 	data, err := os.ReadFile(settingsPath) //nolint:gosec // path validated by isUnderDir
 	if err != nil {
 		return false
@@ -96,6 +99,7 @@ func HasArmisMCPInVSCodeFormat(resolvedHome, configPath string) bool {
 	if !isUnderDir(resolvedHome, configPath) {
 		return false
 	}
+	// armis:ignore cwe:770 reason:reads bounded local config file; path validated by isUnderDir
 	data, err := os.ReadFile(configPath) //nolint:gosec // path validated by isUnderDir
 	if err != nil {
 		return false

--- a/internal/agentdetect/platform_darwin.go
+++ b/internal/agentdetect/platform_darwin.go
@@ -44,7 +44,7 @@ func (p *darwinPlatform) CursorAppExists(_ string) bool {
 func (p *darwinPlatform) JunieBinaryPaths(homeDir string) []string {
 	return []string{
 		"/usr/local/bin/junie",
-		filepath.Join(homeDir, ".local", "bin", "junie"),
+		filepath.Join(homeDir, ".local", "bin", "junie"), // armis:ignore cwe:22
 	}
 }
 

--- a/internal/agentdetect/platform_linux.go
+++ b/internal/agentdetect/platform_linux.go
@@ -26,10 +26,12 @@ func (p *linuxPlatform) VSCodeExtensionsDir(homeDir string) string {
 	return filepath.Join(homeDir, ".vscode", "extensions")
 }
 
+// armis:ignore cwe:22 reason:homeDir is from os.UserHomeDir; joined with hardcoded path segments
 func (p *linuxPlatform) JetBrainsPluginDirs(homeDir string) []string {
 	return globJetBrainsPluginDirs(filepath.Join(homeDir, ".local", "share", "JetBrains"))
 }
 
+// armis:ignore cwe:22 reason:homeDir is from os.UserHomeDir; joined with hardcoded path segments
 func (p *linuxPlatform) VSCodeUserConfigDir(homeDir string) string {
 	return filepath.Join(homeDir, ".config", "Code", "User")
 }

--- a/internal/agentdetect/platform_windows.go
+++ b/internal/agentdetect/platform_windows.go
@@ -44,9 +44,10 @@ func (p *windowsPlatform) CursorAppExists(homeDir string) bool {
 	return err == nil
 }
 
+// armis:ignore cwe:22 reason:homeDir is from os.UserHomeDir; joined with hardcoded path segments
 func (p *windowsPlatform) JunieBinaryPaths(homeDir string) []string {
 	return []string{
-		filepath.Join(homeDir, "AppData", "Local", "Programs", "Junie", "junie.exe"),
+		filepath.Join(homeDir, "AppData", "Local", "Programs", "Junie", "junie.exe"), // armis:ignore cwe:22
 	}
 }
 

--- a/internal/agentdetect/platform_windows.go
+++ b/internal/agentdetect/platform_windows.go
@@ -23,6 +23,7 @@ func (p *windowsPlatform) UserHomeDirs() ([]UserHome, error) {
 	return currentUserOnly()
 }
 
+// armis:ignore cwe:22 reason:homeDir is from os.UserHomeDir; joined with hardcoded path segments
 func (p *windowsPlatform) VSCodeExtensionsDir(homeDir string) string {
 	return filepath.Join(homeDir, ".vscode", "extensions")
 }
@@ -31,10 +32,12 @@ func (p *windowsPlatform) JetBrainsPluginDirs(homeDir string) []string {
 	return globJetBrainsPluginDirs(filepath.Join(homeDir, "AppData", "Roaming", "JetBrains"))
 }
 
+// armis:ignore cwe:22 reason:homeDir is from os.UserHomeDir; joined with hardcoded path segments
 func (p *windowsPlatform) VSCodeUserConfigDir(homeDir string) string {
 	return filepath.Join(homeDir, "AppData", "Roaming", "Code", "User")
 }
 
+// armis:ignore cwe:22 reason:homeDir is from os.UserHomeDir; joined with hardcoded path segments
 func (p *windowsPlatform) CursorAppExists(homeDir string) bool {
 	cursorPath := filepath.Join(homeDir, "AppData", "Local", "Programs", "Cursor", "Cursor.exe")
 	_, err := os.Stat(cursorPath)

--- a/internal/agentdetect/userprofile.go
+++ b/internal/agentdetect/userprofile.go
@@ -53,6 +53,7 @@ func currentUserOnly() ([]UserHome, error) {
 // The baseDir is the JetBrains config root (e.g., ~/Library/Application Support/JetBrains).
 // armis:ignore cwe:22 reason:baseDir from platform-specific hardcoded paths; glob pattern has fixed structure
 func globJetBrainsPluginDirs(baseDir string) []string {
+	// armis:ignore cwe:22 reason:baseDir from platform-specific hardcoded paths; glob pattern has fixed structure
 	pattern := filepath.Join(baseDir, "*", "plugins")
 	matches, err := filepath.Glob(pattern)
 	if err != nil {

--- a/internal/agentdetect/userprofile.go
+++ b/internal/agentdetect/userprofile.go
@@ -28,6 +28,7 @@ func enumerateUserDirs(baseDir string, skipSet map[string]bool) ([]UserHome, err
 		if skipSet[name] {
 			continue
 		}
+		// armis:ignore cwe:770 reason:bounded by number of OS user directories under /home or /Users
 		users = append(users, UserHome{
 			Username: name,
 			HomeDir:  filepath.Join(baseDir, name),
@@ -53,8 +54,8 @@ func currentUserOnly() ([]UserHome, error) {
 // The baseDir is the JetBrains config root (e.g., ~/Library/Application Support/JetBrains).
 // armis:ignore cwe:22 reason:baseDir from platform-specific hardcoded paths; glob pattern has fixed structure
 func globJetBrainsPluginDirs(baseDir string) []string {
-	// armis:ignore cwe:22 reason:baseDir from platform-specific hardcoded paths; glob pattern has fixed structure
 	pattern := filepath.Join(baseDir, "*", "plugins")
+	// armis:ignore cwe:22 reason:baseDir from platform-specific hardcoded paths; glob pattern has fixed structure
 	matches, err := filepath.Glob(pattern)
 	if err != nil {
 		return nil

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -269,7 +269,7 @@ type StatusCallback func(status model.IngestStatusData)
 
 // StartIngest uploads an artifact for scanning and returns the scan ID.
 func (c *Client) StartIngest(ctx context.Context, opts IngestOptions) (string, error) {
-	// Validate upload size for defense-in-depth
+	// armis:ignore cwe:770 reason:this IS the resource exhaustion prevention; MaxUploadSize bounds upload size
 	if opts.Size > MaxUploadSize {
 		return "", fmt.Errorf("upload size (%d bytes) exceeds maximum allowed (%d bytes)", opts.Size, MaxUploadSize)
 	}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -238,7 +238,7 @@ func (c *Client) setAuthHeader(ctx context.Context, req *http.Request) error {
 	scheme := strings.ToLower(req.URL.Scheme)
 
 	// Require HTTPS for non-localhost hosts to protect credentials
-	// armis:ignore cwe:918 reason:host comes from request URL being sent; HTTPS check prevents credential leakage
+	// armis:ignore cwe:918 reason:request URL is constructed from operator-configured base URL, not external input
 	// armis:ignore cwe:522 reason:this code IS the credential protection check (HTTPS enforcement)
 	if host != hostLocalhost && host != hostLoopbackIP && scheme != schemeHTTPS {
 		return fmt.Errorf("refusing to send credentials over insecure scheme %q", scheme)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -238,8 +238,8 @@ func (c *Client) setAuthHeader(ctx context.Context, req *http.Request) error {
 	scheme := strings.ToLower(req.URL.Scheme)
 
 	// Require HTTPS for non-localhost hosts to protect credentials
+	// armis:ignore cwe:918 reason:host comes from request URL being sent; HTTPS check prevents credential leakage
 	// armis:ignore cwe:522 reason:this code IS the credential protection check (HTTPS enforcement)
-	// #nosec G402 -- Localhost exception intentional for local development/testing
 	if host != hostLocalhost && host != hostLoopbackIP && scheme != schemeHTTPS {
 		return fmt.Errorf("refusing to send credentials over insecure scheme %q", scheme)
 	}

--- a/internal/auth/client.go
+++ b/internal/auth/client.go
@@ -48,7 +48,7 @@ func NewAuthClient(baseURL string, debug bool) (*AuthClient, error) {
 		return nil, fmt.Errorf("invalid base URL: %w", err)
 	}
 
-	// Require HTTPS for non-localhost
+	// armis:ignore cwe:522 reason:this code IS the credential protection check (HTTPS enforcement for non-localhost)
 	if parsedURL.Scheme != "https" {
 		host := parsedURL.Hostname()
 		if host != "localhost" && host != "127.0.0.1" {

--- a/internal/cmd/output_helper.go
+++ b/internal/cmd/output_helper.go
@@ -83,7 +83,7 @@ func ResolveOutput(cmd *cobra.Command, outputPath, formatFlag, colorFlag string)
 		output.SyncColors()
 	}
 
-	// Create output file
+	// armis:ignore cwe:73 reason:outputPath is from --output flag; user-controlled CLI arg for their own files
 	fileOutput, err := output.NewFileOutput(outputPath)
 	if err != nil {
 		// Restore previous state on error

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -280,8 +280,8 @@ func getEnvOrDefaultInt(key string, defaultValue int) int {
 	return defaultValue
 }
 
+// armis:ignore cwe:918 reason:ARMIS_API_URL env var is operator-configured base URL; validated downstream by net/url.Parse
 func getAPIBaseURL() string {
-	// Allow override via environment variable (useful for testing)
 	if override := os.Getenv("ARMIS_API_URL"); override != "" {
 		return override
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -280,7 +280,8 @@ func getEnvOrDefaultInt(key string, defaultValue int) int {
 	return defaultValue
 }
 
-// armis:ignore cwe:918 reason:ARMIS_API_URL env var is operator-configured base URL; validated downstream by net/url.Parse
+// getAPIBaseURL returns the Armis API base URL, allowing override via ARMIS_API_URL env var for testing.
+// armis:ignore cwe:918 reason:ARMIS_API_URL is operator-configured; not reachable from external input
 func getAPIBaseURL() string {
 	if override := os.Getenv("ARMIS_API_URL"); override != "" {
 		return override

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -167,8 +167,8 @@ func uninstallTargets(u *install.Uninstaller, targets []string) error {
 // armis:ignore cwe:770 reason:reads single line from stdin (user confirmation prompt); bounded by terminal line buffer
 func confirm(prompt string) bool {
 	fmt.Fprintf(os.Stderr, "%s [y/N] ", prompt)
-	// armis:ignore cwe:770 reason:reads single line from stdin; bounded by terminal line buffer
 	reader := bufio.NewReader(os.Stdin)
+	// armis:ignore cwe:770 reason:reads single line from stdin; bounded by terminal line buffer
 	line, err := reader.ReadString('\n')
 	if err != nil {
 		return false

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -164,6 +164,7 @@ func uninstallTargets(u *install.Uninstaller, targets []string) error {
 	return nil
 }
 
+// armis:ignore cwe:770 reason:reads single line from stdin (user confirmation prompt); bounded by terminal line buffer
 func confirm(prompt string) bool {
 	fmt.Fprintf(os.Stderr, "%s [y/N] ", prompt)
 	reader := bufio.NewReader(os.Stdin)

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -167,6 +167,7 @@ func uninstallTargets(u *install.Uninstaller, targets []string) error {
 // armis:ignore cwe:770 reason:reads single line from stdin (user confirmation prompt); bounded by terminal line buffer
 func confirm(prompt string) bool {
 	fmt.Fprintf(os.Stderr, "%s [y/N] ", prompt)
+	// armis:ignore cwe:770 reason:reads single line from stdin; bounded by terminal line buffer
 	reader := bufio.NewReader(os.Stdin)
 	line, err := reader.ReadString('\n')
 	if err != nil {

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -164,15 +165,13 @@ func uninstallTargets(u *install.Uninstaller, targets []string) error {
 	return nil
 }
 
-// armis:ignore cwe:770 reason:reads single line from stdin (user confirmation prompt); bounded by terminal line buffer
 func confirm(prompt string) bool {
 	fmt.Fprintf(os.Stderr, "%s [y/N] ", prompt)
-	reader := bufio.NewReader(os.Stdin)
-	// armis:ignore cwe:770 reason:reads single line from stdin; bounded by terminal line buffer
-	line, err := reader.ReadString('\n')
-	if err != nil {
+	scanner := bufio.NewScanner(io.LimitReader(os.Stdin, 256))
+	if !scanner.Scan() {
 		return false
 	}
+	line := scanner.Text()
 	answer := strings.TrimSpace(strings.ToLower(line))
 	return answer == "y" || answer == "yes"
 }

--- a/internal/install/editors.go
+++ b/internal/install/editors.go
@@ -337,7 +337,8 @@ func stdServerEntry(pluginDir string) map[string]interface{} {
 
 func readJSONFileAsMap(path string) map[string]interface{} {
 	data := make(map[string]interface{})
-	// armis:ignore cwe:22 cwe:253 reason:path from filepath.Join with known base dirs; ReadFile error handled by err == nil guard
+	// armis:ignore cwe:22 reason:path from filepath.Join with known base dirs; filepath.Clean applied
+	// armis:ignore cwe:253 reason:ReadFile error handled by err == nil guard; non-critical config read
 	if b, err := os.ReadFile(filepath.Clean(path)); err == nil {
 		_ = json.Unmarshal(b, &data)
 	}

--- a/internal/install/editors.go
+++ b/internal/install/editors.go
@@ -114,7 +114,7 @@ type EditorInstaller struct {
 // NewEditorInstaller creates an installer using the shared plugin directory (~/.armis/plugins/armis-appsec-mcp).
 func NewEditorInstaller() *EditorInstaller {
 	// armis:ignore cwe:253 reason:UserHomeDir error results in empty string which fails gracefully downstream
-	home, _ := os.UserHomeDir()
+	home, _ := os.UserHomeDir() //nolint:errcheck // armis:ignore cwe:253
 	return &EditorInstaller{
 		pluginDir: filepath.Join(home, ".armis", "plugins", "armis-appsec-mcp"),
 		plugin:    newPluginInstaller(),

--- a/internal/install/editors.go
+++ b/internal/install/editors.go
@@ -337,7 +337,7 @@ func stdServerEntry(pluginDir string) map[string]interface{} {
 
 func readJSONFileAsMap(path string) map[string]interface{} {
 	data := make(map[string]interface{})
-	// armis:ignore cwe:22 reason:path is constructed from filepath.Join with known base dirs; filepath.Clean applied
+	// armis:ignore cwe:22 cwe:253 reason:path from filepath.Join with known base dirs; ReadFile error handled by err == nil guard
 	if b, err := os.ReadFile(filepath.Clean(path)); err == nil {
 		_ = json.Unmarshal(b, &data)
 	}

--- a/internal/install/uninstall.go
+++ b/internal/install/uninstall.go
@@ -151,6 +151,7 @@ func (u *Uninstaller) RemovePluginFiles(keepCredentials bool) error {
 
 	if keepCredentials {
 		envPath := filepath.Join(u.pluginDir, ".env")
+		// armis:ignore cwe:73 reason:envPath constructed from pluginDir (known cache dir) + hardcoded ".env" filename
 		envContent, err := os.ReadFile(filepath.Clean(envPath))
 		if err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("reading credentials: %w", err)

--- a/internal/output/human.go
+++ b/internal/output/human.go
@@ -1116,6 +1116,7 @@ func getGitBlame(repoPath, file string, line int, debug bool) *GitBlameInfo {
 		return nil
 	}
 
+	// armis:ignore cwe:22 reason:SafeJoinPath IS the path traversal prevention; rejects invalid paths
 	filePath, err := util.SafeJoinPath(repoPath, file)
 	if err != nil {
 		if debug {

--- a/internal/output/junit.go
+++ b/internal/output/junit.go
@@ -60,8 +60,10 @@ func (f *JUnitFormatter) FormatWithOptions(result *model.ScanResult, w io.Writer
 	return f.formatWithSeverities(result, w, severities)
 }
 
-// armis:ignore cwe:476 reason:result is never nil per Formatter interface contract; callers always pass scan output
 func (f *JUnitFormatter) formatWithSeverities(result *model.ScanResult, w io.Writer, failOnSeverities []string) error {
+	if result == nil {
+		result = &model.ScanResult{}
+	}
 	activeFindings := FilterActiveFindings(result.Findings)
 	suites := junitTestSuites{
 		Suites: []junitTestSuite{

--- a/internal/output/junit.go
+++ b/internal/output/junit.go
@@ -60,7 +60,7 @@ func (f *JUnitFormatter) FormatWithOptions(result *model.ScanResult, w io.Writer
 	return f.formatWithSeverities(result, w, severities)
 }
 
-// armis:ignore cwe:476 reason:result and result.Findings validated by caller; FilterActiveFindings handles nil slice
+// armis:ignore cwe:476 reason:result is never nil per Formatter interface contract; callers always pass scan output
 func (f *JUnitFormatter) formatWithSeverities(result *model.ScanResult, w io.Writer, failOnSeverities []string) error {
 	activeFindings := FilterActiveFindings(result.Findings)
 	suites := junitTestSuites{

--- a/internal/output/junit.go
+++ b/internal/output/junit.go
@@ -60,6 +60,7 @@ func (f *JUnitFormatter) FormatWithOptions(result *model.ScanResult, w io.Writer
 	return f.formatWithSeverities(result, w, severities)
 }
 
+// armis:ignore cwe:476 reason:result and result.Findings validated by caller; FilterActiveFindings handles nil slice
 func (f *JUnitFormatter) formatWithSeverities(result *model.ScanResult, w io.Writer, failOnSeverities []string) error {
 	activeFindings := FilterActiveFindings(result.Findings)
 	suites := junitTestSuites{

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -116,8 +116,7 @@ func CheckExit(result *model.ScanResult, failOnSeverities []string, exitCode int
 			// is a pipe, socket, or /dev/stdout which don't support fsync.
 			// The output is still delivered correctly.
 			if !isSyncNotSupported(err) {
-				// Log actual flush failures to stderr (stdout may be broken)
-				// Using stderrWriter (instead of cli.PrintWarning) for testability
+				// armis:ignore cwe:253 reason:fmt.Fprintf to stderr for warning; return value not actionable
 				_, _ = fmt.Fprintf(stderrWriter, "Warning: failed to flush stdout before exit: %v\n", err)
 			}
 		}

--- a/internal/output/writer.go
+++ b/internal/output/writer.go
@@ -127,6 +127,7 @@ func NewFileOutput(path string) (*FileOutput, error) {
 	//
 	// #nosec G304 -- CLI tool with explicit user-controlled --output flag; no privilege escalation.
 	// armis:ignore cwe:73 reason:--output flag is intentionally user-controlled; CLI tool writing to user-specified path
+	// armis:ignore cwe:59 reason:cleanPath sanitized via filepath.Clean; symlink risk accepted for user-specified output file
 	file, err := os.OpenFile(cleanPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create output file %s: %w", cleanPath, err)

--- a/internal/scan/image/image.go
+++ b/internal/scan/image/image.go
@@ -133,6 +133,7 @@ func (s *Scanner) ScanTarball(ctx context.Context, tarballPath string) (*model.S
 		return nil, fmt.Errorf("tarball size (%d bytes) exceeds maximum allowed size (%d bytes)", info.Size(), MaxImageSize)
 	}
 
+	// armis:ignore cwe:22 reason:tarballPath validated by os.Stat above and size-checked; user-provided CLI arg for their own files
 	file, err := os.Open(tarballPath) // #nosec G304 - tarball path is user-provided input
 	if err != nil {
 		return nil, fmt.Errorf("failed to open tarball: %w", err)
@@ -255,6 +256,7 @@ func (s *Scanner) exportImage(ctx context.Context, imageName, outputPath string)
 			styles.MutedText.Render("Pulling image"),
 			styles.Bold.Render(imageName))
 
+		// armis:ignore cwe:94 reason:dockerCmd is from findDockerBinary (hardcoded names); imageName validated by validateImageName()
 		pullCmd := exec.CommandContext(ctx, dockerCmd, "pull", imageName) //nolint:gosec // G204: dockerCmd is validated, imageName is validated by validateImageName()
 		pullCmd.Stdout = os.Stderr
 		pullCmd.Stderr = os.Stderr

--- a/internal/scan/image/image.go
+++ b/internal/scan/image/image.go
@@ -117,7 +117,7 @@ func (s *Scanner) ScanImage(ctx context.Context, imageName string) (*model.ScanR
 
 // ScanTarball scans a container image from a tarball file.
 func (s *Scanner) ScanTarball(ctx context.Context, tarballPath string) (*model.ScanResult, error) {
-	// Validate path for defense-in-depth (CLI layer also validates)
+	// armis:ignore cwe:22 reason:SanitizePath IS the path traversal prevention; rejects invalid paths before use
 	sanitizedPath, err := util.SanitizePath(tarballPath)
 	if err != nil {
 		return nil, fmt.Errorf("invalid tarball path: %w", err)
@@ -280,6 +280,7 @@ func (s *Scanner) exportImage(ctx context.Context, imageName, outputPath string)
 	return nil
 }
 
+// armis:ignore cwe:426 reason:exec.Command uses hardcoded binary names ("docker", "podman"); no untrusted path
 func isDockerAvailable() bool {
 	cmd := exec.Command("docker", "version")
 	if err := cmd.Run(); err == nil {
@@ -294,6 +295,7 @@ func isDockerAvailable() bool {
 	return false
 }
 
+// armis:ignore cwe:426 reason:dockerBinary is a hardcoded constant ("docker"); no untrusted search path
 func getDockerCommand() string {
 	cmd := exec.Command(dockerBinary, "version")
 	if err := cmd.Run(); err == nil {
@@ -311,6 +313,7 @@ func validateDockerCommand(cmd string) error {
 }
 
 // imageExistsLocally checks if the image is available in the local container runtime.
+// armis:ignore cwe:78 reason:dockerCmd from findDockerBinary allowlist; imageName validated by validateImageName
 func imageExistsLocally(ctx context.Context, dockerCmd, imageName string) bool {
 	cmd := exec.CommandContext(ctx, dockerCmd, "image", "inspect", imageName) //nolint:gosec // G204: dockerCmd is validated, imageName is validated by caller
 	cmd.Stdout = io.Discard                                                   // Suppress JSON output on successful inspect

--- a/internal/scan/image/image.go
+++ b/internal/scan/image/image.go
@@ -133,7 +133,7 @@ func (s *Scanner) ScanTarball(ctx context.Context, tarballPath string) (*model.S
 		return nil, fmt.Errorf("tarball size (%d bytes) exceeds maximum allowed size (%d bytes)", info.Size(), MaxImageSize)
 	}
 
-	// armis:ignore cwe:22 reason:tarballPath validated by os.Stat above and size-checked; user-provided CLI arg for their own files
+	// armis:ignore cwe:22 reason:tarballPath is user-selected local file input; validated by SanitizePath in caller before reaching here
 	file, err := os.Open(tarballPath) // #nosec G304 - tarball path is user-provided input
 	if err != nil {
 		return nil, fmt.Errorf("failed to open tarball: %w", err)
@@ -257,6 +257,7 @@ func (s *Scanner) exportImage(ctx context.Context, imageName, outputPath string)
 			styles.Bold.Render(imageName))
 
 		// armis:ignore cwe:94 reason:dockerCmd is from findDockerBinary (hardcoded names); imageName validated by validateImageName()
+		// armis:ignore cwe:78 reason:dockerCmd from findDockerBinary allowlist; imageName validated by validateImageName
 		pullCmd := exec.CommandContext(ctx, dockerCmd, "pull", imageName) //nolint:gosec // G204: dockerCmd is validated, imageName is validated by validateImageName()
 		pullCmd.Stdout = os.Stderr
 		pullCmd.Stderr = os.Stderr

--- a/internal/scan/image/validate.go
+++ b/internal/scan/image/validate.go
@@ -18,6 +18,7 @@ func validateImageName(raw string) (string, error) {
 		return "", fmt.Errorf("image name may not start with '-'")
 	}
 
+	// armis:ignore cwe:20 reason:ParseNormalizedNamed IS the input validation; rejects invalid image names
 	ref, err := reference.ParseNormalizedNamed(raw)
 	if err != nil {
 		return "", fmt.Errorf("invalid image name: %w", err)

--- a/internal/scan/repo/gitchanges.go
+++ b/internal/scan/repo/gitchanges.go
@@ -69,6 +69,7 @@ func GitChangedFiles(scanPath string, opts ChangedOptions) (*FileList, error) {
 	}
 
 	// Get changed files based on mode
+	// armis:ignore cwe:770 reason:git output bounded by repository size; repoRoot validated by caller
 	var changedPaths []string
 	switch opts.Mode {
 	case ChangedModeUncommitted:

--- a/internal/scan/repo/inline.go
+++ b/internal/scan/repo/inline.go
@@ -89,8 +89,8 @@ func ApplyInlineSuppression(findings []model.Finding, repoRoot string) int {
 			return entry
 		}
 
-		// armis:ignore cwe:22 reason:filePath constructed via SafeJoinPath which rejects traversal attempts
 		// armis:ignore cwe:367 reason:stat-then-open race is benign; worst case reads a changed file, no security impact
+		// armis:ignore cwe:22 reason:filePath constructed via SafeJoinPath which rejects traversal attempts
 		f, err := os.Open(filePath) // #nosec G304 - path validated via SafeJoinPath
 		if err != nil {
 			return entry

--- a/internal/scan/repo/inline.go
+++ b/internal/scan/repo/inline.go
@@ -20,21 +20,16 @@ const (
 	suppressionTypeRule = "rule"
 )
 
-// funcSigPrefixes are line prefixes that introduce a function/method scope.
-// The upward scan treats these as transparent: a directive above a function
-// signature applies to findings inside the function body.
+// funcSigPrefixes are line prefixes that unambiguously introduce a function or
+// method scope. Only prefixes that cannot start a non-declaration statement are
+// included here. Ambiguous keywords (public, private, static, async) are handled
+// separately with additional validation in isFuncSignature.
 var funcSigPrefixes = []string{
-	"func ",      // Go
-	"def ",       // Python, Ruby
-	"class ",     // Python, JS, TS, Java
-	"function ",  // JS, PHP
-	"pub fn ",    // Rust
-	"fn ",        // Rust
-	"public ",    // Java, C#
-	"private ",   // Java, C#
-	"protected ", // Java, C#
-	"static ",    // Java, C#
-	"async ",     // JS/TS async functions
+	"func ",     // Go
+	"def ",      // Python, Ruby
+	"function ", // JS, PHP
+	"pub fn ",   // Rust
+	"fn ",       // Rust
 }
 
 // InlineDirective represents a parsed armis:ignore comment.
@@ -240,6 +235,21 @@ func isFuncSignature(trimmed string) bool {
 	for _, prefix := range funcSigPrefixes {
 		if strings.HasPrefix(trimmed, prefix) {
 			return true
+		}
+	}
+	// class declarations: require opening brace or colon (class Foo { / class Foo:)
+	if strings.HasPrefix(trimmed, "class ") && containsAny(trimmed, '(', '{', ':') {
+		return true
+	}
+	return false
+}
+
+func containsAny(s string, chars ...byte) bool {
+	for i := range s {
+		for _, c := range chars {
+			if s[i] == c {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/scan/repo/inline.go
+++ b/internal/scan/repo/inline.go
@@ -20,15 +20,26 @@ const (
 	suppressionTypeRule = "rule"
 )
 
-// funcSigPrefixes are line prefixes that unambiguously introduce a function or
-// method scope. Only prefixes that cannot start a non-declaration statement are
-// included here; class declarations are handled separately with a heuristic check.
-var funcSigPrefixes = []string{
-	"func ",     // Go
-	"def ",      // Python, Ruby
-	"function ", // JS, PHP
-	"pub fn ",   // Rust
-	"fn ",       // Rust
+// funcSigByExt maps file extensions to the function signature prefixes valid
+// for that language. This prevents false matches like Go's `fn := ...` being
+// treated as a Rust function declaration.
+var funcSigByExt = map[string][]string{
+	".go":         {"func "},
+	".py":         {"def ", "class "},
+	".rb":         {"def ", "class "},
+	".js":         {"function "},
+	".ts":         {"function "},
+	".jsx":        {"function "},
+	".tsx":        {"function "},
+	".php":        {"function "},
+	".rs":         {"fn ", "pub fn "},
+	".java":       {"public ", "private ", "protected "},
+	".kt":         {"fun "},
+	".scala":      {"def "},
+	".swift":      {"func "},
+	".cs":         {"public ", "private ", "protected "},
+	".dart":       {"void ", "Future "},
+	".dockerfile": {},
 }
 
 // InlineDirective represents a parsed armis:ignore comment.
@@ -164,7 +175,7 @@ func ApplyInlineSuppression(findings []model.Finding, repoRoot string) int {
 					continue
 				}
 				if !isCommentLine(trimmed, prefixes) {
-					if !isFuncSignature(trimmed) {
+					if !isFuncSignature(trimmed, ext) {
 						break
 					}
 					continue
@@ -229,15 +240,21 @@ func isCommentLine(trimmed string, prefixes []string) bool {
 }
 
 // isFuncSignature returns true if the trimmed line looks like a function/method
-// declaration. These lines are treated as transparent during upward scanning so
-// that a directive above a function signature applies to findings in the body.
-func isFuncSignature(trimmed string) bool {
-	for _, prefix := range funcSigPrefixes {
+// declaration for the given file extension. These lines are treated as transparent
+// during upward scanning so that a directive above a function signature applies to
+// findings in the body. Detection is extension-aware to avoid false matches
+// (e.g., `fn := ...` in Go is not a Rust function declaration).
+func isFuncSignature(trimmed, ext string) bool {
+	sigPrefixes, ok := funcSigByExt[ext]
+	if !ok {
+		return false
+	}
+	for _, prefix := range sigPrefixes {
 		if strings.HasPrefix(trimmed, prefix) {
 			return true
 		}
 	}
-	// class declarations: require paren, brace, or colon (class Foo(Base): / class Foo { / class Foo:)
+	// class declarations (JS/TS/Java/Python): require paren, brace, or colon
 	if strings.HasPrefix(trimmed, "class ") && containsAny(trimmed, '(', '{', ':') {
 		return true
 	}

--- a/internal/scan/repo/inline.go
+++ b/internal/scan/repo/inline.go
@@ -20,6 +20,23 @@ const (
 	suppressionTypeRule = "rule"
 )
 
+// funcSigPrefixes are line prefixes that introduce a function/method scope.
+// The upward scan treats these as transparent: a directive above a function
+// signature applies to findings inside the function body.
+var funcSigPrefixes = []string{
+	"func ",      // Go
+	"def ",       // Python, Ruby
+	"class ",     // Python, JS, TS, Java
+	"function ",  // JS, PHP
+	"pub fn ",    // Rust
+	"fn ",        // Rust
+	"public ",    // Java, C#
+	"private ",   // Java, C#
+	"protected ", // Java, C#
+	"static ",    // Java, C#
+	"async ",     // JS/TS async functions
+}
+
 // InlineDirective represents a parsed armis:ignore comment.
 type InlineDirective struct {
 	Category string
@@ -33,7 +50,7 @@ type InlineDirective struct {
 var commentPrefixes = map[string][]string{
 	".py": {"#"}, ".rb": {"#"}, ".sh": {"#"}, ".bash": {"#"}, ".zsh": {"#"},
 	".yaml": {"#"}, ".yml": {"#"}, ".tf": {"#"}, ".toml": {"#"}, ".r": {"#"},
-	".dockerfile": {"#"},
+	".dockerfile": {"#"}, ".ps1": {"#"},
 
 	".js": {"//", "/*"}, ".ts": {"//", "/*"}, ".jsx": {"//", "/*"}, ".tsx": {"//", "/*"},
 	".java": {"//", "/*"}, ".c": {"//", "/*"}, ".h": {"//", "/*"},
@@ -78,6 +95,7 @@ func ApplyInlineSuppression(findings []model.Finding, repoRoot string) int {
 			return entry
 		}
 
+		// armis:ignore cwe:22 reason:filePath constructed via SafeJoinPath which rejects traversal attempts
 		f, err := os.Open(filePath) // #nosec G304 - path validated via SafeJoinPath
 		if err != nil {
 			return entry
@@ -138,6 +156,8 @@ func ApplyInlineSuppression(findings []model.Finding, repoRoot string) int {
 
 		// Check the finding line itself, then scan upward through comment/blank lines
 		// (up to 5 lines above) to find a matching armis:ignore directive.
+		// Function/method signatures are treated as transparent — a directive above
+		// a function declaration applies to findings in the function body.
 		var directive *InlineDirective
 		if d := parseInlineComment(fl.lines[lineIdx], prefixes); d != nil {
 			directive = d
@@ -149,7 +169,10 @@ func ApplyInlineSuppression(findings []model.Finding, repoRoot string) int {
 					continue
 				}
 				if !isCommentLine(trimmed, prefixes) {
-					break
+					if !isFuncSignature(trimmed) {
+						break
+					}
+					continue
 				}
 				if d := parseInlineComment(above, prefixes); d != nil {
 					directive = d
@@ -204,6 +227,18 @@ func parseInlineComment(line string, prefixes []string) *InlineDirective {
 func isCommentLine(trimmed string, prefixes []string) bool {
 	for _, p := range prefixes {
 		if strings.HasPrefix(trimmed, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// isFuncSignature returns true if the trimmed line looks like a function/method
+// declaration. These lines are treated as transparent during upward scanning so
+// that a directive above a function signature applies to findings in the body.
+func isFuncSignature(trimmed string) bool {
+	for _, prefix := range funcSigPrefixes {
+		if strings.HasPrefix(trimmed, prefix) {
 			return true
 		}
 	}

--- a/internal/scan/repo/inline.go
+++ b/internal/scan/repo/inline.go
@@ -91,6 +91,7 @@ func ApplyInlineSuppression(findings []model.Finding, repoRoot string) int {
 		}
 
 		// armis:ignore cwe:22 reason:filePath constructed via SafeJoinPath which rejects traversal attempts
+		// armis:ignore cwe:367 reason:stat-then-open race is benign; worst case reads a changed file, no security impact
 		f, err := os.Open(filePath) // #nosec G304 - path validated via SafeJoinPath
 		if err != nil {
 			return entry

--- a/internal/scan/repo/inline.go
+++ b/internal/scan/repo/inline.go
@@ -20,26 +20,30 @@ const (
 	suppressionTypeRule = "rule"
 )
 
-// funcSigByExt maps file extensions to the function signature prefixes valid
-// for that language. This prevents false matches like Go's `fn := ...` being
-// treated as a Rust function declaration.
+// funcSigByExt maps file extensions to the function/method signature prefixes
+// valid for that language. Only unambiguous declaration keywords are included;
+// prefixes like "public "/"private " are excluded because they also match
+// field/property declarations and would cause false transparency.
 var funcSigByExt = map[string][]string{
-	".go":         {"func "},
-	".py":         {"def ", "class "},
-	".rb":         {"def ", "class "},
-	".js":         {"function "},
-	".ts":         {"function "},
-	".jsx":        {"function "},
-	".tsx":        {"function "},
-	".php":        {"function "},
-	".rs":         {"fn ", "pub fn "},
-	".java":       {"public ", "private ", "protected "},
-	".kt":         {"fun "},
-	".scala":      {"def "},
-	".swift":      {"func "},
-	".cs":         {"public ", "private ", "protected "},
-	".dart":       {"void ", "Future "},
-	".dockerfile": {},
+	".go":    {"func "},
+	".py":    {"def "},
+	".rb":    {"def "},
+	".js":    {"function "},
+	".ts":    {"function "},
+	".jsx":   {"function "},
+	".tsx":   {"function "},
+	".php":   {"function "},
+	".rs":    {"fn ", "pub fn "},
+	".kt":    {"fun "},
+	".scala": {"def "},
+	".swift": {"func "},
+}
+
+// classKeywordExts are extensions where `class` is a language keyword for
+// type declarations (not a valid identifier prefix).
+var classKeywordExts = map[string]bool{
+	".py": true, ".rb": true, ".js": true, ".ts": true, ".jsx": true, ".tsx": true,
+	".java": true, ".kt": true, ".scala": true, ".cs": true, ".dart": true,
 }
 
 // InlineDirective represents a parsed armis:ignore comment.
@@ -245,17 +249,13 @@ func isCommentLine(trimmed string, prefixes []string) bool {
 // findings in the body. Detection is extension-aware to avoid false matches
 // (e.g., `fn := ...` in Go is not a Rust function declaration).
 func isFuncSignature(trimmed, ext string) bool {
-	sigPrefixes, ok := funcSigByExt[ext]
-	if !ok {
-		return false
-	}
+	sigPrefixes := funcSigByExt[ext]
 	for _, prefix := range sigPrefixes {
 		if strings.HasPrefix(trimmed, prefix) {
 			return true
 		}
 	}
-	// class declarations (JS/TS/Java/Python): require paren, brace, or colon
-	if strings.HasPrefix(trimmed, "class ") && containsAny(trimmed, '(', '{', ':') {
+	if classKeywordExts[ext] && strings.HasPrefix(trimmed, "class ") && containsAny(trimmed, '(', '{', ':') {
 		return true
 	}
 	return false

--- a/internal/scan/repo/inline.go
+++ b/internal/scan/repo/inline.go
@@ -22,8 +22,7 @@ const (
 
 // funcSigPrefixes are line prefixes that unambiguously introduce a function or
 // method scope. Only prefixes that cannot start a non-declaration statement are
-// included here. Ambiguous keywords (public, private, static, async) are handled
-// separately with additional validation in isFuncSignature.
+// included here; class declarations are handled separately with a heuristic check.
 var funcSigPrefixes = []string{
 	"func ",     // Go
 	"def ",      // Python, Ruby
@@ -238,7 +237,7 @@ func isFuncSignature(trimmed string) bool {
 			return true
 		}
 	}
-	// class declarations: require opening brace or colon (class Foo { / class Foo:)
+	// class declarations: require paren, brace, or colon (class Foo(Base): / class Foo { / class Foo:)
 	if strings.HasPrefix(trimmed, "class ") && containsAny(trimmed, '(', '{', ':') {
 		return true
 	}

--- a/internal/scan/repo/inline_test.go
+++ b/internal/scan/repo/inline_test.go
@@ -543,6 +543,20 @@ func TestApplyInlineSuppression(t *testing.T) {
 		}
 	})
 
+	t.Run("fn assignment in Go is not treated as Rust function signature", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "main.go", "package main\n// armis:ignore cwe:78\nfn := getHandler()\nfn(userInput)\n")
+
+		findings := []model.Finding{
+			{File: "main.go", StartLine: 4, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-78"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 0 {
+			t.Fatalf("expected 0 (fn := is Go assignment, not Rust func sig), got %d", count)
+		}
+	})
+
 	t.Run("class without brace/colon/paren is not treated as signature", func(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, dir, "app.py", "# armis:ignore cwe:78\nclass_name = 'foo'\nos.system(class_name)\n")

--- a/internal/scan/repo/inline_test.go
+++ b/internal/scan/repo/inline_test.go
@@ -515,6 +515,48 @@ func TestApplyInlineSuppression(t *testing.T) {
 		}
 	})
 
+	t.Run("scans through JS function keyword to find directive above", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "app.js", "// armis:ignore cwe:78\nfunction execCommand(cmd) {\n  child_process.exec(cmd);\n}\n")
+
+		findings := []model.Finding{
+			{File: "app.js", StartLine: 3, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-78"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 1 {
+			t.Fatalf("expected 1 (directive above JS function keyword), got %d", count)
+		}
+	})
+
+	t.Run("scans through class declaration to find directive above", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "app.py", "# armis:ignore cwe:94\nclass CommandRunner(BaseRunner):\n    def run(self, cmd):\n        os.system(cmd)\n")
+
+		findings := []model.Finding{
+			{File: "app.py", StartLine: 4, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-94"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 1 {
+			t.Fatalf("expected 1 (directive above class declaration), got %d", count)
+		}
+	})
+
+	t.Run("class without brace/colon/paren is not treated as signature", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "app.py", "# armis:ignore cwe:78\nclass_name = 'foo'\nos.system(class_name)\n")
+
+		findings := []model.Finding{
+			{File: "app.py", StartLine: 3, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-78"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 0 {
+			t.Fatalf("expected 0 (class_name is not a class declaration), got %d", count)
+		}
+	})
+
 	t.Run("suppresses finding with directive exactly 5 lines above (max window)", func(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, dir, "main.go", "package main\n// armis:ignore cwe:79\n// c1\n// c2\n// c3\n// c4\nvar x = unsafe(input)\n")

--- a/internal/scan/repo/inline_test.go
+++ b/internal/scan/repo/inline_test.go
@@ -443,6 +443,78 @@ func TestApplyInlineSuppression(t *testing.T) {
 		}
 	})
 
+	t.Run("scans through Go func signature to find directive above", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "main.go", "package main\n// armis:ignore cwe:22\nfunc doSomething(path string) string {\n\treturn filepath.Join(path, \"subdir\")\n}\n")
+
+		findings := []model.Finding{
+			{File: "main.go", StartLine: 4, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-22"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 1 {
+			t.Fatalf("expected 1 (directive above func signature), got %d", count)
+		}
+	})
+
+	t.Run("scans through Go method signature to find directive above", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "main.go", "package main\n// armis:ignore cwe:22\nfunc (p *platform) ConfigDir(homeDir string) string {\n\treturn filepath.Join(homeDir, \".config\")\n}\n")
+
+		findings := []model.Finding{
+			{File: "main.go", StartLine: 4, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-22"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 1 {
+			t.Fatalf("expected 1 (directive above method signature), got %d", count)
+		}
+	})
+
+	t.Run("scans through Python def to find directive above", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "main.py", "import os\n# armis:ignore cwe:78\ndef run_command(cmd):\n    os.system(cmd)\n")
+
+		findings := []model.Finding{
+			{File: "main.py", StartLine: 4, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-78"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 1 {
+			t.Fatalf("expected 1 (directive above Python def), got %d", count)
+		}
+	})
+
+	t.Run("does not bleed func signature transparency across unrelated code", func(t *testing.T) {
+		dir := t.TempDir()
+		// Directive is for a different function; random code separates them
+		writeFile(t, dir, "main.go", "package main\n// armis:ignore cwe:22\nfunc safe() {}\nvar x = 1\nfunc unsafe(path string) string {\n\treturn filepath.Join(path, \"sub\")\n}\n")
+
+		findings := []model.Finding{
+			{File: "main.go", StartLine: 6, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-22"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 0 {
+			t.Fatalf("expected 0 (code line between func signatures breaks scan), got %d", count)
+		}
+	})
+
+	t.Run("func signature counts toward max scan window", func(t *testing.T) {
+		dir := t.TempDir()
+		// 6 lines above: directive is beyond the 5-line window even with func sig transparency
+		writeFile(t, dir, "main.go", "package main\n// armis:ignore cwe:22\n// c1\n// c2\n// c3\nfunc foo(p string) string {\n// c4\n\treturn filepath.Join(p, \"x\")\n}\n")
+
+		findings := []model.Finding{
+			{File: "main.go", StartLine: 8, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-22"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 0 {
+			t.Fatalf("expected 0 (directive beyond 5-line window even with func sig), got %d", count)
+		}
+	})
+
 	t.Run("suppresses finding with directive exactly 5 lines above (max window)", func(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, dir, "main.go", "package main\n// armis:ignore cwe:79\n// c1\n// c2\n// c3\n// c4\nvar x = unsafe(input)\n")

--- a/internal/scan/repo/repo.go
+++ b/internal/scan/repo/repo.go
@@ -83,7 +83,7 @@ func (s *Scanner) WithSBOMVEXOptions(opts *scan.SBOMVEXOptions) *Scanner {
 
 // Scan scans a repository at the given path.
 func (s *Scanner) Scan(ctx context.Context, path string) (*model.ScanResult, error) {
-	// Validate path to prevent path traversal
+	// armis:ignore cwe:22 reason:SanitizePath IS the path traversal prevention; rejects invalid paths before further use
 	if _, err := util.SanitizePath(path); err != nil {
 		return nil, fmt.Errorf("invalid repository path: %w", err)
 	}
@@ -140,6 +140,7 @@ func (s *Scanner) Scan(ctx context.Context, path string) (*model.ScanResult, err
 		}
 
 		tarFunc = func() error {
+			// armis:ignore cwe:253 reason:pw.Close signals EOF to pipe reader; error not actionable in deferred cleanup
 			defer pw.Close() //nolint:errcheck // signals EOF to reader
 			return s.tarGzFiles(absPath, existing, pw)
 		}

--- a/internal/scan/sbom_vex.go
+++ b/internal/scan/sbom_vex.go
@@ -120,8 +120,7 @@ func (d *SBOMVEXDownloader) downloadAndSave(ctx context.Context, url, outputPath
 		return fmt.Errorf("invalid %s URL: %w", docType, err)
 	}
 
-	// DownloadFromPresignedURL enforces size limits (100MB max via io.LimitReader)
-	// and timeout (5min) to prevent resource exhaustion attacks
+	// armis:ignore cwe:770 reason:DownloadFromPresignedURL enforces 100MB limit via io.LimitReader and 5min timeout
 	data, err := d.client.DownloadFromPresignedURL(ctx, url)
 	if err != nil {
 		return fmt.Errorf("failed to download %s: %w", docType, err)

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -233,7 +233,7 @@ func (c *Checker) writeCache(result *cacheFile) {
 	if path == "" {
 		return
 	}
-	// Validate the final path before writing to prevent path traversal (CWE-73)
+	// armis:ignore cwe:73 reason:SanitizePath IS the path traversal prevention; validates before any write
 	sanitizedPath, err := util.SanitizePath(path)
 	if err != nil {
 		return

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -190,6 +190,7 @@ func (c *Checker) fetchLatestVersion(ctx context.Context) (string, error) {
 }
 
 // getCacheFilePath returns the path to the cache file.
+// armis:ignore cwe:73 reason:cacheDir set from XDG/home path; SanitizePath validates before use
 func (c *Checker) getCacheFilePath() string {
 	if c.cacheDir != "" {
 		sanitized, err := util.SanitizePath(c.cacheDir)

--- a/internal/util/mask.go
+++ b/internal/util/mask.go
@@ -111,8 +111,8 @@ func MaskSecretInLine(line string) string {
 		return line
 	}
 
-	// armis:ignore cwe:522 reason:this IS the secret masking function; it processes secrets to redact them from output
 	// armis:ignore cwe:770 reason:maxLineLength bounds input size; this IS the resource control
+	// armis:ignore cwe:522 reason:this IS the secret masking function; it processes secrets to redact them from output
 	if len(line) > maxLineLength {
 		return line // armis:ignore cwe:522
 	}

--- a/internal/util/path.go
+++ b/internal/util/path.go
@@ -27,6 +27,7 @@ func SanitizePath(p string) (string, error) {
 		}
 	}
 
+	// armis:ignore cwe:22 reason:SanitizePath IS the path traversal prevention; Clean + Abs + traversal check below
 	cleaned := filepath.Clean(p)
 
 	if cleaned == "" {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -163,9 +163,7 @@ function Main {
     # then validate the normalized result for defense-in-depth
     $InstallDir = [System.IO.Path]::GetFullPath($InstallDir)
 
-    # After normalization, verify no ".." segments remain
-    # GetFullPath should resolve all "..", but we double-check for defense-in-depth
-    # Pattern matches ".." as a complete path segment (between backslashes or at boundaries)
+    # armis:ignore cwe:22 reason:this IS the path traversal prevention check; rejects paths with ".." segments
     if ($InstallDir -match '(^|\\)\.\.($|\\)') {
         Write-Error "Invalid install directory: path traversal detected after normalization"
         exit 1
@@ -188,7 +186,7 @@ function Main {
     }
 
     $archiveName = "armis-cli-windows-$arch.zip"
-    # Use GUID for cryptographically secure random directory name
+    # armis:ignore cwe:426 reason:$env:TEMP is the standard Windows temp dir; GUID suffix prevents collision/hijacking
     $tmpDir = Join-Path $env:TEMP "armis-cli-install-$([guid]::NewGuid().ToString())"
     New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -404,7 +404,7 @@ main() {
 
     # armis:ignore cwe:367 reason:TOCTOU between writable-check and chmod; acceptable for local installer
     if [ -w "$TARGET_PATH" ]; then
-        # armis:ignore cwe:285 reason:installer must set executable permission on installed binary
+        # armis:ignore cwe:285 cwe:367 reason:installer must chmod after download; TOCTOU benign for local install
         chmod +x "$TARGET_PATH" 2>/dev/null || true
     else
         sudo chmod +x "$TARGET_PATH" 2>/dev/null || true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -404,7 +404,8 @@ main() {
 
     # armis:ignore cwe:367 reason:TOCTOU between writable-check and chmod; acceptable for local installer
     if [ -w "$TARGET_PATH" ]; then
-        # armis:ignore cwe:285 cwe:367 reason:installer must chmod after download; TOCTOU benign for local install
+        # armis:ignore cwe:285 reason:installer must set executable permission on installed binary
+        # armis:ignore cwe:367 reason:TOCTOU between writable-check and chmod; benign for local installer
         chmod +x "$TARGET_PATH" 2>/dev/null || true
     else
         sudo chmod +x "$TARGET_PATH" 2>/dev/null || true


### PR DESCRIPTION
## Related Issue

* [PPSC-810](https://armis-security.atlassian.net/browse/PPSC-810)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

After merging the SARIF suppression filter (PR #185), 22 GitHub Code Scanning alerts remained open. Investigation revealed two root causes:

1. **`ApplyInlineSuppression` stopped at function signatures.** The upward scan breaks at any non-comment line, but in Go/Python/JS the idiomatic placement is `// armis:ignore` above the function declaration — with the `func` line between the comment and the finding inside the body.

2. **Missing `armis:ignore` comments** on several findings, and `.ps1` (PowerShell) not registered as a supported extension for inline directive parsing.

## Solution

- Modified `ApplyInlineSuppression` to treat function/method signature lines (`func`, `def`, `class`, `function`, `pub fn`, etc.) as transparent during the upward scan. A directive above a function signature now applies to findings in the function body.
- Added missing `armis:ignore` comments for all 19 suppressible findings from the CI SARIF.
- Registered `.ps1` in `commentPrefixes` so PowerShell inline directives are parsed.
- The remaining 1 alert (CVE-2026-44740 in go-git dependency) cannot be suppressed via comments — requires a dependency upgrade.

## Testing

### Automated Tests

* [x] Unit tests added/updated (5 new test cases for func signature transparency)
* [x] All existing tests still pass (27 inline suppression tests)
* [x] Full test suite passes

### Manual Testing

Verified the upward scan correctly traverses function signatures in Go, Python, and multi-level scenarios, while still stopping at regular code lines.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-810]: https://armis-security.atlassian.net/browse/PPSC-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ