### PR TITLE
[PPSC-828] fix(scan): inline suppression matches directives by applicability

### DIFF
--- a/internal/agentdetect/agentdetect.go
+++ b/internal/agentdetect/agentdetect.go
@@ -77,7 +77,7 @@ func (s *Scanner) Scan() (*ScanResult, error) {
 			}
 			userResult.Agents = append(userResult.Agents, agent)
 		}
-		result.Users = append(result.Users, userResult)
+		result.Users = append(result.Users, userResult) // armis:ignore cwe:770 reason:bounded by OS user count; enumerateUserDirs skips system dirs
 	}
 
 	return result, nil

--- a/internal/agentdetect/detector.go
+++ b/internal/agentdetect/detector.go
@@ -70,7 +70,7 @@ func hasExtensionPrefix(resolvedHome, extDir, prefix string) bool {
 	}
 	// armis:ignore cwe:770 reason:reads bounded directory (e.g. ~/.vscode/extensions); extDir validated via isUnderDir above
 	entries, err := os.ReadDir(extDir)
-	if err != nil {
+	if err != nil { // armis:ignore cwe:770 reason:reads bounded directory; validated via isUnderDir
 		return false
 	}
 	lower := strings.ToLower(prefix)

--- a/internal/agentdetect/mcpconfig.go
+++ b/internal/agentdetect/mcpconfig.go
@@ -20,7 +20,7 @@ func HasArmisMCP(resolvedHome, configPath string) bool {
 	if !isUnderDir(resolvedHome, configPath) {
 		return false
 	}
-	// armis:ignore cwe:770 reason:reads bounded local config file; path validated by isUnderDir
+	// armis:ignore cwe:770 cwe:22 reason:reads bounded local config file; path validated by isUnderDir
 	data, err := os.ReadFile(configPath) //nolint:gosec // path validated by isUnderDir
 	if err != nil {
 		return false

--- a/internal/agentdetect/platform_windows.go
+++ b/internal/agentdetect/platform_windows.go
@@ -28,6 +28,7 @@ func (p *windowsPlatform) VSCodeExtensionsDir(homeDir string) string {
 	return filepath.Join(homeDir, ".vscode", "extensions")
 }
 
+// armis:ignore cwe:22 reason:homeDir is from os.UserHomeDir; joined with hardcoded path segments
 func (p *windowsPlatform) JetBrainsPluginDirs(homeDir string) []string {
 	return globJetBrainsPluginDirs(filepath.Join(homeDir, "AppData", "Roaming", "JetBrains"))
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -289,6 +289,7 @@ func (c *Client) StartIngest(ctx context.Context, opts IngestOptions) (string, e
 	// This prevents a deadlock where the goroutine blocks on opts.Data.Read()
 	// while we wait on errChan after a request creation failure.
 	endpoint := strings.TrimSuffix(c.baseURL, "/") + "/api/v1/ingest/tar"
+	// armis:ignore cwe:918 reason:baseURL validated in NewClient (HTTPS enforced, no user-controlled URL components)
 	req, err := http.NewRequestWithContext(uploadCtx, "POST", endpoint, pr)
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
@@ -760,6 +761,7 @@ func (c *Client) ValidatePresignedURL(presignedURL string) error {
 	// - bucket.s3.amazonaws.com (legacy)
 	// - bucket.s3.region.amazonaws.com (current)
 	// - s3.region.amazonaws.com/bucket (path-style)
+	// armis:ignore cwe:918 reason:this IS the SSRF validation function; allowlisting verified S3 endpoints
 	if strings.HasSuffix(host, ".amazonaws.com") && strings.Contains(host, "s3") {
 		return nil
 	}
@@ -785,6 +787,7 @@ func (c *Client) DownloadFromPresignedURL(ctx context.Context, presignedURL stri
 	}
 
 	// Note: Pre-signed URLs include authentication, so no auth header needed
+	// armis:ignore cwe:918 reason:URL validated by ValidatePresignedURL above (HTTPS + S3 host allowlist)
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download: %w", err)

--- a/internal/auth/region_cache.go
+++ b/internal/auth/region_cache.go
@@ -43,6 +43,7 @@ func (c *RegionCache) Load(clientID string) (string, bool) {
 		return "", false
 	}
 
+	// armis:ignore cwe:367 reason:stat-then-read race is benign; worst case reads stale cache, no security impact
 	info, err := os.Stat(path)
 	if err != nil {
 		return "", false

--- a/internal/cmd/output_helper.go
+++ b/internal/cmd/output_helper.go
@@ -83,8 +83,8 @@ func ResolveOutput(cmd *cobra.Command, outputPath, formatFlag, colorFlag string)
 		output.SyncColors()
 	}
 
-	// armis:ignore cwe:73 reason:outputPath is from --output flag; user-controlled CLI arg for their own files
-	fileOutput, err := output.NewFileOutput(outputPath)
+	// armis:ignore cwe:22 reason:outputPath is from --output flag; user-controlled CLI arg for their own files
+	fileOutput, err := output.NewFileOutput(outputPath) // armis:ignore cwe:73 reason:outputPath from --output flag; user's own files
 	if err != nil {
 		// Restore previous state on error
 		cli.SetOutputToFile(prevOutputToFile)

--- a/internal/cmd/scan_image.go
+++ b/internal/cmd/scan_image.go
@@ -116,8 +116,9 @@ var scanImageCmd = &cobra.Command{
 				return handleScanError(ctx, err)
 			}
 		} else {
+			// armis:ignore cwe:20 reason:imageName validated by distribution/reference.ParseNormalizedNamed in ScanImage
 			imageName := args[0]
-			result, err = scanner.ScanImage(ctx, imageName)
+			result, err = scanner.ScanImage(ctx, imageName) // armis:ignore cwe:20 reason:validated by reference.ParseNormalizedNamed in ScanImage
 			if err != nil {
 				return handleScanError(ctx, err)
 			}

--- a/internal/install/claude.go
+++ b/internal/install/claude.go
@@ -38,6 +38,7 @@ func (ci *ClaudeInstaller) InstalledVersion() string {
 
 // Install downloads and installs the MCP plugin for Claude Code.
 func (ci *ClaudeInstaller) Install() error {
+	// armis:ignore cwe:253 reason:intentionally checks only IsNotExist; other stat errors are irrelevant to user-facing message
 	if _, err := os.Stat(ci.claudeDir); os.IsNotExist(err) {
 		return fmt.Errorf("Claude Code directory not found at %s — is Claude Code installed?", ci.claudeDir) //nolint:staticcheck // proper noun
 	}

--- a/internal/install/uninstall.go
+++ b/internal/install/uninstall.go
@@ -178,7 +178,7 @@ func (u *Uninstaller) RemovePluginFiles(keepCredentials bool) error {
 func (u *Uninstaller) editorConfigPath(id EditorID, e Editor) string {
 	if u.manifest != nil {
 		if entry, ok := u.manifest.Editors[id]; ok {
-			return entry.ConfigFile // armis:ignore cwe:73 reason:manifest written by our install with paths from ConfigPath(); not external input
+			return entry.ConfigFile // armis:ignore cwe:73 cwe:22 reason:manifest written by our install with paths from ConfigPath(); not external input
 		}
 		// Editor not in manifest — still check its default path so we catch
 		// registrations that predate manifest tracking.

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -193,7 +193,7 @@ func normalizeCVE(s string) string {
 func stripMarkdown(md string) string {
 	// armis:ignore cwe:770 reason:input is finding description from API (bounded by API response size)
 	result := md
-	result = mdHeaderRegex.ReplaceAllString(result, "")       // Remove # headers
+	result = mdHeaderRegex.ReplaceAllString(result, "")       // armis:ignore cwe:770 reason:input bounded by API response size
 	result = mdBoldItalicRegex.ReplaceAllString(result, "$1") // **bold** → bold
 	result = mdLinkRegex.ReplaceAllString(result, "$1")       // [text](url) → text
 	result = mdCodeRegex.ReplaceAllString(result, "$1")       // `code` → code

--- a/internal/scan/mask.go
+++ b/internal/scan/mask.go
@@ -18,6 +18,7 @@ import (
 //
 // Text fields (Explanation, Recommendations, Feedback) are NOT masked as they contain
 // human-readable analysis, not raw code.
+// armis:ignore cwe:522 reason:text fields contain analysis prose, not code; masking would corrupt explanations with false positives
 func MaskFixSecrets(fix *model.Fix) *model.Fix {
 	if fix == nil {
 		return nil

--- a/internal/scan/repo/gitchanges.go
+++ b/internal/scan/repo/gitchanges.go
@@ -263,6 +263,7 @@ func runGit(dir string, args ...string) (string, error) {
 	// Force English output for consistent error message parsing across locales
 	cmd.Env = append(os.Environ(), "LC_ALL=C")
 
+	// armis:ignore cwe:770 reason:git output bounded by repo size; used only for diff/log of controlled internal operations
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/scan/repo/inline.go
+++ b/internal/scan/repo/inline.go
@@ -50,7 +50,7 @@ var classKeywordExts = map[string]bool{
 type InlineDirective struct {
 	Category string
 	Rule     string
-	CWE      string
+	CWEs     []string
 	Severity string
 	Reason   string
 }
@@ -170,8 +170,11 @@ func ApplyInlineSuppression(findings []model.Finding, repoRoot string) int {
 		// a function declaration applies to findings in the function body.
 		var directive *InlineDirective
 		if d := parseInlineComment(fl.lines[lineIdx], prefixes); d != nil {
-			directive = d
-		} else {
+			if matchesInlineDirective(findings[i], d) { //nolint:gosec // G602 false positive: i is bounded by range
+				directive = d
+			}
+		}
+		if directive == nil {
 			for offset := 1; offset <= maxScanLinesAbove && lineIdx-offset >= 0; offset++ {
 				above := fl.lines[lineIdx-offset]
 				trimmed := strings.TrimSpace(above)
@@ -185,8 +188,11 @@ func ApplyInlineSuppression(findings []model.Finding, repoRoot string) int {
 					continue
 				}
 				if d := parseInlineComment(above, prefixes); d != nil {
-					directive = d
-					break
+					if matchesInlineDirective(findings[i], d) { //nolint:gosec // G602 false positive: i is bounded by range
+						directive = d
+						break
+					}
+					continue
 				}
 			}
 		}
@@ -195,11 +201,9 @@ func ApplyInlineSuppression(findings []model.Finding, repoRoot string) int {
 			continue
 		}
 
-		if matchesInlineDirective(findings[i], directive) { //nolint:gosec // G602 false positive: i is bounded by range
-			findings[i].Suppressed = true                                       //nolint:gosec // G602 false positive: i is bounded by range
-			findings[i].SuppressionInfo = buildInlineSuppressionInfo(directive) //nolint:gosec // G602 false positive: i is bounded by range
-			suppressed++
-		}
+		findings[i].Suppressed = true                                       //nolint:gosec // G602 false positive: i is bounded by range
+		findings[i].SuppressionInfo = buildInlineSuppressionInfo(directive) //nolint:gosec // G602 false positive: i is bounded by range
+		suppressed++
 	}
 
 	return suppressed
@@ -356,7 +360,7 @@ func parseDirectiveParams(text string) *InlineDirective {
 			d.Rule = value
 			recognized = true
 		case string(DirectiveCWE):
-			d.CWE = value
+			d.CWEs = append(d.CWEs, value)
 			recognized = true
 		case string(DirectiveSeverity):
 			d.Severity = strings.ToUpper(value)
@@ -387,8 +391,15 @@ func matchesInlineDirective(finding model.Finding, d *InlineDirective) bool {
 		}
 	}
 
-	if d.CWE != "" {
-		if !cweMatches(finding.CWEs, d.CWE) {
+	if len(d.CWEs) > 0 {
+		matched := false
+		for _, cwe := range d.CWEs {
+			if cweMatches(finding.CWEs, cwe) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
 			return false
 		}
 	}
@@ -409,9 +420,9 @@ func buildInlineSuppressionInfo(d *InlineDirective) *model.SuppressionInfo {
 	}
 
 	switch {
-	case d.CWE != "":
+	case len(d.CWEs) > 0:
 		info.Type = suppressionTypeCWE
-		info.Value = d.CWE
+		info.Value = strings.Join(d.CWEs, ",")
 	case d.Rule != "":
 		info.Type = suppressionTypeRule
 		info.Value = d.Rule

--- a/internal/scan/repo/inline_test.go
+++ b/internal/scan/repo/inline_test.go
@@ -68,7 +68,7 @@ func TestParseInlineComment(t *testing.T) {
 			name:     "cwe scope",
 			line:     "# armis:ignore cwe:798",
 			prefixes: []string{"#"},
-			want:     &InlineDirective{CWE: "798"},
+			want:     &InlineDirective{CWEs: []string{"798"}},
 		},
 		{
 			name:     "severity scope",
@@ -80,13 +80,19 @@ func TestParseInlineComment(t *testing.T) {
 			name:     "multiple params",
 			line:     "# armis:ignore category:sast cwe:79",
 			prefixes: []string{"#"},
-			want:     &InlineDirective{Category: "sast", CWE: "79"},
+			want:     &InlineDirective{Category: "sast", CWEs: []string{"79"}},
+		},
+		{
+			name:     "multiple CWEs",
+			line:     "// armis:ignore cwe:73 cwe:22 reason:both apply",
+			prefixes: []string{"//"},
+			want:     &InlineDirective{CWEs: []string{"73", "22"}, Reason: "both apply"},
 		},
 		{
 			name:     "with reason",
 			line:     "// armis:ignore cwe:798 reason: this is a test token",
 			prefixes: []string{"//"},
-			want:     &InlineDirective{CWE: "798", Reason: "this is a test token"},
+			want:     &InlineDirective{CWEs: []string{"798"}, Reason: "this is a test token"},
 		},
 		{
 			name:     "case insensitive ARMIS:IGNORE",
@@ -146,7 +152,7 @@ func TestParseInlineComment(t *testing.T) {
 			name:     "real comment after string literal accepted",
 			line:     `x := "value" // armis:ignore cwe:798`,
 			prefixes: []string{"//"},
-			want:     &InlineDirective{CWE: "798"},
+			want:     &InlineDirective{CWEs: []string{"798"}},
 		},
 		{
 			name:     "params in any order - severity then category",
@@ -158,13 +164,13 @@ func TestParseInlineComment(t *testing.T) {
 			name:     "params in any order - cwe then category",
 			line:     "# armis:ignore cwe:79 category:sast",
 			prefixes: []string{"#"},
-			want:     &InlineDirective{CWE: "79", Category: "sast"},
+			want:     &InlineDirective{CWEs: []string{"79"}, Category: "sast"},
 		},
 		{
 			name:     "params in any order - rule then severity then cwe",
 			line:     "// armis:ignore rule:CKV_AWS_18 severity:HIGH cwe:798",
 			prefixes: []string{"//"},
-			want:     &InlineDirective{Rule: "CKV_AWS_18", Severity: "HIGH", CWE: "798"},
+			want:     &InlineDirective{Rule: "CKV_AWS_18", Severity: "HIGH", CWEs: []string{"798"}},
 		},
 		{
 			name:     "prefix inside backtick string rejected",
@@ -176,19 +182,19 @@ func TestParseInlineComment(t *testing.T) {
 			name:     "real comment after backtick string accepted",
 			line:     "x := `value` // armis:ignore cwe:79",
 			prefixes: []string{"//"},
-			want:     &InlineDirective{CWE: "79"},
+			want:     &InlineDirective{CWEs: []string{"79"}},
 		},
 		{
 			name:     "tabs between params handled",
 			line:     "# armis:ignore\tcategory:sast\tcwe:79",
 			prefixes: []string{"#"},
-			want:     &InlineDirective{Category: "sast", CWE: "79"},
+			want:     &InlineDirective{Category: "sast", CWEs: []string{"79"}},
 		},
 		{
 			name:     "multiple spaces between params handled",
 			line:     "# armis:ignore  category:sast   cwe:79",
 			prefixes: []string{"#"},
-			want:     &InlineDirective{Category: "sast", CWE: "79"},
+			want:     &InlineDirective{Category: "sast", CWEs: []string{"79"}},
 		},
 		{
 			name:     "unknown key only - returns nil",
@@ -200,13 +206,13 @@ func TestParseInlineComment(t *testing.T) {
 			name:     "unknown key with valid key - keeps valid",
 			line:     "# armis:ignore catgory:sast cwe:79",
 			prefixes: []string{"#"},
-			want:     &InlineDirective{CWE: "79"},
+			want:     &InlineDirective{CWEs: []string{"79"}},
 		},
 		{
 			name:     "block comment in JS",
 			line:     "/* armis:ignore cwe:79 */",
 			prefixes: []string{"//", "/*"},
-			want:     &InlineDirective{CWE: "79"},
+			want:     &InlineDirective{CWEs: []string{"79"}},
 		},
 		{
 			name:     "leading whitespace",
@@ -234,8 +240,8 @@ func TestParseInlineComment(t *testing.T) {
 			if got.Rule != tt.want.Rule {
 				t.Errorf("Rule = %q, want %q", got.Rule, tt.want.Rule)
 			}
-			if got.CWE != tt.want.CWE {
-				t.Errorf("CWE = %q, want %q", got.CWE, tt.want.CWE)
+			if !slicesEqual(got.CWEs, tt.want.CWEs) {
+				t.Errorf("CWEs = %v, want %v", got.CWEs, tt.want.CWEs)
 			}
 			if got.Severity != tt.want.Severity {
 				t.Errorf("Severity = %q, want %q", got.Severity, tt.want.Severity)
@@ -275,13 +281,13 @@ func TestMatchesInlineDirective(t *testing.T) {
 		{
 			name:      "cwe matches",
 			finding:   model.Finding{CWEs: []string{"CWE-79: Cross-site Scripting"}},
-			directive: &InlineDirective{CWE: "79"},
+			directive: &InlineDirective{CWEs: []string{"79"}},
 			want:      true,
 		},
 		{
 			name:      "cwe does not match",
 			finding:   model.Finding{CWEs: []string{"CWE-89"}},
-			directive: &InlineDirective{CWE: "79"},
+			directive: &InlineDirective{CWEs: []string{"79"}},
 			want:      false,
 		},
 		{
@@ -299,19 +305,19 @@ func TestMatchesInlineDirective(t *testing.T) {
 		{
 			name:      "AND logic: both category and cwe must match - both match",
 			finding:   model.Finding{Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-79"}},
-			directive: &InlineDirective{Category: "sast", CWE: "79"},
+			directive: &InlineDirective{Category: "sast", CWEs: []string{"79"}},
 			want:      true,
 		},
 		{
 			name:      "AND logic: category matches but cwe does not",
 			finding:   model.Finding{Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-89"}},
-			directive: &InlineDirective{Category: "sast", CWE: "79"},
+			directive: &InlineDirective{Category: "sast", CWEs: []string{"79"}},
 			want:      false,
 		},
 		{
 			name:      "AND logic: cwe matches but category does not",
 			finding:   model.Finding{Type: model.FindingTypeSecret, CWEs: []string{"CWE-79"}},
-			directive: &InlineDirective{Category: "sast", CWE: "79"},
+			directive: &InlineDirective{Category: "sast", CWEs: []string{"79"}},
 			want:      false,
 		},
 		{
@@ -820,7 +826,7 @@ func TestBuildInlineSuppressionInfo(t *testing.T) {
 		},
 		{
 			name:      "cwe takes priority",
-			directive: &InlineDirective{CWE: "79", Category: "sast"},
+			directive: &InlineDirective{CWEs: []string{"79"}, Category: "sast"},
 			wantType:  "cwe",
 			wantValue: "79",
 		},
@@ -860,6 +866,143 @@ func TestBuildInlineSuppressionInfo(t *testing.T) {
 	}
 }
 
+func TestApplyInlineSuppression_StackedComments(t *testing.T) {
+	t.Run("nearest directive wrong CWE, farther directive matches", func(t *testing.T) {
+		dir := t.TempDir()
+		// Line 1: package main
+		// Line 2: // armis:ignore cwe:367 reason:TOCTOU benign
+		// Line 3: // armis:ignore cwe:22 reason:path validated
+		// Line 4: f, err := os.Open(filePath)
+		writeFile(t, dir, "main.go", "package main\n// armis:ignore cwe:367 reason:TOCTOU benign\n// armis:ignore cwe:22 reason:path validated\nf, err := os.Open(filePath)\n")
+
+		findings := []model.Finding{
+			{File: "main.go", StartLine: 4, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-367"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 1 {
+			t.Fatalf("expected 1 (stacked: nearest is cwe:22, farther is cwe:367), got %d", count)
+		}
+		if findings[0].SuppressionInfo.Value != "367" {
+			t.Errorf("expected suppression value 367, got %q", findings[0].SuppressionInfo.Value)
+		}
+	})
+
+	t.Run("stacked comments no match at all", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "main.go", "package main\n// armis:ignore cwe:79\n// armis:ignore cwe:89\nvar x = doSomething(input)\n")
+
+		findings := []model.Finding{
+			{File: "main.go", StartLine: 4, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-22"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 0 {
+			t.Fatalf("expected 0 (stacked comments, none match CWE-22), got %d", count)
+		}
+	})
+
+	t.Run("stacked comments nearest matches", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "main.go", "package main\n// armis:ignore cwe:79 reason:farther\n// armis:ignore cwe:22 reason:nearest\nvar path = readFile(input)\n")
+
+		findings := []model.Finding{
+			{File: "main.go", StartLine: 4, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-22"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 1 {
+			t.Fatalf("expected 1 (nearest stacked comment matches), got %d", count)
+		}
+		if findings[0].SuppressionInfo.Reason != "nearest" {
+			t.Errorf("expected reason from nearest directive, got %q", findings[0].SuppressionInfo.Reason)
+		}
+	})
+}
+
+func TestApplyInlineSuppression_SameLineNonMatchFallsThrough(t *testing.T) {
+	t.Run("non-matching end-of-line directive falls through to comment above", func(t *testing.T) {
+		dir := t.TempDir()
+		// Line 1: package main
+		// Line 2: // armis:ignore cwe:22 reason:path traversal OK
+		// Line 3: fileOutput, err := output.NewFileOutput(path) // armis:ignore cwe:73 reason:other
+		writeFile(t, dir, "main.go", "package main\n// armis:ignore cwe:22 reason:path traversal OK\nfileOutput, err := output.NewFileOutput(path) // armis:ignore cwe:73 reason:other\n")
+
+		findings := []model.Finding{
+			{File: "main.go", StartLine: 3, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-22"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 1 {
+			t.Fatalf("expected 1 (end-of-line cwe:73 doesn't match CWE-22, but comment above does), got %d", count)
+		}
+		if findings[0].SuppressionInfo.Reason != "path traversal OK" {
+			t.Errorf("expected reason from above-line directive, got %q", findings[0].SuppressionInfo.Reason)
+		}
+	})
+
+	t.Run("matching end-of-line directive takes precedence over comment above", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "main.go", "package main\n// armis:ignore cwe:22 reason:above\nfileOutput, err := output.NewFileOutput(path) // armis:ignore cwe:22 reason:inline\n")
+
+		findings := []model.Finding{
+			{File: "main.go", StartLine: 3, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-22"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 1 {
+			t.Fatalf("expected 1 (end-of-line directive matches), got %d", count)
+		}
+		if findings[0].SuppressionInfo.Reason != "inline" {
+			t.Errorf("expected reason from same-line directive (precedence), got %q", findings[0].SuppressionInfo.Reason)
+		}
+	})
+}
+
+func TestApplyInlineSuppression_MultiCWE(t *testing.T) {
+	t.Run("multi-CWE comment suppresses either CWE", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "main.go", "package main\n// armis:ignore cwe:73 cwe:22 reason:both apply\nfileOutput, err := output.NewFileOutput(path)\n")
+
+		findings := []model.Finding{
+			{File: "main.go", StartLine: 3, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-73"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 1 {
+			t.Fatalf("expected 1 (multi-CWE: finding is CWE-73, directive has cwe:73 cwe:22), got %d", count)
+		}
+	})
+
+	t.Run("multi-CWE suppresses second CWE too", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "main.go", "package main\n// armis:ignore cwe:73 cwe:22 reason:both apply\nfileOutput, err := output.NewFileOutput(path)\n")
+
+		findings := []model.Finding{
+			{File: "main.go", StartLine: 3, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-22"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 1 {
+			t.Fatalf("expected 1 (multi-CWE: finding is CWE-22, directive has cwe:73 cwe:22), got %d", count)
+		}
+	})
+
+	t.Run("multi-CWE does not suppress unrelated CWE", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "main.go", "package main\n// armis:ignore cwe:73 cwe:22 reason:both apply\nfileOutput, err := output.NewFileOutput(path)\n")
+
+		findings := []model.Finding{
+			{File: "main.go", StartLine: 3, Type: model.FindingTypeVulnerability, CWEs: []string{"CWE-89"}},
+		}
+
+		count := ApplyInlineSuppression(findings, dir)
+		if count != 0 {
+			t.Fatalf("expected 0 (multi-CWE: finding is CWE-89, not in cwe:73 cwe:22), got %d", count)
+		}
+	})
+}
+
 func writeFile(t *testing.T, dir, name, content string) {
 	t.Helper()
 	path := filepath.Join(dir, name)
@@ -869,4 +1012,16 @@ func writeFile(t *testing.T, dir, name, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/scan/repo/suppression.go
+++ b/internal/scan/repo/suppression.go
@@ -135,6 +135,7 @@ func parseDirectiveLine(line string) (*SuppressionDirective, bool, string) {
 
 	switch prefix {
 	case "rule":
+		// armis:ignore cwe:20 reason:value is from internal .armisignore file; format validated by prefix/colonIdx parsing above
 		if value == "" {
 			return nil, false, fmt.Sprintf("empty rule directive ignored: %q", line)
 		}
@@ -155,6 +156,7 @@ func parseDirectiveLine(line string) (*SuppressionDirective, bool, string) {
 		return &SuppressionDirective{Type: DirectiveSeverity, Value: normalized, Reason: reason}, true, ""
 
 	case "cwe":
+		// armis:ignore cwe:20 reason:validateCWE rejects non-numeric input; accepting any integer is by design for forward-compat
 		normalized, valid, warning := validateCWE(value)
 		if !valid {
 			return nil, false, warning

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -217,7 +217,7 @@ func (c *Checker) readCache() *cacheFile {
 	}
 	// armis:ignore cwe:73 reason:path already validated by SanitizePath above; reads CLI version cache file
 	data, err := os.ReadFile(sanitizedPath) //nolint:gosec // path validated by SanitizePath
-	if err != nil {
+	if err != nil {                         // armis:ignore cwe:73 reason:path validated by SanitizePath; reads CLI version cache
 		return nil
 	}
 	var cache cacheFile

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -79,6 +79,7 @@ function Verify-Checksums {
         [string]$ChecksumsSig
     )
 
+    # armis:ignore cwe:494 reason:$Verify defaults true; explicit opt-out for environments without cosign (documented flag)
     if (-not $Verify) {
         Write-Host "⚠️  Skipping verification (-Verify:`$false)"
         return
@@ -215,6 +216,7 @@ function Main {
         Write-Host ""
 
         Write-Host "📂 Extracting archive..."
+        # armis:ignore cwe:22 reason:archiveFile downloaded from verified GitHub release with checksum validation above
         Expand-Archive -Path $archiveFile -DestinationPath $tmpDir -Force
 
         Write-Host "📥 Installing to $InstallDir..."
@@ -245,12 +247,13 @@ function Main {
         # Add to PATH (skip persistent changes in CI environments where PATH is ephemeral)
         if (-not (Test-CIEnvironment)) {
             $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")
+            # armis:ignore cwe:426 reason:InstallDir validated by Resolve-InstallDir; adds our own install directory to user PATH
             $newUserPath = Add-DirectoryToPath -ExistingPath $currentPath -Directory $InstallDir
             if ($newUserPath -ne $currentPath) {
                 Write-Host "Adding to PATH..."
                 # armis:ignore cwe:426 reason:installer adds its own validated InstallDir to user PATH; standard installer pattern
                 [Environment]::SetEnvironmentVariable(
-                    "Path",
+                    "Path", # armis:ignore cwe:426 reason:installer sets validated InstallDir to user PATH
                     $newUserPath,
                     "User"
                 )

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -355,6 +355,7 @@ main() {
     download_file "$BASE_URL/${BINARY_NAME}-checksums.txt.sig" "$CHECKSUMS_SIG" || true
 
     echo ""
+    # armis:ignore cwe:253 reason:verify_checksums calls fail() on any error; non-zero exit propagates via set -e
     verify_checksums "$ARCHIVE_FILE" "$CHECKSUMS_FILE" "$CHECKSUMS_SIG"
     echo ""
 
@@ -393,7 +394,7 @@ main() {
 
     # armis:ignore cwe:367 reason:TOCTOU between writable-check and mv is acceptable for installer; no security boundary crossed
     if [ -w "$INSTALL_DIR" ]; then
-        # armis:ignore cwe:73 reason:INSTALL_DIR validated by validate_install_dir() when user-set; defaults are hardcoded safe paths
+        # armis:ignore cwe:73 cwe:59 reason:INSTALL_DIR validated by validate_install_dir() when user-set; defaults are hardcoded safe paths
         # armis:ignore cwe:367 reason:mv after writable-check; acceptable TOCTOU for local installer binary placement
         mv "$BINARY_FILE" "$TARGET_PATH" || fail "Failed to move binary to $TARGET_PATH"
     else


### PR DESCRIPTION
## Related Issue

* [PPSC-828](https://armis-security.atlassian.net/browse/PPSC-828)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

The inline suppression engine (`armis:ignore`) had a matching bug: it accepted the first nearby directive without checking whether it actually applied to the finding. With stacked comments targeting different CWEs, the nearest comment would suppress findings it shouldn't, while correct directives farther away were never reached. Additionally, a single comment couldn't specify multiple CWEs.

## Solution

- Move `matchesInlineDirective()` check **before** accepting a directive (both same-line and above-line paths)
- When a same-line directive doesn't match, fall through to scan comments above
- When scanning above-line comments, `continue` past non-matching directives instead of stopping
- Change `InlineDirective.CWE string` → `CWEs []string` to support multiple `cwe:` params with OR logic
- Fix/add `armis:ignore` comments across the codebase to match the correct CWEs for SARIF accuracy

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

- Verified stacked comments: nearest wrong CWE skipped, farther matching CWE suppresses correctly
- Verified same-line non-match falls through to above-line comments
- Verified multi-CWE directive (`cwe:73 cwe:22`) suppresses either CWE but not unrelated ones

## Reviewer Notes

- The bulk of file changes outside `internal/scan/repo/` are `armis:ignore` comment corrections (wrong CWE IDs, missing annotations) discovered while fixing the suppression logic
- `InlineDirective.CWE` → `CWEs` is a breaking change to an internal struct (not exported to consumers)

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-828]: https://armis-security.atlassian.net/browse/PPSC-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ