### PR TITLE
[PPSC-830] test(coverage): add unit tests for install, uninstall, scan, and inline suppression

### DIFF
--- a/internal/cmd/install_test.go
+++ b/internal/cmd/install_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ArmisSecurity/armis-cli/internal/install"
+)
+
+func TestInstallTargetsUnknownEditor(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	err := installTargets([]string{"nonexistent-editor"}, false)
+	if err == nil {
+		t.Fatal("expected error for unknown editor")
+	}
+	if got := err.Error(); got == "" {
+		t.Error("error message should not be empty")
+	}
+}
+
+func TestInstallTargetsAdvisoryEditors(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	advisoryEditors := []string{"jetbrains", "devin", "openhands", "aider"}
+	for _, name := range advisoryEditors {
+		t.Run(name, func(t *testing.T) {
+			err := installTargets([]string{name}, false)
+			if err != nil {
+				t.Errorf("installTargets(%q) unexpected error: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestShowInstalledVersionsNoVersion(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	// Create .claude dir so NewClaudeInstaller doesn't error on its own
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(filepath.Join(claudeDir, "plugins"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	err := showInstalledVersions()
+	if err == nil {
+		t.Fatal("expected error when no version installed")
+	}
+}
+
+func TestShowInstalledVersionsWithMCPVersion(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	// Stage an .installed-version file in the expected plugin dir
+	pluginDir := filepath.Join(home, ".armis", "plugins", "armis-appsec-mcp")
+	if err := os.MkdirAll(pluginDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, ".installed-version"), []byte("1.5.0"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create .claude dir so NewClaudeInstaller doesn't error
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(filepath.Join(claudeDir, "plugins"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	err := showInstalledVersions()
+	if err != nil {
+		t.Errorf("showInstalledVersions() unexpected error: %v", err)
+	}
+}
+
+func TestPrintCredentialStatusWithEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	pluginDir := filepath.Join(home, ".armis", "plugins", "armis-appsec-mcp")
+	if err := os.MkdirAll(pluginDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, ".env"), []byte("CLIENT_ID=test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ei := install.NewEditorInstaller()
+	printCredentialStatus(ei)
+}
+
+func TestPrintCredentialStatusWithoutEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	pluginDir := filepath.Join(home, ".armis", "plugins", "armis-appsec-mcp")
+	if err := os.MkdirAll(pluginDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	ei := install.NewEditorInstaller()
+	printCredentialStatus(ei)
+}

--- a/internal/cmd/uninstall_test.go
+++ b/internal/cmd/uninstall_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ArmisSecurity/armis-cli/internal/install"
+)
+
+func TestConfirm(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"y returns true", "y\n", true},
+		{"yes returns true", "yes\n", true},
+		{"Y returns true", "Y\n", true},
+		{"YES returns true", "YES\n", true},
+		{"n returns false", "n\n", false},
+		{"no returns false", "no\n", false},
+		{"empty returns false", "\n", false},
+		{"arbitrary text returns false", "maybe\n", false},
+		{"whitespace y returns true", "  y  \n", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, _ = w.WriteString(tt.input)
+			_ = w.Close()
+
+			oldStdin := os.Stdin
+			os.Stdin = r
+			defer func() { os.Stdin = oldStdin }()
+
+			got := confirm("Continue?")
+			if got != tt.want {
+				t.Errorf("confirm() with input %q = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("EOF returns false", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = w.Close()
+
+		oldStdin := os.Stdin
+		os.Stdin = r
+		defer func() { os.Stdin = oldStdin }()
+
+		if confirm("Continue?") {
+			t.Error("confirm() should return false on EOF")
+		}
+	})
+}
+
+func TestUninstallTargets(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	pluginDir := filepath.Join(home, ".armis", "plugins", "armis-appsec-mcp")
+	if err := os.MkdirAll(pluginDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	u := install.NewUninstaller()
+
+	t.Run("advisory editors do not error", func(t *testing.T) {
+		advisoryEditors := []string{"jetbrains", "devin", "openhands", "aider"}
+		for _, name := range advisoryEditors {
+			if err := uninstallTargets(u, []string{name}); err != nil {
+				t.Errorf("uninstallTargets(%q) unexpected error: %v", name, err)
+			}
+		}
+	})
+
+	t.Run("unknown editor prints warning without error", func(t *testing.T) {
+		err := uninstallTargets(u, []string{"nonexistent-editor"})
+		if err != nil {
+			t.Errorf("uninstallTargets(unknown) unexpected error: %v", err)
+		}
+	})
+
+	t.Run("copilot maps to vscode", func(t *testing.T) {
+		err := uninstallTargets(u, []string{"copilot"})
+		if err != nil {
+			t.Errorf("uninstallTargets(copilot) unexpected error: %v", err)
+		}
+	})
+}
+
+func TestUninstallAllForce(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	pluginDir := filepath.Join(home, ".armis", "plugins", "armis-appsec-mcp")
+	if err := os.MkdirAll(pluginDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "server.py"), []byte("# server"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, ".env"), []byte("CLIENT_ID=test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("force skips confirmation and removes files", func(t *testing.T) {
+		u := install.NewUninstaller()
+		err := uninstallAll(u, false, true)
+		if err != nil {
+			t.Errorf("uninstallAll(force=true) unexpected error: %v", err)
+		}
+	})
+
+	t.Run("keep-credentials preserves env file", func(t *testing.T) {
+		if err := os.MkdirAll(pluginDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pluginDir, "server.py"), []byte("# server"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pluginDir, ".env"), []byte("CLIENT_ID=test"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		u := install.NewUninstaller()
+		err := uninstallAll(u, true, true)
+		if err != nil {
+			t.Errorf("uninstallAll(keepCreds=true, force=true) unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/cmd/uninstall_test.go
+++ b/internal/cmd/uninstall_test.go
@@ -36,7 +36,10 @@ func TestConfirm(t *testing.T) {
 
 			oldStdin := os.Stdin
 			os.Stdin = r
-			defer func() { os.Stdin = oldStdin }()
+			t.Cleanup(func() {
+				os.Stdin = oldStdin
+				_ = r.Close()
+			})
 
 			got := confirm("Continue?")
 			if got != tt.want {
@@ -54,7 +57,10 @@ func TestConfirm(t *testing.T) {
 
 		oldStdin := os.Stdin
 		os.Stdin = r
-		defer func() { os.Stdin = oldStdin }()
+		t.Cleanup(func() {
+			os.Stdin = oldStdin
+			_ = r.Close()
+		})
 
 		if confirm("Continue?") {
 			t.Error("confirm() should return false on EOF")

--- a/internal/install/uninstall_test.go
+++ b/internal/install/uninstall_test.go
@@ -378,6 +378,200 @@ func TestConfigFormat(t *testing.T) {
 	}
 }
 
+func TestManifestPath(t *testing.T) {
+	dir := t.TempDir()
+
+	tests := []struct {
+		name      string
+		input     string
+		wantEmpty bool
+	}{
+		{"empty string", "", true},
+		{"relative path", "relative/dir", true},
+		{"valid absolute path", dir, false},
+		{"root path", "/", true}, // Join("/", ".manifest.json") == "/.manifest.json" which doesn't start with "/"+"/"
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ManifestPath(tt.input)
+			if tt.wantEmpty && got != "" {
+				t.Errorf("ManifestPath(%q) = %q, want empty", tt.input, got)
+			}
+			if !tt.wantEmpty && got == "" {
+				t.Errorf("ManifestPath(%q) = empty, want non-empty path", tt.input)
+			}
+		})
+	}
+
+	t.Run("valid path ends with .manifest.json", func(t *testing.T) {
+		got := ManifestPath(dir)
+		if got == "" {
+			t.Fatal("expected non-empty path")
+		}
+		if filepath.Base(got) != ".manifest.json" {
+			t.Errorf("ManifestPath() base = %q, want .manifest.json", filepath.Base(got))
+		}
+	})
+}
+
+func TestDeregisterAllEditors(t *testing.T) {
+	t.Run("manifest-based deregistration", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+
+		pluginDir := filepath.Join(home, ".armis", "plugins", "armis-appsec-mcp")
+		if err := os.MkdirAll(pluginDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a cursor config with armis entry
+		cursorConfig := filepath.Join(home, "cursor-mcp.json")
+		mustWriteJSON(t, cursorConfig, map[string]interface{}{
+			"mcpServers": map[string]interface{}{
+				"armis-appsec": map[string]interface{}{"command": "/bin/python"},
+				"other":        map[string]interface{}{"command": "/bin/other"},
+			},
+		})
+
+		// Create manifest pointing to the cursor config
+		m := NewManifest(pluginDir, "1.0.0")
+		m.AddEditor(EditorCursor, cursorConfig, "mcpServers")
+		if err := WriteManifest(m); err != nil {
+			t.Fatal(err)
+		}
+
+		// Override all editor paths to nonexistent so scan doesn't find extra editors
+		configPathOverrides = make(map[EditorID]string)
+		for _, e := range AllEditors {
+			configPathOverrides[e.ID] = filepath.Join(home, "nonexistent", string(e.ID)+".json")
+		}
+		defer func() { configPathOverrides = nil }()
+
+		u := NewUninstaller()
+		deregistered, warnings := u.DeregisterAllEditors()
+
+		if len(warnings) > 0 {
+			t.Errorf("unexpected warnings: %v", warnings)
+		}
+		if len(deregistered) != 1 || deregistered[0] != "Cursor" {
+			t.Errorf("deregistered = %v, want [Cursor]", deregistered)
+		}
+
+		// Verify armis-appsec was removed from cursor config
+		result := mustReadJSON(t, cursorConfig)
+		servers := result["mcpServers"].(map[string]interface{})
+		if _, exists := servers["armis-appsec"]; exists {
+			t.Error("armis-appsec should be removed from cursor config")
+		}
+		if _, exists := servers["other"]; !exists {
+			t.Error("other server should be preserved")
+		}
+	})
+
+	t.Run("no manifest scans known paths", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+
+		pluginDir := filepath.Join(home, ".armis", "plugins", "armis-appsec-mcp")
+		if err := os.MkdirAll(pluginDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a cursor config with armis entry in the overridden path
+		cursorConfig := filepath.Join(home, "cursor-mcp.json")
+		mustWriteJSON(t, cursorConfig, map[string]interface{}{
+			"mcpServers": map[string]interface{}{
+				"armis-appsec": map[string]interface{}{"command": "/bin/python"},
+			},
+		})
+
+		configPathOverrides = make(map[EditorID]string)
+		for _, e := range AllEditors {
+			configPathOverrides[e.ID] = filepath.Join(home, "nonexistent", string(e.ID)+".json")
+		}
+		configPathOverrides[EditorCursor] = cursorConfig
+		defer func() { configPathOverrides = nil }()
+
+		u := &Uninstaller{pluginDir: pluginDir, manifest: nil}
+		deregistered, warnings := u.DeregisterAllEditors()
+
+		if len(warnings) > 0 {
+			t.Errorf("unexpected warnings: %v", warnings)
+		}
+		if len(deregistered) != 1 || deregistered[0] != "Cursor" {
+			t.Errorf("deregistered = %v, want [Cursor]", deregistered)
+		}
+	})
+
+	t.Run("missing config file is silently skipped", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+
+		pluginDir := filepath.Join(home, ".armis", "plugins", "armis-appsec-mcp")
+		if err := os.MkdirAll(pluginDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+
+		configPathOverrides = make(map[EditorID]string)
+		for _, e := range AllEditors {
+			configPathOverrides[e.ID] = filepath.Join(home, "nonexistent", string(e.ID)+".json")
+		}
+		defer func() { configPathOverrides = nil }()
+
+		u := &Uninstaller{pluginDir: pluginDir, manifest: nil}
+		deregistered, warnings := u.DeregisterAllEditors()
+
+		if len(deregistered) != 0 {
+			t.Errorf("deregistered = %v, want empty", deregistered)
+		}
+		if len(warnings) != 0 {
+			t.Errorf("warnings = %v, want empty", warnings)
+		}
+	})
+}
+
+func TestWriteJSONAtomic(t *testing.T) {
+	t.Run("writes valid JSON", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.json")
+		data := map[string]interface{}{
+			"key": "value",
+			"num": 42,
+		}
+
+		if err := writeJSONAtomic(path, data); err != nil {
+			t.Fatalf("writeJSONAtomic() error: %v", err)
+		}
+
+		result := mustReadJSON(t, path)
+		if result["key"] != "value" {
+			t.Errorf("key = %v, want 'value'", result["key"])
+		}
+	})
+
+	t.Run("overwrites existing file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.json")
+		mustWriteJSON(t, path, map[string]interface{}{"old": true})
+
+		if err := writeJSONAtomic(path, map[string]interface{}{"new": true}); err != nil {
+			t.Fatalf("writeJSONAtomic() error: %v", err)
+		}
+
+		result := mustReadJSON(t, path)
+		if _, exists := result["old"]; exists {
+			t.Error("old content should be overwritten")
+		}
+		if _, exists := result["new"]; !exists {
+			t.Error("new content should be present")
+		}
+	})
+}
+
 // --- Test helpers ---
 
 func mustWriteJSON(t *testing.T, path string, data interface{}) {

--- a/internal/scan/repo/inline_test.go
+++ b/internal/scan/repo/inline_test.go
@@ -1025,3 +1025,65 @@ func slicesEqual(a, b []string) bool {
 	}
 	return true
 }
+
+func TestIsFuncSignature(t *testing.T) {
+	tests := []struct {
+		name    string
+		trimmed string
+		ext     string
+		want    bool
+	}{
+		{"Go func", "func Foo() {", ".go", true},
+		{"Go method", "func (s *Server) Handle() {", ".go", true},
+		{"Go non-func", "var fn = func() {", ".go", false},
+		{"Python def", "def process_request(self):", ".py", true},
+		{"Python class with parens", "class MyClass(Base):", ".py", true},
+		{"Python class with brace", "class Handler {", ".py", true},
+		{"Python non-class identifier", "class_name = 'test'", ".py", false},
+		{"Rust fn", "fn main() {", ".rs", true},
+		{"Rust pub fn", "pub fn new() -> Self {", ".rs", true},
+		{"Rust non-fn", "let fn_name = true;", ".rs", false},
+		{"Java class", "class Handler {", ".java", true},
+		{"Java class without brace", "class Handler", ".java", false},
+		{"JS function", "function handleRequest() {", ".js", true},
+		{"TS function", "function handleRequest() {", ".ts", true},
+		{"Swift func", "func viewDidLoad() {", ".swift", true},
+		{"Kotlin fun", "fun main() {", ".kt", true},
+		{"Unknown extension", "func foo()", ".txt", false},
+		{"Empty string", "", ".go", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isFuncSignature(tt.trimmed, tt.ext)
+			if got != tt.want {
+				t.Errorf("isFuncSignature(%q, %q) = %v, want %v", tt.trimmed, tt.ext, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainsAny(t *testing.T) {
+	tests := []struct {
+		name  string
+		s     string
+		chars []byte
+		want  bool
+	}{
+		{"contains first char", "hello(", []byte{'(', '{', ':'}, true},
+		{"contains colon", "class Foo:", []byte{'(', '{', ':'}, true},
+		{"contains brace", "class Foo {", []byte{'(', '{', ':'}, true},
+		{"contains none", "class Foo", []byte{'(', '{', ':'}, false},
+		{"empty string", "", []byte{'('}, false},
+		{"single char match", "(", []byte{'('}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := containsAny(tt.s, tt.chars...)
+			if got != tt.want {
+				t.Errorf("containsAny(%q, %v) = %v, want %v", tt.s, tt.chars, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/scan/title_test.go
+++ b/internal/scan/title_test.go
@@ -1,0 +1,127 @@
+package scan
+
+import (
+	"testing"
+
+	"github.com/ArmisSecurity/armis-cli/internal/model"
+)
+
+func TestGenerateFindingTitle(t *testing.T) {
+	tests := []struct {
+		name    string
+		finding *model.Finding
+		want    string
+	}{
+		{
+			name: "SCA with single CVE",
+			finding: &model.Finding{
+				Type: model.FindingTypeSCA,
+				CVEs: []string{"CVE-2024-1234"},
+			},
+			want: "CVE-2024-1234",
+		},
+		{
+			name: "SCA with multiple CVEs",
+			finding: &model.Finding{
+				Type: model.FindingTypeSCA,
+				CVEs: []string{"CVE-2024-1234", "CVE-2024-5678", "CVE-2024-9999"},
+			},
+			want: "CVE-2024-1234 (+2 more)",
+		},
+		{
+			name: "SCA with two CVEs",
+			finding: &model.Finding{
+				Type: model.FindingTypeSCA,
+				CVEs: []string{"CVE-2024-1234", "CVE-2024-5678"},
+			},
+			want: "CVE-2024-1234 (+1 more)",
+		},
+		{
+			name: "SCA with no CVEs falls through",
+			finding: &model.Finding{
+				Type:        model.FindingTypeSCA,
+				Description: "Outdated dependency",
+			},
+			want: "Outdated dependency",
+		},
+		{
+			name: "OWASP category with title and CWE",
+			finding: &model.Finding{
+				OWASPCategories: []model.OWASPCategory{{ID: "A03", Title: "Injection"}},
+				CWEs:            []string{"CWE-89"},
+			},
+			want: "Injection (CWE-89)",
+		},
+		{
+			name: "OWASP category title without CWE",
+			finding: &model.Finding{
+				OWASPCategories: []model.OWASPCategory{{ID: "A07", Title: "Broken Authentication"}},
+			},
+			want: "Broken Authentication",
+		},
+		{
+			name: "OWASP category with empty title falls through",
+			finding: &model.Finding{
+				OWASPCategories: []model.OWASPCategory{{ID: "A03", Title: ""}},
+				Description:     "SQL injection vulnerability",
+			},
+			want: "SQL injection vulnerability",
+		},
+		{
+			name: "Secret type",
+			finding: &model.Finding{
+				Type: model.FindingTypeSecret,
+			},
+			want: "Exposed Secret",
+		},
+		{
+			name: "Description with sentence ending",
+			finding: &model.Finding{
+				Description: "SQL injection found. More details follow here.",
+			},
+			want: "SQL injection found",
+		},
+		{
+			name: "Description single sentence with trailing period",
+			finding: &model.Finding{
+				Description: "Hardcoded credential.",
+			},
+			want: "Hardcoded credential",
+		},
+		{
+			name: "Description multiline",
+			finding: &model.Finding{
+				Description: "First line\nSecond line\nThird line",
+			},
+			want: "First line",
+		},
+		{
+			name: "Description without period or newline",
+			finding: &model.Finding{
+				Description: "Use of insecure random number generator",
+			},
+			want: "Use of insecure random number generator",
+		},
+		{
+			name: "Category fallback",
+			finding: &model.Finding{
+				FindingCategory: "CODE_VULNERABILITY",
+			},
+			want: "Code Vulnerability",
+		},
+		{
+			name:    "Empty finding returns default",
+			finding: &model.Finding{},
+			want:    "Security Finding",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GenerateFindingTitle(tt.finding)
+			if got != tt.want {
+				t.Errorf("GenerateFindingTitle() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Related Issue

* [PPSC-830](https://armis-security.atlassian.net/browse/PPSC-830)

## Type of Change

* [x] New feature (non-breaking change which adds functionality)

## Problem

Recent install/uninstall commands added ~1,725 lines of source code with insufficient test coverage, dropping overall coverage from ~80% to 73.5%. Key functions like `confirm`, `installTargets`, `uninstallTargets`, `GenerateFindingTitle`, `ManifestPath`, and `DeregisterAllEditors` had 0% coverage.

## Solution

Added targeted unit tests across 5 files (638 lines) to recover coverage to 76%. Tests follow existing project patterns: table-driven with `t.Run` subtests, `t.TempDir()` for filesystem isolation, `t.Setenv("HOME", ...)` for env isolation, and `configPathOverrides` for editor path injection.

**New test files:**
- `internal/scan/title_test.go` — 14 cases for `GenerateFindingTitle` (0% → 100%)
- `internal/cmd/uninstall_test.go` — `confirm()` stdin injection, `uninstallTargets`, `uninstallAll`
- `internal/cmd/install_test.go` — `installTargets` routing, `showInstalledVersions`, `printCredentialStatus`

**Additions to existing:**
- `internal/scan/repo/inline_test.go` — direct tests for `isFuncSignature` and `containsAny` (→ 100%)
- `internal/install/uninstall_test.go` — `ManifestPath` security validation, `DeregisterAllEditors`, `writeJSONAtomic`

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

```bash
go test -count=1 ./internal/cmd/ ./internal/scan/ ./internal/scan/repo/ ./internal/install/
go test -coverprofile=/tmp/cov.out ./... && go tool cover -func=/tmp/cov.out | tail -1
# total: 76.0%
```

## Reviewer Notes

- No production code changes — purely additive test files
- Remaining gap to 85% requires mocking GitHub API (FetchPlugin) or refactoring for interface injection (tracked in PPSC-830)
- Pre-existing lint issues (gosec in api/client_test.go, auth/client.go) are unrelated

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-830]: https://armis-security.atlassian.net/browse/PPSC-830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ