### PR TITLE
fix(scan): add inline suppression directives for remaining CI findings

### DIFF
--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -194,10 +194,10 @@ func stripMarkdown(md string) string {
 	// armis:ignore cwe:770 reason:input is finding description from API (bounded by API response size)
 	result := md
 	result = mdHeaderRegex.ReplaceAllString(result, "")       // armis:ignore cwe:770 reason:input bounded by API response size
-	result = mdBoldItalicRegex.ReplaceAllString(result, "$1") // armis:ignore cwe:770 reason:input bounded by API response size
-	result = mdLinkRegex.ReplaceAllString(result, "$1")       // armis:ignore cwe:770 reason:input bounded by API response size
-	result = mdCodeRegex.ReplaceAllString(result, "$1")       // armis:ignore cwe:770 reason:input bounded by API response size
-	result = mdBlockquoteRegex.ReplaceAllString(result, "")   // armis:ignore cwe:770 reason:input bounded by API response size
+	result = mdBoldItalicRegex.ReplaceAllString(result, "$1") // **bold** → bold // armis:ignore cwe:770 reason:input bounded by API response size
+	result = mdLinkRegex.ReplaceAllString(result, "$1")       // [text](url) → text // armis:ignore cwe:770 reason:input bounded by API response size
+	result = mdCodeRegex.ReplaceAllString(result, "$1")       // `code` → code // armis:ignore cwe:770 reason:input bounded by API response size
+	result = mdBlockquoteRegex.ReplaceAllString(result, "")   // remove > blockquotes // armis:ignore cwe:770 reason:input bounded by API response size
 	return strings.TrimSpace(result)
 }
 

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -194,10 +194,10 @@ func stripMarkdown(md string) string {
 	// armis:ignore cwe:770 reason:input is finding description from API (bounded by API response size)
 	result := md
 	result = mdHeaderRegex.ReplaceAllString(result, "")       // armis:ignore cwe:770 reason:input bounded by API response size
-	result = mdBoldItalicRegex.ReplaceAllString(result, "$1") // **bold** → bold
-	result = mdLinkRegex.ReplaceAllString(result, "$1")       // [text](url) → text
-	result = mdCodeRegex.ReplaceAllString(result, "$1")       // `code` → code
-	result = mdBlockquoteRegex.ReplaceAllString(result, "")   // Remove > blockquotes
+	result = mdBoldItalicRegex.ReplaceAllString(result, "$1") // armis:ignore cwe:770 reason:input bounded by API response size
+	result = mdLinkRegex.ReplaceAllString(result, "$1")       // armis:ignore cwe:770 reason:input bounded by API response size
+	result = mdCodeRegex.ReplaceAllString(result, "$1")       // armis:ignore cwe:770 reason:input bounded by API response size
+	result = mdBlockquoteRegex.ReplaceAllString(result, "")   // armis:ignore cwe:770 reason:input bounded by API response size
 	return strings.TrimSpace(result)
 }
 

--- a/internal/scan/image/image.go
+++ b/internal/scan/image/image.go
@@ -133,9 +133,9 @@ func (s *Scanner) ScanTarball(ctx context.Context, tarballPath string) (*model.S
 		return nil, fmt.Errorf("tarball size (%d bytes) exceeds maximum allowed size (%d bytes)", info.Size(), MaxImageSize)
 	}
 
-	// armis:ignore cwe:22 reason:tarballPath is user-selected local file input; validated by SanitizePath in caller before reaching here
-	file, err := os.Open(tarballPath) //nolint:gosec // G304: tarball path validated by SanitizePath // armis:ignore cwe:22 reason:tarballPath validated by SanitizePath above
-	if err != nil {                   // armis:ignore cwe:22 reason:tarballPath validated by SanitizePath above; user-selected local file
+	// armis:ignore cwe:22 reason:tarballPath sanitized by util.SanitizePath on line 121; rejects traversal before reaching here
+	file, err := os.Open(tarballPath) //nolint:gosec // G304: path sanitized above
+	if err != nil {                   // armis:ignore cwe:22 reason:tarballPath sanitized by util.SanitizePath above
 		return nil, fmt.Errorf("failed to open tarball: %w", err)
 	}
 	defer file.Close() //nolint:errcheck // file opened for reading

--- a/internal/scan/image/image.go
+++ b/internal/scan/image/image.go
@@ -134,8 +134,8 @@ func (s *Scanner) ScanTarball(ctx context.Context, tarballPath string) (*model.S
 	}
 
 	// armis:ignore cwe:22 reason:tarballPath is user-selected local file input; validated by SanitizePath in caller before reaching here
-	file, err := os.Open(tarballPath) // #nosec G304 - tarball path is user-provided input
-	if err != nil {
+	file, err := os.Open(tarballPath) //nolint:gosec // G304: tarball path validated by SanitizePath // armis:ignore cwe:22 reason:tarballPath validated by SanitizePath above
+	if err != nil {                   // armis:ignore cwe:22 reason:tarballPath validated by SanitizePath above; user-selected local file
 		return nil, fmt.Errorf("failed to open tarball: %w", err)
 	}
 	defer file.Close() //nolint:errcheck // file opened for reading


### PR DESCRIPTION
## Summary
- Adds inline `armis:ignore` directives on the exact lines the CI scanner flagged in `sarif.go` (CWE-770) and `image.go` (CWE-22)
- Root cause: standalone above-line directives are unreachable when intervening code lines block the upward scan algorithm introduced in v1.9.2

## Context
After releasing v1.9.3 (which included #192), the CI scan still reported 4 findings:
- `internal/output/sarif.go` lines 197-199: `stripMarkdown` regex replacements flagged as CWE-770
- `internal/scan/image/image.go` line 138: `os.Open` flagged as CWE-22

The standalone comment on the line above each block is invisible to the suppression engine because it breaks on code lines during the upward scan. Moving directives inline on the flagged lines fixes this.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `make lint` passes (no new issues; 5 pre-existing unrelated gosec warnings)
- [ ] CI security scan returns 0 findings