### PR TITLE
[PPSC-853] fix(install): correct Gemini CLI hook timeout unit

### DIFF
--- a/internal/install/native_hooks.go
+++ b/internal/install/native_hooks.go
@@ -428,7 +428,7 @@ func buildGeminiHooks(pluginDir string) map[string]interface{} {
 					map[string]interface{}{
 						"type":    "command",
 						"command": cmd,
-						"timeout": 10,
+						"timeout": 10000,
 					},
 				},
 			},


### PR DESCRIPTION
## Related Issue

* [PPSC-853](https://armis-security.atlassian.net/browse/PPSC-853)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

The Gemini CLI hook timeout was set to `10` in `~/.gemini/settings.json`. Gemini CLI interprets this value in milliseconds, so the hook was timing out after 10ms — before the Python security scanning script could even start — causing it to be silently skipped.

## Solution

Changed the timeout from `10` to `10000` (10 seconds), matching the intended behavior of other client hook configurations.

## Testing

### Automated Tests

* [x] All tests passing locally (`go test ./internal/install/...`)

### Manual Testing

Verified the generated `settings.json` now contains `"timeout": 10000`.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-853]: https://armis-security.atlassian.net/browse/PPSC-853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ