### PR TITLE
[PPSC-846] fix(install): separate Copilot CLI from VS Code target

### DIFF
--- a/internal/agentdetect/detector.go
+++ b/internal/agentdetect/detector.go
@@ -207,12 +207,18 @@ func (d *copilotDetector) Detect(resolvedHome, homeDir string, platform Platform
 	if hasJetBrainsPlugin(resolvedHome, platform, homeDir, "github-copilot") {
 		return true
 	}
+	if dirExists(resolvedHome, filepath.Join(homeDir, ".copilot")) {
+		return true
+	}
 	return dirExists(resolvedHome, filepath.Join(homeDir, ".config", "github-copilot"))
 }
 
 func (d *copilotDetector) CheckMCP(resolvedHome, homeDir string, platform Platform) bool {
 	mcpPath := filepath.Join(platform.VSCodeUserConfigDir(homeDir), "mcp.json")
-	return HasArmisMCP(resolvedHome, mcpPath) || HasArmisMCPInVSCodeFormat(resolvedHome, mcpPath)
+	if HasArmisMCP(resolvedHome, mcpPath) || HasArmisMCPInVSCodeFormat(resolvedHome, mcpPath) {
+		return true
+	}
+	return HasArmisMCP(resolvedHome, filepath.Join(homeDir, ".copilot", "mcp-config.json"))
 }
 
 func (d *copilotDetector) DetectVersion(resolvedHome, homeDir string, platform Platform) string {

--- a/internal/agentdetect/detector_test.go
+++ b/internal/agentdetect/detector_test.go
@@ -249,6 +249,13 @@ func TestCopilotDetector_Detect(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "copilot cli dir exists",
+			setup: func(t *testing.T, home string, _ *mockPlatform) {
+				mustMkdirAll(t, filepath.Join(home, ".copilot"))
+			},
+			expected: true,
+		},
+		{
 			name:     "nothing exists",
 			setup:    func(_ *testing.T, _ string, _ *mockPlatform) {},
 			expected: false,
@@ -294,6 +301,18 @@ func TestCopilotDetector_CheckMCP(t *testing.T) {
 		p.vsCodeConfigDir = configDir
 		if !d.CheckMCP(home, home, p) {
 			t.Error("CheckMCP() should return true for VS Code servers format")
+		}
+	})
+
+	t.Run("copilot cli config", func(t *testing.T) {
+		home := resolvedTempDir(t)
+		copilotDir := filepath.Join(home, ".copilot")
+		mustMkdirAll(t, copilotDir)
+		mustWriteFile(t, filepath.Join(copilotDir, "mcp-config.json"),
+			`{"mcpServers":{"armis-appsec":{"command":"python3","args":["server.py"]}}}`)
+		p := newMockPlatform(home)
+		if !d.CheckMCP(home, home, p) {
+			t.Error("CheckMCP() should return true for Copilot CLI mcp-config.json")
 		}
 	})
 }

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -178,12 +178,19 @@ func installAll(force bool) error {
 
 	if install.IsCodexDetected() {
 		if err := install.RegisterCodexMCP(ei.PluginDir()); err != nil {
-			fmt.Fprintf(os.Stderr, "  ✗ Codex CLI: %v\n", err)
+			fmt.Fprintf(os.Stderr, "  ✗ Codex CLI (MCP): %v\n", err)
 			failed = append(failed, "Codex CLI")
 		} else {
-			fmt.Fprintf(os.Stderr, "  ✓ Codex CLI\n")
+			fmt.Fprintf(os.Stderr, "  ✓ Codex CLI (MCP)\n")
 			registered = append(registered, "Codex CLI")
 			manifest.SetCodex(install.CodexConfigPath())
+		}
+		if hc, ok := install.HookClientByID(install.HookClientCodex); ok {
+			if err := install.InstallNativeHook(hc, ei.PluginDir()); err != nil {
+				fmt.Fprintf(os.Stderr, "  ⚠ Codex CLI (hooks): %v\n", err)
+			} else {
+				fmt.Fprintf(os.Stderr, "  ✓ Codex CLI (hooks)\n")
+			}
 		}
 	}
 

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -22,6 +22,7 @@ Specify one or more editor names to target specific tools.
 Supported editors:
   claude          Claude Code (uses plugin system)
   claude-desktop  Claude Desktop app (macOS/Windows)
+  codex           Codex CLI (registers MCP server + hooks)
   vscode          VS Code / GitHub Copilot
   copilot         Alias for vscode
   cursor          Cursor
@@ -175,6 +176,17 @@ func installAll(force bool) error {
 		manifest.SetClaude(ci.PluginCacheDir())
 	}
 
+	if install.IsCodexDetected() {
+		if err := install.RegisterCodexMCP(ei.PluginDir()); err != nil {
+			fmt.Fprintf(os.Stderr, "  ✗ Codex CLI: %v\n", err)
+			failed = append(failed, "Codex CLI")
+		} else {
+			fmt.Fprintf(os.Stderr, "  ✓ Codex CLI\n")
+			registered = append(registered, "Codex CLI")
+			manifest.SetCodex(install.CodexConfigPath())
+		}
+	}
+
 	if err := install.WriteManifest(manifest); err != nil {
 		fmt.Fprintf(os.Stderr, "  ⚠ Could not write install manifest: %v\n", err)
 	}
@@ -199,10 +211,14 @@ func installTargets(targets []string, force bool) error {
 	hasClaude := false
 	var editorIDs []install.EditorID
 
+	hasCodex := false
+
 	for _, name := range targets {
 		switch name {
 		case "claude":
 			hasClaude = true
+		case targetCodex:
+			hasCodex = true
 		case "copilot":
 			editorIDs = append(editorIDs, install.EditorVSCode)
 		case "jetbrains":
@@ -230,7 +246,7 @@ func installTargets(targets []string, force bool) error {
 		}
 	}
 
-	needsSharedPlugin := len(editorIDs) > 0
+	needsSharedPlugin := len(editorIDs) > 0 || hasCodex
 	var ei *install.EditorInstaller
 
 	if needsSharedPlugin {
@@ -265,6 +281,23 @@ func installTargets(targets []string, force bool) error {
 				manifest.AddEditor(e.ID, e.ConfigPath(), install.ConfigFormat(e.ID))
 			}
 		}
+
+		if hasCodex {
+			if err := install.RegisterCodexMCP(ei.PluginDir()); err != nil {
+				fmt.Fprintf(os.Stderr, "  ✗ Codex CLI (MCP): %v\n", err)
+			} else {
+				fmt.Fprintf(os.Stderr, "  ✓ Codex CLI (MCP)\n")
+				manifest.SetCodex(install.CodexConfigPath())
+			}
+			if hc, ok := install.HookClientByID(install.HookClientCodex); ok {
+				if err := install.InstallNativeHook(hc, ei.PluginDir()); err != nil {
+					fmt.Fprintf(os.Stderr, "  ⚠ Codex CLI (hooks): %v\n", err)
+				} else {
+					fmt.Fprintf(os.Stderr, "  ✓ Codex CLI (hooks)\n")
+				}
+			}
+		}
+
 		if err := install.WriteManifest(manifest); err != nil {
 			fmt.Fprintf(os.Stderr, "  ⚠ Could not write install manifest: %v\n", err)
 		}

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -23,8 +23,8 @@ Supported editors:
   claude          Claude Code (uses plugin system)
   claude-desktop  Claude Desktop app (macOS/Windows)
   codex           Codex CLI (registers MCP server + hooks)
-  vscode          VS Code / GitHub Copilot
-  copilot         Alias for vscode
+  vscode          VS Code / GitHub Copilot Chat extension
+  copilot         GitHub Copilot CLI
   cursor          Cursor
   windsurf        Windsurf (Codeium)
   zed             Zed
@@ -220,7 +220,7 @@ func installTargets(targets []string, force bool) error {
 		case targetCodex:
 			hasCodex = true
 		case "copilot":
-			editorIDs = append(editorIDs, install.EditorVSCode)
+			editorIDs = append(editorIDs, install.EditorCopilotCLI)
 		case "jetbrains":
 			fmt.Fprintln(os.Stderr, "JetBrains: MCP servers are configured per-project.")
 			fmt.Fprintln(os.Stderr, "After installing, copy .jb-mcp.json to your project root.")

--- a/internal/cmd/install_interactive.go
+++ b/internal/cmd/install_interactive.go
@@ -35,12 +35,15 @@ func runInteractiveInstall(force bool) error {
 		return nil
 	}
 
-	selectedEditors, installClaude, cancelled := selectEditors(theme, accessible)
-	if cancelled {
+	editorResult := selectEditorsWithCodex(theme, accessible)
+	if editorResult.cancelled {
 		fmt.Fprintln(os.Stderr, "\n  Setup cancelled.")
 		return nil
 	}
-	if len(selectedEditors) == 0 && !installClaude {
+	selectedEditors := editorResult.editors
+	installClaude := editorResult.installClaude
+	installCodex := editorResult.installCodex
+	if len(selectedEditors) == 0 && !installClaude && !installCodex {
 		return fmt.Errorf("no editors selected — nothing to install")
 	}
 
@@ -57,7 +60,7 @@ func runInteractiveInstall(force bool) error {
 	fmt.Fprintln(os.Stderr, "")
 
 	ei := install.NewEditorInstaller()
-	needsSharedPlugin := len(selectedEditors) > 0
+	needsSharedPlugin := len(selectedEditors) > 0 || installCodex
 
 	if needsSharedPlugin {
 		spinner := progress.NewSpinner("Downloading MCP server...", !cli.ColorsEnabled())
@@ -89,6 +92,15 @@ func runInteractiveInstall(force bool) error {
 			} else {
 				registered = append(registered, e.Name)
 				manifest.AddEditor(e.ID, e.ConfigPath(), install.ConfigFormat(e.ID))
+			}
+		}
+
+		if installCodex {
+			if err := install.RegisterCodexMCP(ei.PluginDir()); err != nil {
+				failures = append(failures, fmt.Sprintf("Codex CLI: %v", err))
+			} else {
+				registered = append(registered, "Codex CLI")
+				manifest.SetCodex(install.CodexConfigPath())
 			}
 		}
 
@@ -352,17 +364,26 @@ func validateAndReport(clientID, clientSecret string, accessible bool) error {
 	return nil
 }
 
-func selectEditors(theme *huh.Theme, accessible bool) ([]install.Editor, bool, bool) {
+// selectEditorsResult holds the selection from the editor picker.
+type selectEditorsResult struct {
+	editors       []install.Editor
+	installClaude bool
+	installCodex  bool
+	cancelled     bool
+}
+
+func selectEditorsWithCodex(theme *huh.Theme, accessible bool) selectEditorsResult {
 	detected := install.DetectedEditors()
 
 	claudeAvailable := false
 	if _, err := install.NewClaudeInstaller(); err == nil {
 		claudeAvailable = true
 	}
+	codexAvailable := install.IsCodexDetected()
 
-	if len(detected) == 0 && !claudeAvailable {
+	if len(detected) == 0 && !claudeAvailable && !codexAvailable {
 		fmt.Fprintln(os.Stderr, "  No supported editors detected.")
-		return nil, false, false
+		return selectEditorsResult{}
 	}
 
 	var options []huh.Option[string]
@@ -376,6 +397,10 @@ func selectEditors(theme *huh.Theme, accessible bool) ([]install.Editor, bool, b
 	if claudeAvailable {
 		options = append(options, huh.NewOption("Claude Code", "claude"))
 		allEditorKeys = append(allEditorKeys, "claude")
+	}
+	if codexAvailable {
+		options = append(options, huh.NewOption("Codex CLI", targetCodex))
+		allEditorKeys = append(allEditorKeys, targetCodex)
 	}
 
 	// Pre-select all by default
@@ -393,23 +418,32 @@ func selectEditors(theme *huh.Theme, accessible bool) ([]install.Editor, bool, b
 	).WithTheme(theme).WithAccessible(accessible)
 
 	if err := form.Run(); err != nil {
-		return nil, false, true
+		return selectEditorsResult{cancelled: true}
 	}
 
 	var editors []install.Editor
 	installClaude := false
+	installCodex := false
 
 	for _, sel := range selected {
-		if sel == "claude" {
+		switch sel {
+		case "claude":
 			installClaude = true
-			continue
-		}
-		if e, ok := install.EditorByID(install.EditorID(sel)); ok {
-			editors = append(editors, e)
+		case targetCodex:
+			installCodex = true
+		default:
+			if e, ok := install.EditorByID(install.EditorID(sel)); ok {
+				editors = append(editors, e)
+			}
 		}
 	}
 
-	return editors, installClaude, false
+	return selectEditorsResult{
+		editors:       editors,
+		installClaude: installClaude,
+		installCodex:  installCodex,
+		cancelled:     false,
+	}
 }
 
 func offerHookSetup(theme *huh.Theme, accessible bool, hasClaude bool) ([]install.HookClient, bool) {

--- a/internal/cmd/targets.go
+++ b/internal/cmd/targets.go
@@ -1,0 +1,7 @@
+package cmd
+
+const (
+	targetClaude  = "claude"
+	targetCodex   = "codex"
+	targetCopilot = "copilot"
+)

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -145,13 +145,13 @@ func uninstallAll(u *install.Uninstaller, keepCreds, force bool) error {
 		}
 	}
 
-	if err := install.DeregisterCodexMCP(); err != nil {
+	if removed, err := install.DeregisterCodexMCP(); err != nil {
 		if styled {
 			fmt.Fprintf(os.Stderr, "  %s Codex CLI: %v\n", warnMark.Render("⚠"), err)
 		} else {
 			fmt.Fprintf(os.Stderr, "  ⚠ Codex CLI: %v\n", err)
 		}
-	} else if install.IsCodexDetected() {
+	} else if removed {
 		if styled {
 			fmt.Fprintf(os.Stderr, "  %s Removed from Codex CLI\n", successMark.Render("✓"))
 		} else {
@@ -188,12 +188,6 @@ func uninstallAll(u *install.Uninstaller, keepCreds, force bool) error {
 	fmt.Fprintln(os.Stderr, "")
 	return nil
 }
-
-const (
-	targetClaude  = "claude"
-	targetCodex   = "codex"
-	targetCopilot = "copilot"
-)
 
 func uninstallTargets(u *install.Uninstaller, targets []string) error {
 	styled := cli.ColorsEnabled()
@@ -237,9 +231,9 @@ func uninstallTargets(u *install.Uninstaller, targets []string) error {
 				printSuccess("Claude Code")
 			}
 		case targetCodex:
-			if err := install.DeregisterCodexMCP(); err != nil {
+			if removed, err := install.DeregisterCodexMCP(); err != nil {
 				printFail(fmt.Sprintf("Codex CLI: %v", err))
-			} else {
+			} else if removed {
 				printSuccess("Codex CLI")
 			}
 		case targetCopilot:

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -243,10 +243,10 @@ func uninstallTargets(u *install.Uninstaller, targets []string) error {
 				printSuccess("Codex CLI")
 			}
 		case targetCopilot:
-			if err := u.DeregisterEditor(install.EditorVSCode); err != nil {
-				printFail(fmt.Sprintf("VS Code: %v", err))
+			if err := u.DeregisterEditor(install.EditorCopilotCLI); err != nil {
+				printFail(fmt.Sprintf("Copilot CLI: %v", err))
 			} else {
-				printSuccess("VS Code")
+				printSuccess("Copilot CLI")
 			}
 		case "jetbrains":
 			printWarn("JetBrains: Remove .jb-mcp.json from your project root manually.")
@@ -270,13 +270,9 @@ func uninstallTargets(u *install.Uninstaller, targets []string) error {
 			}
 		}
 
-		// Remove native hook config — skip for "copilot" which is an alias for
-		// VS Code MCP, not the Copilot CLI hook at ~/.config/github-copilot/.
-		if name != targetCopilot {
-			if hc, ok := install.HookClientByID(install.HookClientID(name)); ok {
-				if err := install.RemoveNativeHook(hc); err != nil {
-					printWarn(fmt.Sprintf("Hook config (%s): %v", hc.Name, err))
-				}
+		if hc, ok := install.HookClientByID(install.HookClientID(name)); ok {
+			if err := install.RemoveNativeHook(hc); err != nil {
+				printWarn(fmt.Sprintf("Hook config (%s): %v", hc.Name, err))
 			}
 		}
 	}
@@ -291,7 +287,7 @@ func uninstallTargets(u *install.Uninstaller, targets []string) error {
 			case targetCodex:
 				manifest.Codex = nil
 			case targetCopilot:
-				manifest.RemoveEditor(install.EditorVSCode)
+				manifest.RemoveEditor(install.EditorCopilotCLI)
 			default:
 				manifest.RemoveEditor(install.EditorID(name))
 			}

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -145,6 +145,20 @@ func uninstallAll(u *install.Uninstaller, keepCreds, force bool) error {
 		}
 	}
 
+	if err := install.DeregisterCodexMCP(); err != nil {
+		if styled {
+			fmt.Fprintf(os.Stderr, "  %s Codex CLI: %v\n", warnMark.Render("⚠"), err)
+		} else {
+			fmt.Fprintf(os.Stderr, "  ⚠ Codex CLI: %v\n", err)
+		}
+	} else if install.IsCodexDetected() {
+		if styled {
+			fmt.Fprintf(os.Stderr, "  %s Removed from Codex CLI\n", successMark.Render("✓"))
+		} else {
+			fmt.Fprintf(os.Stderr, "  ✓ Removed from Codex CLI\n")
+		}
+	}
+
 	if err := u.RemovePluginFiles(keepCreds); err != nil {
 		if styled {
 			fmt.Fprintf(os.Stderr, "  %s Plugin files: %v\n", warnMark.Render("⚠"), err)
@@ -177,6 +191,7 @@ func uninstallAll(u *install.Uninstaller, keepCreds, force bool) error {
 
 const (
 	targetClaude  = "claude"
+	targetCodex   = "codex"
 	targetCopilot = "copilot"
 )
 
@@ -220,6 +235,12 @@ func uninstallTargets(u *install.Uninstaller, targets []string) error {
 				printFail(fmt.Sprintf("Claude Code: %v", err))
 			} else {
 				printSuccess("Claude Code")
+			}
+		case targetCodex:
+			if err := install.DeregisterCodexMCP(); err != nil {
+				printFail(fmt.Sprintf("Codex CLI: %v", err))
+			} else {
+				printSuccess("Codex CLI")
 			}
 		case targetCopilot:
 			if err := u.DeregisterEditor(install.EditorVSCode); err != nil {
@@ -267,6 +288,8 @@ func uninstallTargets(u *install.Uninstaller, targets []string) error {
 			switch name {
 			case targetClaude:
 				manifest.Claude = nil
+			case targetCodex:
+				manifest.Codex = nil
 			case targetCopilot:
 				manifest.RemoveEditor(install.EditorVSCode)
 			default:

--- a/internal/cmd/uninstall_test.go
+++ b/internal/cmd/uninstall_test.go
@@ -96,7 +96,7 @@ func TestUninstallTargets(t *testing.T) {
 		}
 	})
 
-	t.Run("copilot maps to vscode", func(t *testing.T) {
+	t.Run("copilot maps to copilot cli", func(t *testing.T) {
 		err := uninstallTargets(u, []string{"copilot"})
 		if err != nil {
 			t.Errorf("uninstallTargets(copilot) unexpected error: %v", err)

--- a/internal/install/codex.go
+++ b/internal/install/codex.go
@@ -236,7 +236,7 @@ func writeFileAtomic(path, content string) error {
 		_ = os.Remove(tmpPath) // #nosec G703 -- tmpPath from os.CreateTemp in controlled dir
 		return fmt.Errorf("closing temp file: %w", err)
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
+	if err := os.Rename(tmpPath, path); err != nil { // #nosec G703 -- atomic write to known config path
 		_ = os.Remove(tmpPath) // #nosec G703 -- tmpPath from os.CreateTemp in controlled dir
 		return fmt.Errorf("renaming config: %w", err)
 	}

--- a/internal/install/codex.go
+++ b/internal/install/codex.go
@@ -209,20 +209,20 @@ func writeFileAtomic(path, content string) error {
 
 	if _, err := f.WriteString(content); err != nil {
 		_ = f.Close()
-		_ = os.Remove(tmpPath)
+		_ = os.Remove(tmpPath) // #nosec G703 -- tmpPath from os.CreateTemp in controlled dir
 		return fmt.Errorf("writing config: %w", err)
 	}
 	if err := f.Chmod(0o600); err != nil {
 		_ = f.Close()
-		_ = os.Remove(tmpPath)
+		_ = os.Remove(tmpPath) // #nosec G703 -- tmpPath from os.CreateTemp in controlled dir
 		return fmt.Errorf("setting permissions: %w", err)
 	}
 	if err := f.Close(); err != nil {
-		_ = os.Remove(tmpPath)
+		_ = os.Remove(tmpPath) // #nosec G703 -- tmpPath from os.CreateTemp in controlled dir
 		return fmt.Errorf("closing temp file: %w", err)
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
-		_ = os.Remove(tmpPath)
+		_ = os.Remove(tmpPath) // #nosec G703 -- tmpPath from os.CreateTemp in controlled dir
 		return fmt.Errorf("renaming config: %w", err)
 	}
 	return nil

--- a/internal/install/codex.go
+++ b/internal/install/codex.go
@@ -1,0 +1,229 @@
+package install
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const codexMCPServerName = "armis_scanner"
+
+var codexSectionHeader = "[mcp_servers." + codexMCPServerName + "]"
+
+// codexConfigPathOverride allows tests to inject a custom path.
+var codexConfigPathOverride string
+
+// CodexConfigPath returns the path to Codex CLI's config.toml.
+func CodexConfigPath() string {
+	if codexConfigPathOverride != "" {
+		return codexConfigPathOverride
+	}
+	return homeDir(".codex", "config.toml")
+}
+
+// IsCodexDetected returns true if the ~/.codex/ directory exists.
+func IsCodexDetected() bool {
+	p := CodexConfigPath()
+	if p == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Dir(p))
+	return err == nil
+}
+
+// RegisterCodexMCP adds or updates the [mcp_servers.armis_scanner] section
+// in Codex CLI's config.toml.
+func RegisterCodexMCP(pluginDir string) error {
+	if !filepath.IsAbs(pluginDir) {
+		return fmt.Errorf("plugin directory must be an absolute path: %s", pluginDir)
+	}
+
+	configPath := CodexConfigPath()
+	if configPath == "" {
+		return fmt.Errorf("codex config path not available on this platform")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+
+	content, err := readFileOrEmpty(configPath)
+	if err != nil {
+		return err
+	}
+
+	newSection := buildCodexSection(pluginDir)
+	updated := replaceTOMLSection(content, codexSectionHeader, newSection)
+
+	return writeFileAtomic(configPath, updated)
+}
+
+// DeregisterCodexMCP removes the [mcp_servers.armis_scanner] section
+// from Codex CLI's config.toml.
+func DeregisterCodexMCP() error {
+	configPath := CodexConfigPath()
+	if configPath == "" {
+		return nil
+	}
+
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return nil
+	}
+
+	content, err := readFileOrEmpty(configPath)
+	if err != nil {
+		return err
+	}
+
+	updated := removeTOMLSection(content, codexSectionHeader)
+	if updated == content {
+		return nil
+	}
+
+	return writeFileAtomic(configPath, updated)
+}
+
+func buildCodexSection(pluginDir string) string {
+	command := venvPython(pluginDir)
+	serverPy := filepath.Join(pluginDir, "server.py")
+	return fmt.Sprintf("%s\ncommand = %s\nargs = [%s]\n",
+		codexSectionHeader,
+		tomlQuote(command),
+		tomlQuote(serverPy),
+	)
+}
+
+// replaceTOMLSection replaces an existing section or appends a new one.
+func replaceTOMLSection(content, header, newSection string) string {
+	start, end := findTOMLSectionBounds(content, header)
+	if start == -1 {
+		// Append: ensure trailing newline before new section
+		trimmed := strings.TrimRight(content, "\n")
+		if trimmed == "" {
+			return newSection
+		}
+		return trimmed + "\n\n" + newSection
+	}
+	// Replace existing section
+	return content[:start] + newSection + content[end:]
+}
+
+// removeTOMLSection removes a section from the TOML content.
+func removeTOMLSection(content, header string) string {
+	start, end := findTOMLSectionBounds(content, header)
+	if start == -1 {
+		return content
+	}
+
+	before := content[:start]
+	after := content[end:]
+
+	// Clean up: remove extra blank lines at the join point
+	before = strings.TrimRight(before, "\n")
+	after = strings.TrimLeft(after, "\n")
+
+	if before == "" && after == "" {
+		return ""
+	}
+	if before == "" {
+		return after
+	}
+	if after == "" {
+		return before + "\n"
+	}
+	return before + "\n\n" + after
+}
+
+// findTOMLSectionBounds locates a section in the content.
+// Returns (startByte, endByte) of the section including its header line.
+// Returns (-1, -1) if not found.
+func findTOMLSectionBounds(content, header string) (int, int) {
+	lines := strings.Split(content, "\n")
+	startLine := -1
+
+	for i, line := range lines {
+		if strings.TrimSpace(line) == header {
+			startLine = i
+			break
+		}
+	}
+	if startLine == -1 {
+		return -1, -1
+	}
+
+	// Find the end: next line starting with '[' (a new section header)
+	endLine := len(lines)
+	for i := startLine + 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if len(trimmed) > 0 && trimmed[0] == '[' {
+			endLine = i
+			break
+		}
+	}
+
+	// Skip trailing blank lines within the section
+	for endLine > startLine+1 && strings.TrimSpace(lines[endLine-1]) == "" {
+		endLine--
+	}
+
+	// Calculate byte offsets
+	startByte := 0
+	for i := 0; i < startLine; i++ {
+		startByte += len(lines[i]) + 1 // +1 for \n
+	}
+	endByte := 0
+	for i := 0; i < endLine; i++ {
+		endByte += len(lines[i]) + 1
+	}
+
+	return startByte, endByte
+}
+
+// tomlQuote wraps a string in double quotes with proper escaping.
+func tomlQuote(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return `"` + s + `"`
+}
+
+func readFileOrEmpty(path string) (string, error) {
+	// armis:ignore cwe:22 reason:path from known config location (homeDir + hardcoded segments)
+	b, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("reading %s: %w", path, err)
+	}
+	return string(b), nil
+}
+
+func writeFileAtomic(path, content string) error {
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpPath := f.Name()
+
+	if _, err := f.WriteString(content); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("writing config: %w", err)
+	}
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("setting permissions: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("renaming config: %w", err)
+	}
+	return nil
+}

--- a/internal/install/codex.go
+++ b/internal/install/codex.go
@@ -171,24 +171,24 @@ func findTOMLSectionBounds(content, header string) (int, int) {
 		endLine--
 	}
 
-	// Calculate byte offsets.
-	// Only add +1 (for \n) between lines, not after the final line if there's
-	// no trailing newline in the original content.
-	hasTrailingNewline := strings.HasSuffix(content, "\n")
+	// Calculate byte offsets using character positions in the original content.
+	// Each line except the very last has a \n separator (strings.Split consumed them).
+	// When content ends with \n, Split produces a trailing empty element — the \n
+	// between the second-to-last and last element accounts for the trailing newline.
 	lastLine := len(lines) - 1
 
 	startByte := 0
 	for i := 0; i < startLine; i++ {
 		startByte += len(lines[i])
-		if i < lastLine || hasTrailingNewline {
-			startByte++
+		if i < lastLine {
+			startByte++ // \n separator
 		}
 	}
 	endByte := 0
 	for i := 0; i < endLine; i++ {
 		endByte += len(lines[i])
-		if i < lastLine || hasTrailingNewline {
-			endByte++
+		if i < lastLine {
+			endByte++ // \n separator
 		}
 	}
 

--- a/internal/install/codex.go
+++ b/internal/install/codex.go
@@ -39,6 +39,10 @@ func RegisterCodexMCP(pluginDir string) error {
 		return fmt.Errorf("plugin directory must be an absolute path: %s", pluginDir)
 	}
 
+	// Sanitize: resolve symlink-like components (e.g. "..") to prevent
+	// path traversal when the stored path is later used by Codex CLI.
+	pluginDir = filepath.Clean(pluginDir)
+
 	configPath := CodexConfigPath()
 	if configPath == "" {
 		return fmt.Errorf("codex config path not available on this platform")
@@ -60,28 +64,28 @@ func RegisterCodexMCP(pluginDir string) error {
 }
 
 // DeregisterCodexMCP removes the [mcp_servers.armis_scanner] section
-// from Codex CLI's config.toml.
-func DeregisterCodexMCP() error {
+// from Codex CLI's config.toml. Returns true if a section was actually removed.
+func DeregisterCodexMCP() (bool, error) {
 	configPath := CodexConfigPath()
 	if configPath == "" {
-		return nil
+		return false, nil
 	}
 
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		return nil
+		return false, nil
 	}
 
 	content, err := readFileOrEmpty(configPath)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	updated := removeTOMLSection(content, codexSectionHeader)
 	if updated == content {
-		return nil
+		return false, nil
 	}
 
-	return writeFileAtomic(configPath, updated)
+	return true, writeFileAtomic(configPath, updated)
 }
 
 func buildCodexSection(pluginDir string) string {
@@ -167,14 +171,25 @@ func findTOMLSectionBounds(content, header string) (int, int) {
 		endLine--
 	}
 
-	// Calculate byte offsets
+	// Calculate byte offsets.
+	// Only add +1 (for \n) between lines, not after the final line if there's
+	// no trailing newline in the original content.
+	hasTrailingNewline := strings.HasSuffix(content, "\n")
+	lastLine := len(lines) - 1
+
 	startByte := 0
 	for i := 0; i < startLine; i++ {
-		startByte += len(lines[i]) + 1 // +1 for \n
+		startByte += len(lines[i])
+		if i < lastLine || hasTrailingNewline {
+			startByte++
+		}
 	}
 	endByte := 0
 	for i := 0; i < endLine; i++ {
-		endByte += len(lines[i]) + 1
+		endByte += len(lines[i])
+		if i < lastLine || hasTrailingNewline {
+			endByte++
+		}
 	}
 
 	return startByte, endByte

--- a/internal/install/codex_test.go
+++ b/internal/install/codex_test.go
@@ -181,8 +181,12 @@ args = ["-y", "@upstash/context7-mcp"]
 		t.Fatal(err)
 	}
 
-	if err := DeregisterCodexMCP(); err != nil {
+	removed, err := DeregisterCodexMCP()
+	if err != nil {
 		t.Fatalf("DeregisterCodexMCP() error: %v", err)
+	}
+	if !removed {
+		t.Error("DeregisterCodexMCP() returned false, want true")
 	}
 
 	content, err := os.ReadFile(configFile) //nolint:gosec // test file with controlled path
@@ -218,8 +222,12 @@ args = ["-y", "@upstash/context7-mcp"]
 		t.Fatal(err)
 	}
 
-	if err := DeregisterCodexMCP(); err != nil {
+	removed, err := DeregisterCodexMCP()
+	if err != nil {
 		t.Fatalf("DeregisterCodexMCP() error: %v", err)
+	}
+	if removed {
+		t.Error("DeregisterCodexMCP() returned true, want false (no section)")
 	}
 
 	content, err := os.ReadFile(configFile) //nolint:gosec // test file with controlled path
@@ -240,8 +248,12 @@ func TestDeregisterCodexMCP_FileMissing(t *testing.T) {
 	t.Cleanup(func() { codexConfigPathOverride = "" })
 
 	// No error when file doesn't exist
-	if err := DeregisterCodexMCP(); err != nil {
+	removed, err := DeregisterCodexMCP()
+	if err != nil {
 		t.Fatalf("DeregisterCodexMCP() error: %v", err)
+	}
+	if removed {
+		t.Error("DeregisterCodexMCP() returned true, want false (file missing)")
 	}
 }
 
@@ -269,6 +281,68 @@ func TestIsCodexDetected(t *testing.T) {
 func TestRegisterCodexMCP_RelativePath(t *testing.T) {
 	if err := RegisterCodexMCP("relative/path"); err == nil {
 		t.Error("expected error for relative path")
+	}
+}
+
+func TestRegisterCodexMCP_PathTraversalCleaned(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.toml")
+	codexConfigPathOverride = configFile
+	t.Cleanup(func() { codexConfigPathOverride = "" })
+
+	// Plugin dir with ".." segments — should be cleaned before writing to config
+	pluginDir := filepath.Join(dir, "plugins", "foo", "..", "armis-appsec-mcp")
+	setupFakeVenv(t, pluginDir)
+
+	if err := RegisterCodexMCP(pluginDir); err != nil {
+		t.Fatalf("RegisterCodexMCP() error: %v", err)
+	}
+
+	content, err := os.ReadFile(configFile) //nolint:gosec // test file with controlled path
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+
+	got := string(content)
+	if strings.Contains(got, "..") {
+		t.Errorf("config contains unresolved path traversal:\n%s", got)
+	}
+	cleanedDir := filepath.Clean(pluginDir)
+	if !strings.Contains(got, tomlQuote(venvPython(cleanedDir))) {
+		t.Errorf("missing cleaned python path in:\n%s", got)
+	}
+}
+
+func TestRegisterCodexMCP_NoTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.toml")
+	codexConfigPathOverride = configFile
+	t.Cleanup(func() { codexConfigPathOverride = "" })
+
+	// Config without trailing newline
+	existing := `model = "gpt-5-codex"`
+	if err := os.WriteFile(configFile, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	pluginDir := filepath.Join(dir, "plugins", "armis-appsec-mcp")
+	setupFakeVenv(t, pluginDir)
+
+	if err := RegisterCodexMCP(pluginDir); err != nil {
+		t.Fatalf("RegisterCodexMCP() error: %v", err)
+	}
+
+	content, err := os.ReadFile(configFile) //nolint:gosec // test file with controlled path
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+
+	got := string(content)
+	if !strings.Contains(got, `model = "gpt-5-codex"`) {
+		t.Errorf("existing content lost:\n%s", got)
+	}
+	if !strings.Contains(got, "[mcp_servers.armis_scanner]") {
+		t.Errorf("missing armis_scanner section:\n%s", got)
 	}
 }
 

--- a/internal/install/codex_test.go
+++ b/internal/install/codex_test.go
@@ -161,6 +161,35 @@ args = ["-y", "@upstash/context7-mcp"]
 	}
 }
 
+func TestDeregisterCodexMCP_SectionAtEOFWithTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.toml")
+	codexConfigPathOverride = configFile
+	t.Cleanup(func() { codexConfigPathOverride = "" })
+
+	// Section is the last thing in the file, WITH trailing newline
+	existing := "[mcp_servers.armis_scanner]\ncommand = \"/old/python\"\nargs = [\"/old/server.py\"]\n"
+	if err := os.WriteFile(configFile, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := DeregisterCodexMCP()
+	if err != nil {
+		t.Fatalf("DeregisterCodexMCP() error: %v", err)
+	}
+	if !removed {
+		t.Error("DeregisterCodexMCP() returned false, want true")
+	}
+
+	content, err := os.ReadFile(configFile) //nolint:gosec // test file with controlled path
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+	if strings.Contains(string(content), "armis_scanner") {
+		t.Errorf("section not removed:\n%s", string(content))
+	}
+}
+
 func TestDeregisterCodexMCP(t *testing.T) {
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, "config.toml")

--- a/internal/install/codex_test.go
+++ b/internal/install/codex_test.go
@@ -3,6 +3,7 @@ package install
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -29,10 +30,10 @@ func TestRegisterCodexMCP_MissingFile(t *testing.T) {
 	if !strings.Contains(got, "[mcp_servers.armis_scanner]") {
 		t.Errorf("missing section header in:\n%s", got)
 	}
-	if !strings.Contains(got, `command = "`+venvPython(pluginDir)+`"`) {
+	if !strings.Contains(got, "command = "+tomlQuote(venvPython(pluginDir))) {
 		t.Errorf("missing command in:\n%s", got)
 	}
-	if !strings.Contains(got, filepath.Join(pluginDir, "server.py")) {
+	if !strings.Contains(got, tomlQuote(filepath.Join(pluginDir, "server.py"))) {
 		t.Errorf("missing server.py path in:\n%s", got)
 	}
 }
@@ -147,8 +148,8 @@ args = ["-y", "@upstash/context7-mcp"]
 	if strings.Contains(got, "/old/path/") {
 		t.Errorf("old path still present:\n%s", got)
 	}
-	// New path present
-	if !strings.Contains(got, venvPython(pluginDir)) {
+	// New path present (TOML-escaped)
+	if !strings.Contains(got, tomlQuote(venvPython(pluginDir))) {
 		t.Errorf("new python path missing:\n%s", got)
 	}
 	// Other sections preserved
@@ -274,7 +275,12 @@ func TestRegisterCodexMCP_RelativePath(t *testing.T) {
 // setupFakeVenv creates a minimal directory structure so venvPython resolves.
 func setupFakeVenv(t *testing.T, pluginDir string) {
 	t.Helper()
-	venvBin := filepath.Join(pluginDir, ".venv", "bin")
+	var venvBin string
+	if runtime.GOOS == osWindows {
+		venvBin = filepath.Join(pluginDir, ".venv", "Scripts")
+	} else {
+		venvBin = filepath.Join(pluginDir, ".venv", "bin")
+	}
 	if err := os.MkdirAll(venvBin, 0o750); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/install/codex_test.go
+++ b/internal/install/codex_test.go
@@ -1,0 +1,281 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRegisterCodexMCP_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.toml")
+	codexConfigPathOverride = configFile
+	t.Cleanup(func() { codexConfigPathOverride = "" })
+
+	pluginDir := filepath.Join(dir, "plugins", "armis-appsec-mcp")
+	setupFakeVenv(t, pluginDir)
+
+	if err := RegisterCodexMCP(pluginDir); err != nil {
+		t.Fatalf("RegisterCodexMCP() error: %v", err)
+	}
+
+	content, err := os.ReadFile(configFile) //nolint:gosec // test file with controlled path
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+
+	got := string(content)
+	if !strings.Contains(got, "[mcp_servers.armis_scanner]") {
+		t.Errorf("missing section header in:\n%s", got)
+	}
+	if !strings.Contains(got, `command = "`+venvPython(pluginDir)+`"`) {
+		t.Errorf("missing command in:\n%s", got)
+	}
+	if !strings.Contains(got, filepath.Join(pluginDir, "server.py")) {
+		t.Errorf("missing server.py path in:\n%s", got)
+	}
+}
+
+func TestRegisterCodexMCP_ExistingConfig(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.toml")
+	codexConfigPathOverride = configFile
+	t.Cleanup(func() { codexConfigPathOverride = "" })
+
+	existing := `model = "gpt-5-codex"
+model_reasoning_effort = "medium"
+
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp"]
+`
+	if err := os.WriteFile(configFile, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	pluginDir := filepath.Join(dir, "plugins", "armis-appsec-mcp")
+	setupFakeVenv(t, pluginDir)
+
+	if err := RegisterCodexMCP(pluginDir); err != nil {
+		t.Fatalf("RegisterCodexMCP() error: %v", err)
+	}
+
+	content, err := os.ReadFile(configFile) //nolint:gosec // test file with controlled path
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+
+	got := string(content)
+	// Existing content preserved
+	if !strings.Contains(got, `model = "gpt-5-codex"`) {
+		t.Errorf("existing model setting lost:\n%s", got)
+	}
+	if !strings.Contains(got, "[mcp_servers.context7]") {
+		t.Errorf("existing MCP server lost:\n%s", got)
+	}
+	// New section added
+	if !strings.Contains(got, "[mcp_servers.armis_scanner]") {
+		t.Errorf("missing armis_scanner section:\n%s", got)
+	}
+}
+
+func TestRegisterCodexMCP_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.toml")
+	codexConfigPathOverride = configFile
+	t.Cleanup(func() { codexConfigPathOverride = "" })
+
+	pluginDir := filepath.Join(dir, "plugins", "armis-appsec-mcp")
+	setupFakeVenv(t, pluginDir)
+
+	// Register twice
+	if err := RegisterCodexMCP(pluginDir); err != nil {
+		t.Fatalf("first RegisterCodexMCP() error: %v", err)
+	}
+	if err := RegisterCodexMCP(pluginDir); err != nil {
+		t.Fatalf("second RegisterCodexMCP() error: %v", err)
+	}
+
+	content, err := os.ReadFile(configFile) //nolint:gosec // test file with controlled path
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+
+	got := string(content)
+	count := strings.Count(got, "[mcp_servers.armis_scanner]")
+	if count != 1 {
+		t.Errorf("expected 1 section header, got %d:\n%s", count, got)
+	}
+}
+
+func TestRegisterCodexMCP_UpdatesExistingSection(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.toml")
+	codexConfigPathOverride = configFile
+	t.Cleanup(func() { codexConfigPathOverride = "" })
+
+	// Pre-existing section with old path
+	existing := `model = "gpt-5-codex"
+
+[mcp_servers.armis_scanner]
+command = "/old/path/python"
+args = ["/old/path/server.py"]
+
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp"]
+`
+	if err := os.WriteFile(configFile, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	pluginDir := filepath.Join(dir, "plugins", "armis-appsec-mcp")
+	setupFakeVenv(t, pluginDir)
+
+	if err := RegisterCodexMCP(pluginDir); err != nil {
+		t.Fatalf("RegisterCodexMCP() error: %v", err)
+	}
+
+	content, err := os.ReadFile(configFile) //nolint:gosec // test file with controlled path
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+
+	got := string(content)
+	// Old path gone
+	if strings.Contains(got, "/old/path/") {
+		t.Errorf("old path still present:\n%s", got)
+	}
+	// New path present
+	if !strings.Contains(got, venvPython(pluginDir)) {
+		t.Errorf("new python path missing:\n%s", got)
+	}
+	// Other sections preserved
+	if !strings.Contains(got, "[mcp_servers.context7]") {
+		t.Errorf("context7 section lost:\n%s", got)
+	}
+	if !strings.Contains(got, `model = "gpt-5-codex"`) {
+		t.Errorf("model setting lost:\n%s", got)
+	}
+}
+
+func TestDeregisterCodexMCP(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.toml")
+	codexConfigPathOverride = configFile
+	t.Cleanup(func() { codexConfigPathOverride = "" })
+
+	existing := `model = "gpt-5-codex"
+
+[mcp_servers.armis_scanner]
+command = "/some/path/python"
+args = ["/some/path/server.py"]
+
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp"]
+`
+	if err := os.WriteFile(configFile, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DeregisterCodexMCP(); err != nil {
+		t.Fatalf("DeregisterCodexMCP() error: %v", err)
+	}
+
+	content, err := os.ReadFile(configFile) //nolint:gosec // test file with controlled path
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+
+	got := string(content)
+	if strings.Contains(got, "armis_scanner") {
+		t.Errorf("armis_scanner section not removed:\n%s", got)
+	}
+	if !strings.Contains(got, "[mcp_servers.context7]") {
+		t.Errorf("context7 section lost:\n%s", got)
+	}
+	if !strings.Contains(got, `model = "gpt-5-codex"`) {
+		t.Errorf("model setting lost:\n%s", got)
+	}
+}
+
+func TestDeregisterCodexMCP_NoSection(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.toml")
+	codexConfigPathOverride = configFile
+	t.Cleanup(func() { codexConfigPathOverride = "" })
+
+	existing := `model = "gpt-5-codex"
+
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp"]
+`
+	if err := os.WriteFile(configFile, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DeregisterCodexMCP(); err != nil {
+		t.Fatalf("DeregisterCodexMCP() error: %v", err)
+	}
+
+	content, err := os.ReadFile(configFile) //nolint:gosec // test file with controlled path
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+
+	// File unchanged
+	if string(content) != existing {
+		t.Errorf("file was modified when it shouldn't have been:\n%s", string(content))
+	}
+}
+
+func TestDeregisterCodexMCP_FileMissing(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.toml")
+	codexConfigPathOverride = configFile
+	t.Cleanup(func() { codexConfigPathOverride = "" })
+
+	// No error when file doesn't exist
+	if err := DeregisterCodexMCP(); err != nil {
+		t.Fatalf("DeregisterCodexMCP() error: %v", err)
+	}
+}
+
+func TestIsCodexDetected(t *testing.T) {
+	dir := t.TempDir()
+	codexDir := filepath.Join(dir, ".codex")
+	configFile := filepath.Join(codexDir, "config.toml")
+	codexConfigPathOverride = configFile
+	t.Cleanup(func() { codexConfigPathOverride = "" })
+
+	// Not detected when dir doesn't exist
+	if IsCodexDetected() {
+		t.Error("IsCodexDetected() = true, want false (dir missing)")
+	}
+
+	// Detected when dir exists
+	if err := os.MkdirAll(codexDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if !IsCodexDetected() {
+		t.Error("IsCodexDetected() = false, want true (dir exists)")
+	}
+}
+
+func TestRegisterCodexMCP_RelativePath(t *testing.T) {
+	if err := RegisterCodexMCP("relative/path"); err == nil {
+		t.Error("expected error for relative path")
+	}
+}
+
+// setupFakeVenv creates a minimal directory structure so venvPython resolves.
+func setupFakeVenv(t *testing.T, pluginDir string) {
+	t.Helper()
+	venvBin := filepath.Join(pluginDir, ".venv", "bin")
+	if err := os.MkdirAll(venvBin, 0o750); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/install/editors.go
+++ b/internal/install/editors.go
@@ -27,6 +27,7 @@ const (
 	EditorRooCode       EditorID = "roocode"
 	EditorJunie         EditorID = "junie"
 	EditorClaudeDesktop EditorID = "claude-desktop"
+	EditorCopilotCLI    EditorID = "copilot"
 )
 
 // Editor represents a code editor with MCP server support.
@@ -49,6 +50,7 @@ var AllEditors = []Editor{
 	{EditorRooCode, "Roo Code"},
 	{EditorJunie, "Junie"},
 	{EditorClaudeDesktop, "Claude Desktop"},
+	{EditorCopilotCLI, "Copilot CLI"},
 }
 
 // EditorByID returns the editor with the given ID.
@@ -217,6 +219,8 @@ func defaultConfigPath(id EditorID) string {
 			return ""
 		}
 		return appSupportPath("Claude", "claude_desktop_config.json")
+	case EditorCopilotCLI:
+		return homeDir(".copilot", "mcp-config.json")
 	}
 	return ""
 }

--- a/internal/install/editors_test.go
+++ b/internal/install/editors_test.go
@@ -107,7 +107,7 @@ func TestDetectedEditors(t *testing.T) {
 }
 
 func TestRegisterMCPServersFormat(t *testing.T) {
-	editors := []EditorID{EditorCursor, EditorWindsurf, EditorCline, EditorAmazonQ, EditorAntigravity, EditorContinue, EditorGemini, EditorClaudeDesktop}
+	editors := []EditorID{EditorCursor, EditorWindsurf, EditorCline, EditorAmazonQ, EditorAntigravity, EditorContinue, EditorGemini, EditorClaudeDesktop, EditorCopilotCLI}
 	for _, id := range editors {
 		t.Run(string(id), func(t *testing.T) {
 			dir := t.TempDir()

--- a/internal/install/manifest.go
+++ b/internal/install/manifest.go
@@ -19,6 +19,7 @@ type Manifest struct {
 	PluginDir     string                     `json:"pluginDir"`
 	Editors       map[EditorID]ManifestEntry `json:"editors,omitempty"`
 	Claude        *ManifestClaude            `json:"claude,omitempty"`
+	Codex         *ManifestCodex             `json:"codex,omitempty"`
 }
 
 // ManifestEntry records where an editor was registered.
@@ -30,6 +31,11 @@ type ManifestEntry struct {
 // ManifestClaude records Claude Code installation details.
 type ManifestClaude struct {
 	CacheDir string `json:"cacheDir"`
+}
+
+// ManifestCodex records Codex CLI MCP registration details.
+type ManifestCodex struct {
+	ConfigFile string `json:"configFile"`
 }
 
 // ManifestPath returns the path to the manifest file for the given plugin directory.
@@ -107,6 +113,11 @@ func (m *Manifest) RemoveEditor(id EditorID) {
 // SetClaude records Claude Code installation in the manifest.
 func (m *Manifest) SetClaude(cacheDir string) {
 	m.Claude = &ManifestClaude{CacheDir: cacheDir}
+}
+
+// SetCodex records Codex CLI MCP registration in the manifest.
+func (m *Manifest) SetCodex(configFile string) {
+	m.Codex = &ManifestCodex{ConfigFile: configFile}
 }
 
 // ConfigFormat returns the JSON format identifier for a given editor.


### PR DESCRIPTION
## Related Issue

* [PPSC-846](https://armis-security.atlassian.net/browse/PPSC-846)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

Two issues with MCP install targets:

1. **Copilot CLI**: The `armis-cli install copilot` command treated "copilot" as an alias for VS Code, writing MCP config to `~/.vscode/mcp.json` instead of Copilot CLI's own `~/.copilot/mcp-config.json`. Uninstall also removed the wrong config, and agent detection missed the `.copilot` directory entirely.

2. **Codex CLI**: The `armis-cli install codex` command did not register the MCP server in Codex CLI's `config.toml`, so Codex couldn't discover the Armis scanner.

## Solution

1. **Copilot CLI** — Added `EditorCopilotCLI` as a distinct editor target with config path `~/.copilot/mcp-config.json`. Updated detection to recognize the `.copilot` directory and its MCP config. Fixed uninstall to clean up the correct file and remove native hooks.

2. **Codex CLI** — Added `RegisterCodexMCP()` to write the MCP server entry into `~/.codex/config.toml` (TOML format), alongside the existing hook-based integration.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

- Verified `armis-cli install copilot` writes to `~/.copilot/mcp-config.json`
- Verified `armis-cli uninstall copilot` removes the correct config
- Verified Codex CLI config.toml registration

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-846]: https://armis-security.atlassian.net/browse/PPSC-846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ