### PR TITLE
docs: update CHANGELOG for v1.9.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.9.2] - 2026-05-25
+
+### Fixed
+
+- Inline suppression now matches directives by applicability (CWE, category, rule) before accepting, preventing false suppressions from stacked comments and ensuring fall-through to the correct directive (#189)
+
+---
+
 ## [1.9.1] - 2026-05-24
 
 ### Fixed
@@ -350,7 +358,8 @@ Manual entries for significant releases:
 
 -->
 
-[Unreleased]: https://github.com/ArmisSecurity/armis-cli/compare/v1.9.1...HEAD
+[Unreleased]: https://github.com/ArmisSecurity/armis-cli/compare/v1.9.2...HEAD
+[1.9.2]: https://github.com/ArmisSecurity/armis-cli/compare/v1.9.1...v1.9.2
 [1.9.1]: https://github.com/ArmisSecurity/armis-cli/compare/v1.9.0...v1.9.1
 [1.9.0]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.4...v1.9.0
 [1.8.4]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.3...v1.8.4


### PR DESCRIPTION
## Summary
- Release preparation for armis-cli v1.9.2 (PATCH)
- Changelog updated with fix from #189: inline suppression now matches directives by applicability before accepting

## Release ticket
[PPSC-829](https://armis-security.atlassian.net/browse/PPSC-829)

## Test plan
- [ ] CI passes
- [ ] Changelog formatting verified
- [ ] After merge: tag `v1.9.2`, publish GitHub Release, verify Homebrew update

[PPSC-829]: https://armis-security.atlassian.net/browse/PPSC-829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ