### PR TITLE
[PPSC-840] fix(scan): add inline suppression directives for remaining CI findings

### DIFF
--- a/internal/agentdetect/agentdetect.go
+++ b/internal/agentdetect/agentdetect.go
@@ -27,6 +27,7 @@ type ScanResult struct {
 
 // FlatResults returns all DetectedAgent entries in a flat slice (for JSON output).
 func (r *ScanResult) FlatResults() []DetectedAgent {
+	// armis:ignore cwe:770 reason:bounded by number of OS users; only iterates pre-scanned results in memory
 	var results []DetectedAgent
 	for _, u := range r.Users {
 		results = append(results, u.Agents...) // armis:ignore cwe:770 reason:bounded by number of OS users; only iterates pre-scanned results in memory

--- a/internal/agentdetect/mcpconfig.go
+++ b/internal/agentdetect/mcpconfig.go
@@ -41,7 +41,7 @@ func HasArmisMCPInClaudeSettings(resolvedHome, settingsPath string) bool {
 	if !isUnderDir(resolvedHome, settingsPath) {
 		return false
 	}
-	// armis:ignore cwe:770 reason:reads bounded local config file; path validated by isUnderDir
+	// armis:ignore cwe:770 cwe:22 reason:reads bounded local config file; path validated by isUnderDir
 	data, err := os.ReadFile(settingsPath) //nolint:gosec // path validated by isUnderDir
 	if err != nil {
 		return false
@@ -69,7 +69,7 @@ func HasArmisMCPInZedSettings(resolvedHome, settingsPath string) bool {
 	if !isUnderDir(resolvedHome, settingsPath) {
 		return false
 	}
-	// armis:ignore cwe:770 reason:reads bounded local config file; path validated by isUnderDir
+	// armis:ignore cwe:770 cwe:22 reason:reads bounded local config file; path validated by isUnderDir
 	data, err := os.ReadFile(settingsPath) //nolint:gosec // path validated by isUnderDir
 	if err != nil {
 		return false
@@ -99,7 +99,7 @@ func HasArmisMCPInVSCodeFormat(resolvedHome, configPath string) bool {
 	if !isUnderDir(resolvedHome, configPath) {
 		return false
 	}
-	// armis:ignore cwe:770 reason:reads bounded local config file; path validated by isUnderDir
+	// armis:ignore cwe:770 cwe:22 reason:reads bounded local config file; path validated by isUnderDir
 	data, err := os.ReadFile(configPath) //nolint:gosec // path validated by isUnderDir
 	if err != nil {
 		return false

--- a/internal/agentdetect/userprofile.go
+++ b/internal/agentdetect/userprofile.go
@@ -28,10 +28,10 @@ func enumerateUserDirs(baseDir string, skipSet map[string]bool) ([]UserHome, err
 		if skipSet[name] {
 			continue
 		}
-		// armis:ignore cwe:770 reason:bounded by number of OS user directories under /home or /Users
+		// armis:ignore cwe:770 cwe:22 reason:bounded by OS user directories; baseDir is hardcoded /home or /Users; name from os directory listing
 		users = append(users, UserHome{
 			Username: name,
-			HomeDir:  filepath.Join(baseDir, name),
+			HomeDir:  filepath.Join(baseDir, name), // armis:ignore cwe:22 reason:baseDir is hardcoded /home or /Users; name from OS directory listing
 		})
 	}
 	return users, nil

--- a/internal/cmd/scan_image.go
+++ b/internal/cmd/scan_image.go
@@ -107,6 +107,7 @@ var scanImageCmd = &cobra.Command{
 		}
 
 		if tarballPath != "" {
+			// armis:ignore cwe:22 reason:tarballPath is immediately sanitized by SanitizePath; only sanitizedPath is used
 			sanitizedPath, pathErr := util.SanitizePath(tarballPath)
 			if pathErr != nil {
 				return fmt.Errorf("invalid tarball path: %w", pathErr)

--- a/internal/cmd/scan_repo.go
+++ b/internal/cmd/scan_repo.go
@@ -157,6 +157,7 @@ var scanRepoCmd = &cobra.Command{
 		ctx, cancel := NewSignalContext()
 		defer cancel()
 
+		// armis:ignore cwe:22 reason:repoPath is from direct CLI argument; validated as existing directory above
 		result, err := scanner.Scan(ctx, repoPath)
 		if err != nil {
 			return handleScanError(ctx, err)

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -75,6 +75,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 
 		// armis:ignore cwe:918 reason:URL validated by api.Client caller (HTTPS enforced, no redirects)
 		resp, err = c.httpClient.Do(req) //nolint:gosec // G704: URL is from API client, validated before use
+		// armis:ignore cwe:918 reason:URL validated by api.Client caller (HTTPS enforced, no redirects)
 		if err != nil {
 			// Close response body if present to prevent resource leaks
 			// (some HTTP errors may return both a response and an error)

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -75,7 +75,6 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 
 		// armis:ignore cwe:918 reason:URL validated by api.Client caller (HTTPS enforced, no redirects)
 		resp, err = c.httpClient.Do(req) //nolint:gosec // G704: URL is from API client, validated before use
-		// armis:ignore cwe:918 reason:URL validated by api.Client caller (HTTPS enforced, no redirects)
 		if err != nil {
 			// Close response body if present to prevent resource leaks
 			// (some HTTP errors may return both a response and an error)

--- a/internal/install/claude.go
+++ b/internal/install/claude.go
@@ -61,6 +61,7 @@ func (ci *ClaudeInstaller) Install() error {
 		return fmt.Errorf("failed to enable plugin: %w", err)
 	}
 
+	// armis:ignore cwe:522 reason:env file written with 0600 permissions; credentials sourced from caller's environment variables
 	if err := writeEnvFromEnvironment(ci.EnvFilePath()); err != nil {
 		return fmt.Errorf("failed to write credentials: %w", err)
 	}

--- a/internal/scan/image/image.go
+++ b/internal/scan/image/image.go
@@ -259,6 +259,7 @@ func (s *Scanner) exportImage(ctx context.Context, imageName, outputPath string)
 		// armis:ignore cwe:94 reason:dockerCmd from getDockerCommand (hardcoded docker/podman); imageName validated by validateImageName()
 		// armis:ignore cwe:78 reason:dockerCmd validated by validateDockerCommand allowlist; imageName validated by validateImageName
 		pullCmd := exec.CommandContext(ctx, dockerCmd, "pull", imageName) //nolint:gosec // G204: dockerCmd is validated, imageName is validated by validateImageName()
+		// armis:ignore cwe:78 cwe:94 reason:dockerCmd validated by validateDockerCommand allowlist; imageName validated by validateImageName
 		pullCmd.Stdout = os.Stderr
 		pullCmd.Stderr = os.Stderr
 		if err := pullCmd.Run(); err != nil {
@@ -321,6 +322,7 @@ func imageExistsLocally(ctx context.Context, dockerCmd, imageName string) bool {
 	if _, err := validateImageName(imageName); err != nil {
 		return false
 	}
+	// armis:ignore cwe:78 cwe:94 reason:dockerCmd validated by validateDockerCommand; imageName validated by validateImageName
 	cmd := exec.CommandContext(ctx, dockerCmd, "image", "inspect", imageName) //nolint:gosec // G204: dockerCmd is validated, imageName is validated above
 	cmd.Stdout = io.Discard                                                   // Suppress JSON output on successful inspect
 	cmd.Stderr = io.Discard                                                   // Suppress "Error: no such image" noise

--- a/internal/scan/image/image.go
+++ b/internal/scan/image/image.go
@@ -259,7 +259,6 @@ func (s *Scanner) exportImage(ctx context.Context, imageName, outputPath string)
 		// armis:ignore cwe:94 reason:dockerCmd from getDockerCommand (hardcoded docker/podman); imageName validated by validateImageName()
 		// armis:ignore cwe:78 reason:dockerCmd validated by validateDockerCommand allowlist; imageName validated by validateImageName
 		pullCmd := exec.CommandContext(ctx, dockerCmd, "pull", imageName) //nolint:gosec // G204: dockerCmd is validated, imageName is validated by validateImageName()
-		// armis:ignore cwe:78 cwe:94 reason:dockerCmd validated by validateDockerCommand allowlist; imageName validated by validateImageName
 		pullCmd.Stdout = os.Stderr
 		pullCmd.Stderr = os.Stderr
 		if err := pullCmd.Run(); err != nil {

--- a/internal/scan/mask.go
+++ b/internal/scan/mask.go
@@ -55,5 +55,6 @@ func MaskFixSecrets(fix *model.Fix) *model.Fix {
 		fixCopy.PatchFiles = util.MaskSecretsInStringMap(fixCopy.PatchFiles)
 	}
 
+	// armis:ignore cwe:522 reason:text fields contain analysis prose, not code; masking would corrupt explanations with false positives
 	return &fixCopy
 }

--- a/internal/scan/repo/matcher.go
+++ b/internal/scan/repo/matcher.go
@@ -43,6 +43,7 @@ func MatchFinding(finding model.Finding, config *SuppressionConfig) MatchResult 
 		}
 	}
 
+	// armis:ignore cwe:20 reason:config.CWEs is parsed from trusted .armisignore directives, not external input
 	for _, d := range config.CWEs {
 		if cweMatches(finding.CWEs, d.Value) {
 			return MatchResult{Matched: true, Directive: d}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -193,6 +193,7 @@ func (c *Checker) fetchLatestVersion(ctx context.Context) (string, error) {
 // armis:ignore cwe:73 reason:cacheDir set from XDG/home path; SanitizePath validates before use
 func (c *Checker) getCacheFilePath() string {
 	if c.cacheDir != "" {
+		// armis:ignore cwe:73 reason:cacheDir set from XDG/home path; SanitizePath validates before use
 		sanitized, err := util.SanitizePath(c.cacheDir)
 		if err != nil {
 			return "" // invalid cacheDir, disable caching

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -230,6 +230,7 @@ function Main {
         # Detect upgrade vs fresh install
         if (Test-Path $binaryDest) {
             try {
+                # armis:ignore cwe:78 reason:binaryDest constructed from Join-Path with validated InstallDir; executing our own installed binary
                 $existingVersion = & $binaryDest --version 2>$null | Select-Object -First 1
                 if ($existingVersion) {
                     Write-Host "Upgrading existing installation..."


### PR DESCRIPTION
## Related Issue

* [PPSC-840](https://armis-security.atlassian.net/browse/PPSC-840)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

The inline matching engine flags certain code patterns as potential vulnerabilities (CWE-22, CWE-78, CWE-94, CWE-522, CWE-20, CWE-770) even though the inputs are already validated or bounded by design. This causes CI scan noise on every run.

## Solution

Add and update `armis:ignore` inline suppression comments across 12 files to suppress false-positive findings. Each directive includes a `reason:` explaining why the flagged code is safe (e.g., path validated by `isUnderDir`, command args validated by allowlist, credentials written with 0600 permissions). Also adds missing `cwe:22` to existing `cwe:770` directives where both CWEs are reported on the same line.

## Testing

### Automated Tests

* [x] All tests passing locally
* [ ] Unit tests added/updated (not applicable — comment-only changes)

### Manual Testing

Verified that `make lint` and `make test` pass with no regressions from these changes.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-840]: https://armis-security.atlassian.net/browse/PPSC-840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ