### PR TITLE
[PPSC-836] fix(install): write Copilot CLI hook to correct path

### DIFF
--- a/internal/agentdetect/detector_test.go
+++ b/internal/agentdetect/detector_test.go
@@ -233,7 +233,14 @@ func TestCopilotDetector_Detect(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "config dir exists",
+			name: "copilot CLI config dir exists",
+			setup: func(t *testing.T, home string, _ *mockPlatform) {
+				mustMkdirAll(t, filepath.Join(home, ".copilot"))
+			},
+			expected: true,
+		},
+		{
+			name: "legacy config dir exists",
 			setup: func(t *testing.T, home string, _ *mockPlatform) {
 				mustMkdirAll(t, filepath.Join(home, ".config", "github-copilot"))
 			},

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -161,6 +161,12 @@ func installAll(force bool) error {
 			registered = append(registered, e.Name)
 			manifest.AddEditor(e.ID, e.ConfigPath(), install.ConfigFormat(e.ID))
 		}
+
+		if hc, ok := install.HookClientByID(install.HookClientID(e.ID)); ok {
+			if err := install.InstallNativeHook(hc, ei.PluginDir()); err != nil {
+				fmt.Fprintf(os.Stderr, "  ⚠ %s (hooks): %v\n", e.Name, err)
+			}
+		}
 	}
 
 	ci, ciErr := install.NewClaudeInstaller()
@@ -286,6 +292,12 @@ func installTargets(targets []string, force bool) error {
 			} else {
 				fmt.Fprintf(os.Stderr, "  ✓ %s\n", e.Name)
 				manifest.AddEditor(e.ID, e.ConfigPath(), install.ConfigFormat(e.ID))
+			}
+
+			if hc, ok := install.HookClientByID(install.HookClientID(id)); ok {
+				if err := install.InstallNativeHook(hc, ei.PluginDir()); err != nil {
+					fmt.Fprintf(os.Stderr, "  ⚠ %s (hooks): %v\n", e.Name, err)
+				}
 			}
 		}
 

--- a/internal/install/native_hooks.go
+++ b/internal/install/native_hooks.go
@@ -274,11 +274,14 @@ func installMergedHook(pluginDir, configPath string, client HookClient) error {
 
 	for key, entries := range newHooks {
 		existing, _ := hooksSection[key].([]interface{})
-		if !hasArmisHookEntries(existing) {
-			newEntries, _ := entries.([]interface{})
+		newEntries, _ := entries.([]interface{})
+		if hasArmisHookEntries(existing) {
+			filtered := filterNonArmisEntries(existing)
+			existing = append(filtered, newEntries...)
+		} else {
 			existing = append(existing, newEntries...)
-			hooksSection[key] = existing
 		}
+		hooksSection[key] = existing
 	}
 
 	data["hooks"] = hooksSection
@@ -339,11 +342,14 @@ func installCursorHook(pluginDir, configPath string) error {
 
 	for key, entries := range hooks {
 		existing, _ := hooksSection[key].([]interface{})
-		if !hasArmisHookEntries(existing) {
-			newEntries, _ := entries.([]interface{})
+		newEntries, _ := entries.([]interface{})
+		if hasArmisHookEntries(existing) {
+			filtered := filterNonArmisEntries(existing)
+			existing = append(filtered, newEntries...)
+		} else {
 			existing = append(existing, newEntries...)
-			hooksSection[key] = existing
 		}
+		hooksSection[key] = existing
 	}
 
 	data["hooks"] = hooksSection
@@ -471,7 +477,7 @@ func buildCopilotHooks(pluginDir string) map[string]interface{} {
 			map[string]interface{}{
 				"type":       "command",
 				"bash":       cmd,
-				"matcher":    "bash|powershell|create|edit",
+				"matcher":    "bash|shell|terminal|powershell|create|edit",
 				"timeoutSec": 10,
 			},
 		},

--- a/internal/install/native_hooks.go
+++ b/internal/install/native_hooks.go
@@ -139,7 +139,14 @@ func InstallNativeHook(client HookClient, pluginDir string) error {
 		return fmt.Errorf("creating config directory: %w", err)
 	}
 
-	return installClientHook(client, pluginDir, configPath)
+	if err := installClientHook(client, pluginDir, configPath); err != nil {
+		return err
+	}
+
+	if client.ID == HookClientCopilot {
+		cleanupLegacyCopilotHook()
+	}
+	return nil
 }
 
 // RemoveNativeHook removes hook entries for a client.
@@ -164,7 +171,7 @@ func installClientHook(client HookClient, pluginDir, configPath string) error {
 	case HookClientCodex:
 		return installMergedHook(pluginDir, configPath, client)
 	case HookClientCopilot:
-		return installCopilotHook(pluginDir, configPath)
+		return installMergedHook(pluginDir, configPath, client)
 	case HookClientCline:
 		return installMergedHook(pluginDir, configPath, client)
 	}
@@ -176,8 +183,6 @@ func removeClientHook(client HookClient, configPath string) error {
 	switch client.ID {
 	case HookClientCursor:
 		return removeCursorHook(configPath)
-	case HookClientCopilot:
-		return removeCopilotHook(configPath)
 	default:
 		return removeMergedHook(configPath, client)
 	}
@@ -205,22 +210,7 @@ func codexHooksPath() string {
 
 func copilotHooksPath() string {
 	return hookConfigPath(HookClientCopilot, func() string {
-		switch runtime.GOOS {
-		case osDarwin, osLinux:
-			return homeDir(".config", "github-copilot", "hooks.json")
-		case osWindows:
-			// armis:ignore cwe:73 cwe:22 reason:APPDATA is the OS-standard config dir; validated as absolute path below
-			appdata := os.Getenv("APPDATA")
-			if appdata == "" {
-				return ""
-			}
-			appdata = filepath.Clean(appdata)
-			if !filepath.IsAbs(appdata) {
-				return ""
-			}
-			return filepath.Join(appdata, "github-copilot", "hooks.json")
-		}
-		return ""
+		return homeDir(".copilot", "settings.json")
 	})
 }
 
@@ -394,42 +384,6 @@ func removeCursorHook(configPath string) error {
 	return writeJSONAtomic(configPath, data)
 }
 
-// installCopilotHook handles Copilot CLI's hook format (uses "bash" key instead of "command").
-func installCopilotHook(pluginDir, configPath string) error {
-	data, err := readJSONFileAsMapSafe(configPath)
-	if err != nil {
-		return err
-	}
-
-	if _, ok := data["version"]; !ok {
-		data["version"] = 1
-	}
-
-	hooks := buildCopilotHooks(pluginDir)
-
-	hooksSection, _ := data["hooks"].(map[string]interface{})
-	if hooksSection == nil {
-		hooksSection = make(map[string]interface{})
-	}
-
-	for key, entries := range hooks {
-		existing, _ := hooksSection[key].([]interface{})
-		if !hasArmisHookEntries(existing) {
-			newEntries, _ := entries.([]interface{})
-			existing = append(existing, newEntries...)
-			hooksSection[key] = existing
-		}
-	}
-
-	data["hooks"] = hooksSection
-	return writeJSONAtomic(configPath, data)
-}
-
-// removeCopilotHook removes Armis entries from Copilot hook config.
-func removeCopilotHook(configPath string) error {
-	return removeCursorHook(configPath) // same structure
-}
-
 // --- Hook config builders ---
 
 // armis:ignore cwe:78 reason:pluginDir from known install location; quotedCommand uses posixQuote to escape shell metacharacters
@@ -576,6 +530,44 @@ func isArmisHookJSON(entry interface{}) bool {
 		strings.Contains(s, "codex_pre_tool.py") ||
 		strings.Contains(s, "copilot_pre_tool.py") ||
 		strings.Contains(s, "cline_pre_tool.py")
+}
+
+// cleanupLegacyCopilotHook removes the old ~/.config/github-copilot/hooks.json
+// if it only contains Armis hook entries (left over from the incorrect path).
+// armis:ignore cwe:22 reason:path is hardcoded from homeDir(".config","github-copilot","hooks.json"), not user input
+func cleanupLegacyCopilotHook() {
+	legacyPath := homeDir(".config", "github-copilot", "hooks.json")
+	if legacyPath == "" {
+		return
+	}
+	data, err := readJSONFileAsMapSafe(legacyPath)
+	if err != nil || len(data) == 0 {
+		return
+	}
+	hooksSection, _ := data["hooks"].(map[string]interface{})
+	if hooksSection == nil {
+		return
+	}
+	// Only remove if every hook entry is ours.
+	for _, entries := range hooksSection {
+		arr, ok := entries.([]interface{})
+		if !ok {
+			return
+		}
+		for _, entry := range arr {
+			if !isArmisHookJSON(entry) {
+				return
+			}
+		}
+	}
+	// Check there's nothing else besides "version" and "hooks".
+	for key := range data {
+		if key != "version" && key != "hooks" {
+			return
+		}
+	}
+	// armis:ignore cwe:22 reason:legacyPath is constructed from hardcoded literals via homeDir(".config","github-copilot","hooks.json")
+	_ = os.Remove(filepath.Clean(legacyPath)) //nolint:gosec // best-effort cleanup of our own file
 }
 
 // posixQuote wraps a string in POSIX-safe single quotes, escaping embedded single quotes.

--- a/internal/install/native_hooks.go
+++ b/internal/install/native_hooks.go
@@ -545,11 +545,11 @@ func cleanupLegacyCopilotHook() {
 	if p := homeDir(".config", "github-copilot", "hooks.json"); p != "" {
 		removeLegacyFileIfArmisOnly(p)
 	}
-	// armis:ignore cwe:73 cwe:22 reason:APPDATA is the OS-standard config dir; validated absolute
 	if runtime.GOOS == osWindows {
 		if appdata := os.Getenv("APPDATA"); appdata != "" {
 			appdata = filepath.Clean(appdata)
 			if filepath.IsAbs(appdata) {
+				// armis:ignore cwe:73 cwe:22 reason:APPDATA is the OS-standard config dir; validated absolute above
 				removeLegacyFileIfArmisOnly(filepath.Join(appdata, "github-copilot", "hooks.json"))
 			}
 		}

--- a/internal/install/native_hooks.go
+++ b/internal/install/native_hooks.go
@@ -532,15 +532,27 @@ func isArmisHookJSON(entry interface{}) bool {
 		strings.Contains(s, "cline_pre_tool.py")
 }
 
-// cleanupLegacyCopilotHook removes the old ~/.config/github-copilot/hooks.json
-// if it only contains Armis hook entries (left over from the incorrect path).
-// armis:ignore cwe:22 reason:path is hardcoded from homeDir(".config","github-copilot","hooks.json"), not user input
+// cleanupLegacyCopilotHook removes old hook files that were previously written
+// to the wrong path, if they only contain Armis entries.
 func cleanupLegacyCopilotHook() {
-	legacyPath := homeDir(".config", "github-copilot", "hooks.json")
-	if legacyPath == "" {
-		return
+	// armis:ignore cwe:22 reason:homeDir uses os.UserHomeDir(); path components are hardcoded literals
+	if p := homeDir(".config", "github-copilot", "hooks.json"); p != "" {
+		removeLegacyFileIfArmisOnly(p)
 	}
-	data, err := readJSONFileAsMapSafe(legacyPath)
+	// armis:ignore cwe:73 cwe:22 reason:APPDATA is the OS-standard config dir; validated absolute
+	if runtime.GOOS == osWindows {
+		if appdata := os.Getenv("APPDATA"); appdata != "" {
+			appdata = filepath.Clean(appdata)
+			if filepath.IsAbs(appdata) {
+				removeLegacyFileIfArmisOnly(filepath.Join(appdata, "github-copilot", "hooks.json"))
+			}
+		}
+	}
+}
+
+// armis:ignore cwe:22 cwe:73 reason:called only from cleanupLegacyCopilotHook with hardcoded OS config paths
+func removeLegacyFileIfArmisOnly(path string) {
+	data, err := readJSONFileAsMapSafe(path)
 	if err != nil || len(data) == 0 {
 		return
 	}
@@ -548,7 +560,6 @@ func cleanupLegacyCopilotHook() {
 	if hooksSection == nil {
 		return
 	}
-	// Only remove if every hook entry is ours.
 	for _, entries := range hooksSection {
 		arr, ok := entries.([]interface{})
 		if !ok {
@@ -560,14 +571,12 @@ func cleanupLegacyCopilotHook() {
 			}
 		}
 	}
-	// Check there's nothing else besides "version" and "hooks".
 	for key := range data {
 		if key != "version" && key != "hooks" {
 			return
 		}
 	}
-	// armis:ignore cwe:22 reason:legacyPath is constructed from hardcoded literals via homeDir(".config","github-copilot","hooks.json")
-	_ = os.Remove(filepath.Clean(legacyPath)) //nolint:gosec // best-effort cleanup of our own file
+	_ = os.Remove(filepath.Clean(path)) //nolint:gosec // armis:ignore cwe:22 cwe:73 reason:path from hardcoded OS config dirs
 }
 
 // posixQuote wraps a string in POSIX-safe single quotes, escaping embedded single quotes.

--- a/internal/install/native_hooks_test.go
+++ b/internal/install/native_hooks_test.go
@@ -94,10 +94,14 @@ func TestInstallNativeHook(t *testing.T) {
 		}
 	})
 
-	t.Run("copilot hook uses bash key", func(t *testing.T) {
+	t.Run("copilot hook merges into settings and uses bash key", func(t *testing.T) {
 		dir := t.TempDir()
-		configPath := filepath.Join(dir, "hooks.json")
+		configPath := filepath.Join(dir, "settings.json")
 		pluginDir := setupFakePluginDir(t, "copilot_pre_tool.py")
+
+		// Pre-populate with existing settings to verify merge behavior.
+		existing := map[string]interface{}{"memory": true, "model": "claude-opus-4.7"}
+		writeTestJSON(t, configPath, existing)
 
 		hookConfigPathOverrides = map[HookClientID]string{
 			HookClientCopilot: configPath,
@@ -110,6 +114,21 @@ func TestInstallNativeHook(t *testing.T) {
 		}
 
 		data := readTestJSON(t, configPath)
+
+		// Existing settings preserved.
+		if data["memory"] != true {
+			t.Error("existing 'memory' setting was lost")
+		}
+		if data["model"] != "claude-opus-4.7" {
+			t.Error("existing 'model' setting was lost")
+		}
+
+		// No "version" key (settings.json doesn't use it).
+		if _, ok := data["version"]; ok {
+			t.Error("settings.json should not have 'version' key")
+		}
+
+		// Hook uses "bash" key.
 		hooks := data["hooks"].(map[string]interface{})
 		preToolUse := hooks["preToolUse"].([]interface{})
 		entry := preToolUse[0].(map[string]interface{})

--- a/internal/install/native_hooks_test.go
+++ b/internal/install/native_hooks_test.go
@@ -106,6 +106,8 @@ func TestInstallNativeHook(t *testing.T) {
 		hookConfigPathOverrides = map[HookClientID]string{
 			HookClientCopilot: configPath,
 		}
+		// Redirect HOME so cleanupLegacyCopilotHook targets the temp dir.
+		t.Setenv("HOME", dir)
 		defer func() { hookConfigPathOverrides = nil }()
 
 		client, _ := HookClientByID(HookClientCopilot)
@@ -134,6 +136,67 @@ func TestInstallNativeHook(t *testing.T) {
 		entry := preToolUse[0].(map[string]interface{})
 		if _, ok := entry["bash"]; !ok {
 			t.Error("expected 'bash' key in copilot hook (not 'command')")
+		}
+	})
+
+	t.Run("copilot legacy cleanup removes armis-only file", func(t *testing.T) {
+		dir := t.TempDir()
+		// Place legacy file where cleanupLegacyCopilotHook will look.
+		legacyDir := filepath.Join(dir, ".config", "github-copilot")
+		if err := os.MkdirAll(legacyDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		legacyPath := filepath.Join(legacyDir, "hooks.json")
+
+		legacy := map[string]interface{}{
+			"version": float64(1),
+			"hooks": map[string]interface{}{
+				"preToolUse": []interface{}{
+					map[string]interface{}{
+						"type":    "command",
+						"bash":    "'/path/to/python' '/path/to/copilot_pre_tool.py'",
+						"matcher": "bash|powershell|create|edit",
+					},
+				},
+			},
+		}
+		writeTestJSON(t, legacyPath, legacy)
+
+		t.Setenv("HOME", dir)
+		cleanupLegacyCopilotHook()
+
+		if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+			t.Error("expected legacy file to be removed")
+		}
+	})
+
+	t.Run("copilot legacy cleanup preserves non-armis file", func(t *testing.T) {
+		dir := t.TempDir()
+		legacyDir := filepath.Join(dir, ".config", "github-copilot")
+		if err := os.MkdirAll(legacyDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		legacyPath := filepath.Join(legacyDir, "hooks.json")
+
+		legacy := map[string]interface{}{
+			"version": float64(1),
+			"hooks": map[string]interface{}{
+				"preToolUse": []interface{}{
+					map[string]interface{}{
+						"type":    "command",
+						"bash":    "some-other-tool",
+						"matcher": "bash",
+					},
+				},
+			},
+		}
+		writeTestJSON(t, legacyPath, legacy)
+
+		t.Setenv("HOME", dir)
+		cleanupLegacyCopilotHook()
+
+		if _, err := os.Stat(legacyPath); err != nil {
+			t.Error("expected legacy file to be preserved when it has non-Armis entries")
 		}
 	})
 

--- a/internal/install/native_hooks_test.go
+++ b/internal/install/native_hooks_test.go
@@ -108,6 +108,7 @@ func TestInstallNativeHook(t *testing.T) {
 		}
 		// Redirect HOME so cleanupLegacyCopilotHook targets the temp dir.
 		t.Setenv("HOME", dir)
+		t.Setenv("USERPROFILE", dir)
 		defer func() { hookConfigPathOverrides = nil }()
 
 		client, _ := HookClientByID(HookClientCopilot)
@@ -163,6 +164,7 @@ func TestInstallNativeHook(t *testing.T) {
 		writeTestJSON(t, legacyPath, legacy)
 
 		t.Setenv("HOME", dir)
+		t.Setenv("USERPROFILE", dir)
 		cleanupLegacyCopilotHook()
 
 		if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
@@ -193,6 +195,7 @@ func TestInstallNativeHook(t *testing.T) {
 		writeTestJSON(t, legacyPath, legacy)
 
 		t.Setenv("HOME", dir)
+		t.Setenv("USERPROFILE", dir)
 		cleanupLegacyCopilotHook()
 
 		if _, err := os.Stat(legacyPath); err != nil {


### PR DESCRIPTION
## Related Issue

* [PPSC-836](https://armis-security.atlassian.net/browse/PPSC-836)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

The install wizard wrote the Copilot CLI hook to `~/.config/github-copilot/hooks.json` — the VS Code Copilot extension's config directory. GitHub Copilot CLI (terminal agent) reads hooks from `~/.copilot/settings.json`, so the hook was silently dead and commits went through unscanned.

## Solution

- Fix `copilotHooksPath()` to target `~/.copilot/settings.json`
- Route Copilot install/remove through `installMergedHook` to safely preserve existing user settings (memory, model, etc.) without injecting a spurious `"version": 1`
- Add `~/.copilot` to agent detection in `agentdetect`
- Clean up the legacy dead file at `~/.config/github-copilot/hooks.json` on re-install (only if it contains exclusively Armis entries)

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

- Verified `~/.config/github-copilot/hooks.json` exists on disk (old incorrect install)
- Verified `~/.copilot/settings.json` is what Copilot CLI v1.0.54 reads (`copilot help config` confirms `hooks` key in settings)
- Confirmed `copilot --help` shows `--log-dir` defaulting to `~/.copilot/logs/`

## Reviewer Notes

- The `buildCopilotHooks()` output format (using `"bash"` key, lowercase `"preToolUse"`) is unchanged — only the file it's written to has changed.
- Users who re-run the interactive wizard will get the fix automatically. The old dead file is cleaned up as a best-effort side effect.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-836]: https://armis-security.atlassian.net/browse/PPSC-836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ