### PR TITLE
[PPSC-877] feat(supply-chain): add Python package release-age enforcement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ArmisSecurity/armis-cli
 go 1.25.0
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/alecthomas/chroma/v2 v2.24.1
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/charmbracelet/huh v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=

--- a/internal/cmd/supply_chain.go
+++ b/internal/cmd/supply_chain.go
@@ -34,9 +34,10 @@ compromised maintainer accounts, or dependency confusion.
 
 Supported ecosystems:
   Node:   npm, pnpm, bun, yarn (transparent proxy enforcement)
+  Python: pip, uv (transparent proxy); poetry, pipenv, pdm (pre-install block)
 
 No Armis Cloud authentication is required — supply-chain queries public registries
-(npm registry).`,
+(npm registry, PyPI).`,
 	Example: `  # Audit lockfile for recently-published packages (CI mode)
   armis-cli supply-chain check
 

--- a/internal/cmd/supply_chain_init.go
+++ b/internal/cmd/supply_chain_init.go
@@ -25,7 +25,8 @@ var scInitCmd = &cobra.Command{
 
 This wraps your package manager (auto-detected from lockfiles) so that armis-cli
 can enforce age policies on package installations. Node PMs (npm, pnpm, bun, yarn)
-use a transparent proxy that filters registry responses.
+and pip/uv use a transparent proxy that filters registry responses. poetry, pipenv,
+and pdm use a pre-install check that blocks the build if violations are found.
 
 Four modes are available:
   rc     — Inject shell functions into ~/.bashrc / ~/.zshrc (default, interactive)
@@ -95,15 +96,26 @@ func detectWrappablePMs() []string {
 	seen := make(map[string]bool)
 	var pms []string
 
+	addPM := func(pm string) {
+		if pm == "" || seen[pm] {
+			return
+		}
+		seen[pm] = true
+		pms = append(pms, pm)
+	}
+
 	for _, e := range ecosystems {
 		pm := ecosystemToPM(e.Ecosystem)
-		if pm == "" {
+		// A bare requirements.txt is installed with pip, which can be present
+		// under several names (pip, pip3, pip3.12). Wrap every variant on PATH
+		// so enforcement holds regardless of which one the user invokes.
+		if pm == pmPip {
+			for _, variant := range supplychain.DetectPipVariants() {
+				addPM(variant)
+			}
 			continue
 		}
-		if !seen[pm] {
-			seen[pm] = true
-			pms = append(pms, pm)
-		}
+		addPM(pm)
 	}
 
 	if len(pms) == 0 {
@@ -122,6 +134,16 @@ func ecosystemToPM(eco supplychain.Ecosystem) string {
 		return pmBun
 	case supplychain.EcosystemYarn:
 		return pmYarn
+	case supplychain.EcosystemPip:
+		return pmPip
+	case supplychain.EcosystemPoetry:
+		return pmPoetry
+	case supplychain.EcosystemPipfile:
+		return pmPipenv
+	case supplychain.EcosystemPDM:
+		return pmPDM
+	case supplychain.EcosystemUV:
+		return pmUV
 	default:
 		return ""
 	}

--- a/internal/cmd/supply_chain_wrap.go
+++ b/internal/cmd/supply_chain_wrap.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ArmisSecurity/armis-cli/internal/model"
 	"github.com/ArmisSecurity/armis-cli/internal/output"
 	"github.com/ArmisSecurity/armis-cli/internal/supplychain"
+	"github.com/ArmisSecurity/armis-cli/internal/supplychain/check"
 	"github.com/spf13/cobra"
 )
 
@@ -29,10 +30,15 @@ const (
 // allowlist, the registry-env switch, and the exec mapping in sync and avoids
 // scattering the literals across the file.
 const (
-	pmNPM  = "npm"
-	pmPNPM = "pnpm"
-	pmBun  = "bun"
-	pmYarn = "yarn"
+	pmNPM    = "npm"
+	pmPNPM   = "pnpm"
+	pmBun    = "bun"
+	pmYarn   = "yarn"
+	pmPip    = "pip"
+	pmUV     = "uv"
+	pmPoetry = "poetry"
+	pmPipenv = "pipenv"
+	pmPDM    = "pdm"
 )
 
 var scWrapCmd = &cobra.Command{
@@ -48,14 +54,23 @@ func init() {
 	supplyChainCmd.AddCommand(scWrapCmd)
 }
 
-var allowedPMs = map[string]bool{pmNPM: true, pmPNPM: true, pmBun: true, pmYarn: true}
+var allowedPMs = map[string]bool{
+	pmNPM: true, pmPNPM: true, pmBun: true, pmYarn: true,
+	pmPip: true, pmUV: true, pmPoetry: true, pmPipenv: true, pmPDM: true,
+}
 
 func runSupplyChainWrap(cmd *cobra.Command, args []string) error {
+	// pmName is the exact command the user invoked (e.g. "pip3.12"); execName is
+	// the binary actually run. canonicalPM collapses pip variants (pip3, pip3.12)
+	// to "pip" for every policy decision — the allowlist, pre-install routing, and
+	// registry-env all behave identically for any pip — while pmName is preserved
+	// for execution so a versioned variant still installs into its own interpreter.
 	pmName := args[0]
 	pmArgs := args[1:]
+	canonical := canonicalPM(pmName)
 
-	if !allowedPMs[pmName] {
-		return fmt.Errorf("unsupported package manager: %s (allowed: npm, pnpm, bun, yarn)", pmName)
+	if !allowedPMs[canonical] {
+		return fmt.Errorf("unsupported package manager: %s (allowed: npm, pnpm, bun, yarn, pip, uv, poetry, pipenv, pdm)", pmName)
 	}
 
 	if os.Getenv(envSCActive) == "1" {
@@ -67,7 +82,26 @@ func runSupplyChainWrap(cmd *cobra.Command, args []string) error {
 		return exitWithCode(execPM(pmName, pmArgs, nil))
 	}
 
+	// poetry, pipenv, and pdm resolve dependencies through their own lockfiles
+	// rather than honoring an npm-style registry override, so they cannot be
+	// enforced via the transparent proxy. Instead we audit the lockfile and
+	// hard-block the build before it runs if any package is too young.
+	if requiresPreInstallBlock(canonical) {
+		return runPreInstallBlock(cmd, pmName, pmArgs)
+	}
+
 	return runProxyWrap(cmd, pmName, pmArgs)
+}
+
+// canonicalPM maps a user-invoked package-manager name to the name used for
+// policy decisions. pip variants (pip3, pip3.11, pip3.12) all resolve to PyPI
+// and share one enforcement path, so they collapse to "pip"; every other name
+// is returned unchanged.
+func canonicalPM(pm string) string {
+	if supplychain.IsPipVariant(pm) {
+		return pmPip
+	}
+	return pm
 }
 
 func runProxyWrap(cmd *cobra.Command, pmName string, pmArgs []string) error {
@@ -95,7 +129,9 @@ func runProxyWrap(cmd *cobra.Command, pmName string, pmArgs []string) error {
 	defer proxy.Close() //nolint:errcheck
 
 	registryURL := fmt.Sprintf("http://%s/", addr)
-	extraEnv := registryEnvForPM(pmName, registryURL)
+	// Canonicalize so a versioned pip variant (pip3.12) still gets PIP_INDEX_URL
+	// rather than falling through to the npm registry env.
+	extraEnv := registryEnvForPM(canonicalPM(pmName), registryURL)
 	extraEnv = append(extraEnv, fmt.Sprintf("%s=1", envSCActive))
 
 	exitCode, err := execPM(pmName, pmArgs, extraEnv)
@@ -119,7 +155,7 @@ func execPM(pm string, args []string, extraEnv []string) (int, error) {
 	// constant rather than the caller's argument, so there is no data-flow path
 	// from user input into the lookup. Resolving the user's own package manager
 	// from their PATH is the intended behavior of a transparent wrapper; only
-	// the four known names can ever reach this point.
+	// the known PM names enumerated below can ever reach this point.
 	var pmName string
 	switch pm {
 	case pmNPM:
@@ -130,11 +166,31 @@ func execPM(pm string, args []string, extraEnv []string) (int, error) {
 		pmName = pmBun
 	case pmYarn:
 		pmName = pmYarn
+	case pmPip:
+		pmName = pmPip
+	case pmUV:
+		pmName = pmUV
+	case pmPoetry:
+		pmName = pmPoetry
+	case pmPipenv:
+		pmName = pmPipenv
+	case pmPDM:
+		pmName = pmPDM
 	default:
-		return 1, fmt.Errorf("unsupported package manager: %s (allowed: npm, pnpm, bun, yarn)", pm)
+		// Versioned pip variants (pip3, pip3.11, pip3.12) must execute the exact
+		// binary the user invoked so the install lands in that interpreter's
+		// environment. IsPipVariant enforces a strict pattern (letters, digits, a
+		// single dotted numeric suffix), so the value reaching exec.LookPath is
+		// still a bounded, shell-metacharacter-free name rather than arbitrary
+		// user input — preserving the CWE-426 guarantee the literal cases provide.
+		if supplychain.IsPipVariant(pm) {
+			pmName = pm
+			break
+		}
+		return 1, fmt.Errorf("unsupported package manager: %s (allowed: npm, pnpm, bun, yarn, pip, uv, poetry, pipenv, pdm)", pm)
 	}
 
-	// armis:ignore cwe:426 reason:pmName is one of four hardcoded string literals selected by the switch above, never the user argument; resolving the user's own PM from PATH is the point of a transparent wrapper
+	// armis:ignore cwe:426 cwe:427 reason:pmName is one of the hardcoded string literals selected by the switch above, never the user argument; resolving the user's own PM from PATH is the point of a transparent wrapper
 	pmPath, err := exec.LookPath(pmName)
 	if err != nil {
 		return 1, fmt.Errorf("finding %s: %w", pm, err)
@@ -298,6 +354,18 @@ func registryEnvForPM(pm, registryURL string) []string {
 			fmt.Sprintf("npm_config_registry=%s", registryURL),
 			fmt.Sprintf("YARN_NPM_REGISTRY_SERVER=%s", registryURL),
 		}
+	case pmUV:
+		// registryURL is built by the caller with a trailing slash, so trim it
+		// before appending the PEP 503 "/simple/" path to avoid a "//simple/"
+		// double slash. Clients normalize it today, but the PyPI proxy handler
+		// (future work) should receive a clean "/simple/..." path.
+		return []string{
+			fmt.Sprintf("UV_INDEX_URL=%s/simple/", strings.TrimSuffix(registryURL, "/")),
+		}
+	case pmPip:
+		return []string{
+			fmt.Sprintf("PIP_INDEX_URL=%s/simple/", strings.TrimSuffix(registryURL, "/")),
+		}
 	default:
 		return []string{
 			fmt.Sprintf("npm_config_registry=%s", registryURL),
@@ -343,4 +411,157 @@ func resolveWrapPolicy() supplychain.Policy {
 		}
 	}
 	return supplychain.DefaultPolicy()
+}
+
+// requiresPreInstallBlock reports whether a package manager must be enforced via
+// a pre-install lockfile audit rather than the transparent registry proxy.
+// poetry, pipenv, and pdm resolve from their own lockfiles and do not honor an
+// npm-style registry override, so the proxy cannot filter young versions for
+// them; instead the build is blocked up front if the lockfile contains a
+// too-young package.
+func requiresPreInstallBlock(pm string) bool {
+	switch pm {
+	case pmPoetry, pmPipenv, pmPDM:
+		return true
+	}
+	return false
+}
+
+func runPreInstallBlock(cmd *cobra.Command, pmName string, pmArgs []string) error {
+	skipPkgs := parseSkipPackages(os.Getenv(envSCSkip))
+	policy := resolveWrapPolicy()
+
+	// Walk up from the current directory to find the lockfile. poetry/pdm/pipenv
+	// are commonly run from a subdirectory while the lockfile lives at the project
+	// root (monorepos, CI steps that cd into a service dir); probing only "." here
+	// would silently skip enforcement and run the build unprotected.
+	lockfilePath := supplychain.FindEcosystemLockfile(".", pmToEcosystem(pmName))
+
+	if lockfilePath == "" {
+		fmt.Fprintf(os.Stderr, "%s no lockfile found for %s, running without enforcement\n", scPrefix, pmName)
+		return exitWithCode(execPM(pmName, pmArgs, nil))
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
+	defer cancel()
+
+	result, err := check.RunCheck(ctx, policy, lockfilePath, "")
+	if err != nil {
+		// Honor the fail-open policy the same way the proxy path does: with
+		// FailOpen set, a failed audit (e.g. PyPI unreachable, lockfile parse
+		// error) allows the build; otherwise it blocks. poetry/pipenv/pdm have
+		// no other enforcement path, so silently running on every audit error
+		// would let a transient failure bypass the control entirely.
+		if policy.FailOpen {
+			fmt.Fprintf(os.Stderr, "%s supply-chain: check failed, allowing (fail-open): %v\n", scPrefix, err)
+			return exitWithCode(execPM(pmName, pmArgs, nil))
+		}
+		fmt.Fprintf(os.Stderr, "%s supply-chain: check failed, blocking (fail-closed): %v\n", scPrefix, err)
+		fmt.Fprintf(os.Stderr, "  %s\n", "Set fail-open: true in .armis-supply-chain.yaml to allow installs when the check cannot run.")
+		os.Exit(1)
+		return nil
+	}
+
+	// Drop any violation whose package is in the skip list before deciding
+	// whether to block, so ARMIS_SUPPLY_CHAIN_SKIP works for the pre-install
+	// path the same way SkipPackages works for the proxy path.
+	skip := make(map[string]bool, len(skipPkgs))
+	for _, s := range skipPkgs {
+		skip[s] = true
+	}
+	var violations []supplychain.Violation
+	for _, v := range result.Violations {
+		if !skip[v.Name] {
+			violations = append(violations, v)
+		}
+	}
+
+	if len(violations) == 0 {
+		if result.Checked > 0 {
+			s := output.GetStyles()
+			fmt.Fprintf(os.Stderr, "%s %s %s %s\n",
+				s.MutedText.Render(scPrefix),
+				s.SuccessText.Render(output.IconSuccess),
+				s.SuccessText.Render(fmt.Sprintf("supply-chain: %d packages checked, all pass", result.Checked)),
+				s.MutedText.Render(fmt.Sprintf("(%s minimum age)", formatDurationShort(policy.MinReleaseAge))))
+		}
+		return exitWithCode(execPM(pmName, pmArgs, nil))
+	}
+
+	printPreInstallBlockSummary(violations, policy, pmName)
+	os.Exit(1)
+	return nil
+}
+
+func printPreInstallBlockSummary(violations []supplychain.Violation, policy supplychain.Policy, pmName string) {
+	s := output.GetStyles()
+
+	sort.Slice(violations, func(i, j int) bool {
+		return violations[i].Age < violations[j].Age
+	})
+
+	fmt.Fprintf(os.Stderr, "\n%s %s\n",
+		s.MutedText.Render(scPrefix),
+		s.WarningText.Render(fmt.Sprintf("supply-chain: BLOCKED — %d package(s) younger than %s", len(violations), formatDurationShort(policy.MinReleaseAge))))
+
+	fmt.Fprintf(os.Stderr, "  %s\n", s.MutedText.Render("Build was stopped BEFORE execution to prevent supply chain attacks."))
+
+	displayCount := len(violations)
+	if displayCount > maxBlockedDisplay {
+		displayCount = maxBlockedDisplay
+	}
+
+	fmt.Fprintf(os.Stderr, "\n  %s\n", s.MutedText.Render("Violations:"))
+	for _, v := range violations[:displayCount] {
+		age := formatDurationShort(v.Age)
+		dot := severityDot(s, v.Severity)
+		fmt.Fprintf(os.Stderr, "    %s %s %s\n",
+			dot,
+			s.Bold.Render(fmt.Sprintf("%s@%s", v.Name, v.Version)),
+			s.MutedText.Render(fmt.Sprintf("(published %s ago)", age)))
+	}
+	if remaining := len(violations) - displayCount; remaining > 0 {
+		fmt.Fprintf(os.Stderr, "    %s\n",
+			s.MutedText.Render(fmt.Sprintf("… and %d more", remaining)))
+	}
+
+	names := blockedViolationNames(violations)
+
+	fmt.Fprintf(os.Stderr, "\n  %s\n", s.MutedText.Render(strings.Repeat("─", scSepLen)))
+	if len(names) <= 3 {
+		fmt.Fprintf(os.Stderr, "  %s %s\n",
+			s.MutedText.Render("Bypass:"),
+			s.Bold.Render(fmt.Sprintf("%s=%s %s <args>", envSCSkip, strings.Join(names, ","), pmName)))
+	}
+	fmt.Fprintf(os.Stderr, "  %s %s\n",
+		s.MutedText.Render("Disable:"),
+		s.Bold.Render(fmt.Sprintf("%s=off %s <args>", envSCOff, pmName)))
+	fmt.Fprintf(os.Stderr, "  %s %s\n\n",
+		s.MutedText.Render("Exclude:"),
+		s.Bold.Render("add to exclusions in .armis-supply-chain.yaml"))
+}
+
+func blockedViolationNames(violations []supplychain.Violation) []string {
+	seen := make(map[string]bool)
+	names := make([]string, 0, len(violations))
+	for _, v := range violations {
+		if !seen[v.Name] {
+			seen[v.Name] = true
+			names = append(names, v.Name)
+		}
+	}
+	return names
+}
+
+func pmToEcosystem(pm string) supplychain.Ecosystem {
+	switch pm {
+	case pmPoetry:
+		return supplychain.EcosystemPoetry
+	case pmPipenv:
+		return supplychain.EcosystemPipfile
+	case pmPDM:
+		return supplychain.EcosystemPDM
+	default:
+		return ""
+	}
 }

--- a/internal/cmd/supply_chain_wrap_pm_test.go
+++ b/internal/cmd/supply_chain_wrap_pm_test.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ArmisSecurity/armis-cli/internal/supplychain"
+)
+
+func TestCanonicalPM(t *testing.T) {
+	tests := []struct {
+		pm   string
+		want string
+	}{
+		{pmPip, pmPip},
+		{"pip3", pmPip},
+		{"pip3.11", pmPip},
+		{"pip3.12", pmPip},
+		{pmUV, pmUV},
+		{pmNPM, pmNPM},
+		{pmPoetry, pmPoetry},
+		// pipx / pipenv are distinct tools, not pip variants — must not collapse.
+		{pmPipenv, pmPipenv},
+		{"pipx", "pipx"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pm, func(t *testing.T) {
+			if got := canonicalPM(tt.pm); got != tt.want {
+				t.Errorf("canonicalPM(%q) = %q, want %q", tt.pm, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalPMAllowed(t *testing.T) {
+	// A versioned pip variant must pass the allowlist check after canonicalization,
+	// otherwise a wrapped `pip3.12 install` would error with "unsupported".
+	for _, variant := range []string{"pip3", "pip3.11", "pip3.12"} {
+		if !allowedPMs[canonicalPM(variant)] {
+			t.Errorf("canonicalPM(%q) is not in allowedPMs; wrapped invocation would be rejected", variant)
+		}
+	}
+}
+
+func TestRequiresPreInstallBlock(t *testing.T) {
+	tests := []struct {
+		pm   string
+		want bool
+	}{
+		{pmPoetry, true},
+		{pmPipenv, true},
+		{pmPDM, true},
+		{pmPip, false},
+		{pmUV, false},
+		{pmNPM, false},
+		{pmPNPM, false},
+		{pmBun, false},
+		{pmYarn, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pm, func(t *testing.T) {
+			if got := requiresPreInstallBlock(tt.pm); got != tt.want {
+				t.Errorf("requiresPreInstallBlock(%q) = %v, want %v", tt.pm, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPmToEcosystem(t *testing.T) {
+	tests := []struct {
+		pm   string
+		want supplychain.Ecosystem
+	}{
+		{pmPoetry, supplychain.EcosystemPoetry},
+		{pmPipenv, supplychain.EcosystemPipfile},
+		{pmPDM, supplychain.EcosystemPDM},
+		// pip/uv use the proxy path, not the pre-install block, so they have no
+		// pre-install ecosystem mapping.
+		{pmPip, ""},
+		{pmUV, ""},
+		{pmNPM, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pm, func(t *testing.T) {
+			if got := pmToEcosystem(tt.pm); got != tt.want {
+				t.Errorf("pmToEcosystem(%q) = %q, want %q", tt.pm, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRegistryEnvForPM(t *testing.T) {
+	// registryURL is built by the caller as fmt.Sprintf("http://%s/", addr), so it
+	// always carries a trailing slash. registryEnvForPM trims that trailing slash
+	// before appending "/simple/" for pip/uv, so the index URL has a single,
+	// clean "/simple/" path (no "//simple/" double slash) — the shape a PEP 503
+	// proxy handler should expect.
+	const url = "http://127.0.0.1:9999/"
+
+	tests := []struct {
+		pm      string
+		wantKey string
+		wantVal string
+	}{
+		{pmNPM, "npm_config_registry", url},
+		{pmPNPM, "npm_config_registry", url},
+		{pmBun, "BUN_CONFIG_REGISTRY", url},
+		{pmYarn, "YARN_NPM_REGISTRY_SERVER", url},
+		{pmPip, "PIP_INDEX_URL", "http://127.0.0.1:9999/simple/"},
+		{pmUV, "UV_INDEX_URL", "http://127.0.0.1:9999/simple/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pm, func(t *testing.T) {
+			env := registryEnvForPM(tt.pm, url)
+			found := false
+			for _, e := range env {
+				if strings.HasPrefix(e, tt.wantKey+"=") && strings.HasSuffix(e, tt.wantVal) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("registryEnvForPM(%q, %q) = %v, want entry %s=...%s", tt.pm, url, env, tt.wantKey, tt.wantVal)
+			}
+		})
+	}
+}

--- a/internal/supplychain/check/check.go
+++ b/internal/supplychain/check/check.go
@@ -4,6 +4,7 @@ package check
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -93,14 +94,30 @@ func parseLockfile(ecosystem supplychain.Ecosystem, path string) ([]PackageEntry
 		return ParseBunLockfile(path)
 	case supplychain.EcosystemYarn:
 		return ParseYarnLockfile(path)
+	case supplychain.EcosystemPip:
+		return ParsePipRequirements(path)
+	case supplychain.EcosystemPoetry:
+		return ParsePoetryLockfile(path)
+	case supplychain.EcosystemPipfile:
+		return ParsePipfileLock(path)
+	case supplychain.EcosystemPDM:
+		return ParsePDMLockfile(path)
+	case supplychain.EcosystemUV:
+		return ParseUVLockfile(path)
 	default:
 		return ParseNPMLockfile(path)
 	}
 }
 
-func queryRegistry(ctx context.Context, _ supplychain.Ecosystem, packages []registry.PackageRequest) []registry.QueryResult {
-	client := registry.NewClient()
-	return client.GetPublishDates(ctx, packages)
+func queryRegistry(ctx context.Context, ecosystem supplychain.Ecosystem, packages []registry.PackageRequest) []registry.QueryResult {
+	switch ecosystem {
+	case supplychain.EcosystemPip, supplychain.EcosystemPoetry, supplychain.EcosystemPipfile, supplychain.EcosystemPDM, supplychain.EcosystemUV:
+		client := registry.NewPyPIClient()
+		return client.GetPublishDates(ctx, packages)
+	default:
+		client := registry.NewClient()
+		return client.GetPublishDates(ctx, packages)
+	}
 }
 
 func detectEcosystemFromPath(path string) supplychain.Ecosystem {
@@ -112,9 +129,33 @@ func detectEcosystemFromPath(path string) supplychain.Ecosystem {
 		return supplychain.EcosystemBun
 	case strings.HasSuffix(lower, "yarn.lock") || strings.HasSuffix(lower, "yarn-berry.lock"):
 		return supplychain.EcosystemYarn
+	case strings.HasSuffix(lower, "poetry.lock"):
+		return supplychain.EcosystemPoetry
+	case strings.HasSuffix(lower, "pipfile.lock"):
+		return supplychain.EcosystemPipfile
+	case strings.HasSuffix(lower, "pdm.lock"):
+		return supplychain.EcosystemPDM
+	case strings.HasSuffix(lower, "uv.lock"):
+		return supplychain.EcosystemUV
+	case isRequirementsFile(lower):
+		return supplychain.EcosystemPip
 	default:
 		return supplychain.EcosystemNPM
 	}
+}
+
+// isRequirementsFile reports whether a lowercased path is a pip requirements
+// file. It matches the conventional layouts (requirements.txt, requirements-dev.txt,
+// and the requirements/<name>.txt directory split) by requiring both a
+// "requirements" path segment and a .txt extension. The .txt guard is what keeps
+// pip-tools input files (requirements.in, which hold unpinned specifiers
+// ParsePipRequirements would silently drop) from being misclassified as a pinned
+// lockfile and yielding a false "all clear".
+func isRequirementsFile(lowerPath string) bool {
+	if !strings.HasSuffix(lowerPath, ".txt") {
+		return false
+	}
+	return strings.Contains(filepath.ToSlash(lowerPath), "requirements")
 }
 
 func diffEntries(current, base []PackageEntry) []PackageEntry {

--- a/internal/supplychain/check/check_test.go
+++ b/internal/supplychain/check/check_test.go
@@ -6,6 +6,11 @@ import (
 	"github.com/ArmisSecurity/armis-cli/internal/supplychain"
 )
 
+// testPkgSQLAlchemy is the mixed-case package name used across the Python
+// lockfile fixtures to assert that parsers apply PEP 503 name normalization
+// (lowercasing). Shared so the assertion reads the same in every parser test.
+const testPkgSQLAlchemy = "SQLAlchemy"
+
 func TestDiffEntries(t *testing.T) {
 	t.Run("returns only new packages", func(t *testing.T) {
 		current := []PackageEntry{
@@ -80,6 +85,22 @@ func TestDetectEcosystemFromPath(t *testing.T) {
 		{"yarn.lock", supplychain.EcosystemYarn},
 		{"/project/yarn.lock", supplychain.EcosystemYarn},
 		{"unknown.lock", supplychain.EcosystemNPM},
+		// Python ecosystems.
+		{"poetry.lock", supplychain.EcosystemPoetry},
+		{"/srv/app/poetry.lock", supplychain.EcosystemPoetry},
+		{"Pipfile.lock", supplychain.EcosystemPipfile},
+		{"/home/u/Pipfile.lock", supplychain.EcosystemPipfile},
+		{"pdm.lock", supplychain.EcosystemPDM},
+		{"uv.lock", supplychain.EcosystemUV},
+		{"requirements.txt", supplychain.EcosystemPip},
+		{"/project/requirements-dev.txt", supplychain.EcosystemPip},
+		{"/project/requirements/base.txt", supplychain.EcosystemPip},
+		// requirements.in (pip-tools input, unpinned) must NOT be treated as a
+		// pinned requirements lockfile — doing so would silently skip every
+		// unpinned line and report a false "all clear". It falls through to the
+		// npm default, which simply fails to parse rather than passing silently.
+		{"requirements.in", supplychain.EcosystemNPM},
+		{"/project/requirements.in", supplychain.EcosystemNPM},
 	}
 
 	for _, tt := range tests {

--- a/internal/supplychain/check/lockfile.go
+++ b/internal/supplychain/check/lockfile.go
@@ -30,10 +30,15 @@ func readLockfile(path string) ([]byte, error) {
 	defer f.Close() //nolint:errcheck // best-effort close on read path
 
 	// io.LimitReader caps the read at maxLockfileSize so a huge file cannot
-	// exhaust memory (CWE-770).
-	data, err := io.ReadAll(io.LimitReader(f, maxLockfileSize))
+	// exhaust memory (CWE-770). Read one byte past the cap so an oversize file
+	// is reported clearly instead of being silently truncated and failing later
+	// as a confusing JSON/YAML parse error.
+	data, err := io.ReadAll(io.LimitReader(f, maxLockfileSize+1))
 	if err != nil {
 		return nil, fmt.Errorf("reading lockfile: %w", err)
+	}
+	if len(data) > maxLockfileSize {
+		return nil, fmt.Errorf("lockfile too large (max %d bytes): %s", maxLockfileSize, path)
 	}
 	return data, nil
 }

--- a/internal/supplychain/check/lockfile_test.go
+++ b/internal/supplychain/check/lockfile_test.go
@@ -1,0 +1,62 @@
+package check
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadLockfile(t *testing.T) {
+	t.Run("reads small file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "package-lock.json")
+		want := []byte(`{"lockfileVersion":3}`)
+		if err := os.WriteFile(path, want, 0o600); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+
+		got, err := readLockfile(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(got) != string(want) {
+			t.Errorf("readLockfile = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("missing file errors", func(t *testing.T) {
+		_, err := readLockfile(filepath.Join(t.TempDir(), "does-not-exist.json"))
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+
+	t.Run("file too large", func(t *testing.T) {
+		// A lockfile larger than maxLockfileSize must fail with a clear "too
+		// large" error rather than being silently truncated and surfacing as a
+		// confusing JSON/YAML parse error. Truncate creates a sparse file so the
+		// oversize size is recorded without writing 64MB to disk.
+		dir := t.TempDir()
+		path := filepath.Join(dir, "package-lock.json")
+		f, err := os.Create(path) //nolint:gosec // path is test-scoped under t.TempDir()
+		if err != nil {
+			t.Fatalf("create fixture: %v", err)
+		}
+		if err := f.Truncate(maxLockfileSize + 1); err != nil {
+			f.Close() //nolint:errcheck,gosec
+			t.Fatalf("truncate fixture: %v", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("close fixture: %v", err)
+		}
+
+		_, err = readLockfile(path)
+		if err == nil {
+			t.Fatal("expected error for oversized lockfile")
+		}
+		if !strings.Contains(err.Error(), "too large") {
+			t.Fatalf("expected 'too large' error, got: %v", err)
+		}
+	})
+}

--- a/internal/supplychain/check/pdm.go
+++ b/internal/supplychain/check/pdm.go
@@ -1,0 +1,70 @@
+package check
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+type pdmLockfile struct {
+	Package []pdmPackage `toml:"package"`
+}
+
+type pdmPackage struct {
+	Name    string    `toml:"name"`
+	Version string    `toml:"version"`
+	Source  pdmSource `toml:"source"`
+}
+
+type pdmSource struct {
+	Type string `toml:"type"`
+}
+
+// ParsePDMLockfile parses a pdm.lock file (TOML format).
+// armis:ignore cwe:22 cwe:23 cwe:73 reason:local CLI reading the user's own lockfile; path is from local detection or an explicit --lockfile flag, not untrusted input crossing a trust boundary
+func ParsePDMLockfile(path string) ([]PackageEntry, error) {
+	// armis:ignore cwe:22 cwe:23 cwe:73 reason:local CLI reading the user's own lockfile; path is from local detection or an explicit --lockfile flag, not untrusted input crossing a trust boundary
+	data, err := readLockfile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var lockfile pdmLockfile
+	// armis:ignore cwe:502 cwe:770 reason:toml.Unmarshal into a typed struct does not execute code; data is size-bounded by readLockfile and is the user's own lockfile, not untrusted data
+	if err := toml.Unmarshal(data, &lockfile); err != nil {
+		return nil, fmt.Errorf("parsing pdm.lock: %w", err)
+	}
+
+	var entries []PackageEntry
+	for _, pkg := range lockfile.Package {
+		if pkg.Name == "" || pkg.Version == "" {
+			continue
+		}
+
+		if shouldSkipPDMSource(pkg.Source) {
+			continue
+		}
+
+		entries = append(entries, PackageEntry{
+			Name:    normalizePipName(pkg.Name),
+			Version: pkg.Version,
+		})
+	}
+
+	return entries, nil
+}
+
+// shouldSkipPDMSource drops packages that do not resolve from a package index.
+// A git/local/url dependency carries a lockfile version that has no meaning on
+// PyPI, so querying PyPI for it would either 404 (silently warned away) or, worse,
+// match an unrelated same-named PyPI package and age-check the wrong artifact.
+// Index-backed packages have no source.type (or an explicit registry type), so
+// only the non-registry types are excluded.
+func shouldSkipPDMSource(source pdmSource) bool {
+	switch strings.ToLower(source.Type) {
+	case sourceTypeGit, sourceTypeVCS, sourceTypeDirectory, sourceTypePath, sourceTypeFile, sourceTypeURL:
+		return true
+	}
+	return false
+}

--- a/internal/supplychain/check/pdm_test.go
+++ b/internal/supplychain/check/pdm_test.go
@@ -1,0 +1,55 @@
+package check
+
+import (
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestParsePDMLockfile(t *testing.T) {
+	t.Run("valid pdm.lock", func(t *testing.T) {
+		entries, err := ParsePDMLockfile(filepath.Join("testdata", "pdm.lock"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].Name < entries[j].Name
+		})
+
+		expected := []PackageEntry{
+			{Name: "click", Version: "8.1.7"},
+			{Name: "flask", Version: "3.0.0"},
+			{Name: "requests", Version: "2.31.0"},
+		}
+
+		if len(entries) != len(expected) {
+			t.Fatalf("expected %d entries, got %d: %+v", len(expected), len(entries), entries)
+		}
+
+		for i, e := range entries {
+			if e.Name != expected[i].Name || e.Version != expected[i].Version {
+				t.Errorf("entry %d: expected %s@%s, got %s@%s", i, expected[i].Name, expected[i].Version, e.Name, e.Version)
+			}
+		}
+	})
+
+	t.Run("skips git and path sources", func(t *testing.T) {
+		entries, err := ParsePDMLockfile(filepath.Join("testdata", "pdm.lock"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, e := range entries {
+			if e.Name == "my-git-dep" || e.Name == "local-dep" {
+				t.Errorf("should have skipped non-registry source %s", e.Name)
+			}
+		}
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		_, err := ParsePDMLockfile("testdata/nonexistent.lock")
+		if err == nil {
+			t.Fatal("expected error for nonexistent file")
+		}
+	})
+}

--- a/internal/supplychain/check/pip.go
+++ b/internal/supplychain/check/pip.go
@@ -1,0 +1,121 @@
+package check
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/ArmisSecurity/armis-cli/internal/supplychain/registry"
+)
+
+// Lockfile "source.type" values that mark a package as NOT resolving from a
+// package index (PyPI). The pdm, poetry, and uv parsers each match the subset
+// their lockfile format actually emits via shouldSkip*Source; centralizing the
+// literals here keeps those sets from silently drifting apart.
+const (
+	sourceTypeGit       = "git"
+	sourceTypeVCS       = "vcs"
+	sourceTypeDirectory = "directory"
+	sourceTypePath      = "path"
+	sourceTypeFile      = "file"
+	sourceTypeURL       = "url"
+)
+
+// ParsePipRequirements parses a pip requirements.txt into package entries.
+// Only pinned (==) requirements are considered; VCS, local, and unpinned
+// entries are skipped.
+// armis:ignore cwe:22 cwe:23 cwe:73 reason:local CLI reading the user's own lockfile; path is from local detection or an explicit --lockfile flag, not untrusted input crossing a trust boundary
+func ParsePipRequirements(path string) ([]PackageEntry, error) {
+	// armis:ignore cwe:22 cwe:23 cwe:73 reason:local CLI reading the user's own lockfile; path is from local detection or an explicit --lockfile flag, not untrusted input crossing a trust boundary
+	data, err := readLockfile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var entries []PackageEntry
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if strings.HasPrefix(line, "-") {
+			continue
+		}
+
+		if shouldSkipPipLine(line) {
+			continue
+		}
+
+		name, version := parsePipRequirement(line)
+		if name == "" || version == "" {
+			continue
+		}
+
+		entries = append(entries, PackageEntry{
+			Name:    normalizePipName(name),
+			Version: version,
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scanning requirements file: %w", err)
+	}
+
+	return entries, nil
+}
+
+func parsePipRequirement(line string) (string, string) {
+	// Remove extras: package[extra1,extra2]==version
+	if idx := strings.Index(line, "["); idx > 0 {
+		end := strings.Index(line, "]")
+		if end > idx {
+			line = line[:idx] + line[end+1:]
+		}
+	}
+
+	// Remove environment markers: package==version ; python_version >= "3.8"
+	if idx := strings.Index(line, ";"); idx > 0 {
+		line = strings.TrimSpace(line[:idx])
+	}
+
+	// Remove hashes: --hash=sha256:...
+	if idx := strings.Index(line, " \\"); idx > 0 {
+		line = strings.TrimSpace(line[:idx])
+	}
+
+	// Only support pinned versions (==)
+	if parts := strings.SplitN(line, "==", 2); len(parts) == 2 {
+		return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+	}
+
+	return "", ""
+}
+
+func shouldSkipPipLine(line string) bool {
+	// Skip VCS and local installs
+	if strings.HasPrefix(line, "git+") ||
+		strings.HasPrefix(line, "svn+") ||
+		strings.HasPrefix(line, "hg+") ||
+		strings.HasPrefix(line, "bzr+") {
+		return true
+	}
+	if strings.HasPrefix(line, "/") || strings.HasPrefix(line, ".") {
+		return true
+	}
+	if strings.Contains(line, "@ file://") || strings.Contains(line, "@ git+") {
+		return true
+	}
+	return false
+}
+
+// normalizePipName canonicalizes a package name read from a Python lockfile.
+// It delegates to registry.NormalizePyPIName so lockfile parsing and the PyPI
+// query path share one PEP 503 normalization rule and can never drift apart.
+func normalizePipName(name string) string {
+	return registry.NormalizePyPIName(name)
+}

--- a/internal/supplychain/check/pip_test.go
+++ b/internal/supplychain/check/pip_test.go
@@ -1,0 +1,128 @@
+package check
+
+import (
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestParsePipRequirements(t *testing.T) {
+	t.Run("valid requirements.txt", func(t *testing.T) {
+		entries, err := ParsePipRequirements(filepath.Join("testdata", "requirements.txt"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].Name < entries[j].Name
+		})
+
+		expected := []PackageEntry{
+			{Name: "celery", Version: "5.3.6"},
+			{Name: "flask", Version: "3.0.0"},
+			{Name: "my-cool-package", Version: "1.0.0"},
+			{Name: "numpy", Version: "1.26.2"},
+			{Name: "requests", Version: "2.31.0"},
+			{Name: "sqlalchemy", Version: "2.0.23"},
+			{Name: "typing-extensions", Version: "4.8.0"},
+		}
+
+		if len(entries) != len(expected) {
+			t.Fatalf("expected %d entries, got %d: %v", len(expected), len(entries), entries)
+		}
+
+		for i, e := range entries {
+			if e.Name != expected[i].Name || e.Version != expected[i].Version {
+				t.Errorf("entry %d: expected %s@%s, got %s@%s", i, expected[i].Name, expected[i].Version, e.Name, e.Version)
+			}
+		}
+	})
+
+	t.Run("skips git and local installs", func(t *testing.T) {
+		entries, err := ParsePipRequirements(filepath.Join("testdata", "requirements.txt"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		for _, e := range entries {
+			if e.Name == "mypkg" {
+				t.Error("should have skipped git install")
+			}
+			if e.Name == "local-package" {
+				t.Error("should have skipped local install")
+			}
+		}
+	})
+
+	t.Run("normalizes names", func(t *testing.T) {
+		entries, err := ParsePipRequirements(filepath.Join("testdata", "requirements.txt"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		for _, e := range entries {
+			if e.Name == "my_cool_package" {
+				t.Error("underscore should be normalized to hyphen")
+			}
+			if e.Name == testPkgSQLAlchemy {
+				t.Error("name should be lowercased")
+			}
+		}
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		_, err := ParsePipRequirements("nonexistent.txt")
+		if err == nil {
+			t.Error("expected error for missing file")
+		}
+	})
+}
+
+func TestParsePipRequirement(t *testing.T) {
+	tests := []struct {
+		line     string
+		wantName string
+		wantVer  string
+	}{
+		{"flask==3.0.0", "flask", "3.0.0"},
+		{"celery[redis]==5.3.6", "celery", "5.3.6"},
+		{"typing-extensions==4.8.0 ; python_version < \"3.11\"", "typing-extensions", "4.8.0"},
+		{"boto3>=1.28.0", "", ""},
+		{"requests~=2.31", "", ""},
+		{"", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			name, version := parsePipRequirement(tt.line)
+			if name != tt.wantName || version != tt.wantVer {
+				t.Errorf("parsePipRequirement(%q) = (%q, %q), want (%q, %q)", tt.line, name, version, tt.wantName, tt.wantVer)
+			}
+		})
+	}
+}
+
+func TestNormalizePipName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Flask", "flask"},
+		{"my_package", "my-package"},
+		{"My.Package", "my-package"},
+		{"requests", "requests"},
+		// PEP 503 collapses runs of separators to a single hyphen.
+		{"my__package", "my-package"},
+		{"my.._package", "my-package"},
+		{"a_-_b", "a-b"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizePipName(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizePipName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/supplychain/check/pipfile.go
+++ b/internal/supplychain/check/pipfile.go
@@ -1,0 +1,77 @@
+package check
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type pipfileLock struct {
+	Default map[string]pipfilePackage `json:"default"`
+	Develop map[string]pipfilePackage `json:"develop"`
+}
+
+type pipfilePackage struct {
+	Version string `json:"version"`
+}
+
+// ParsePipfileLock parses a Pipfile.lock (JSON format from pipenv).
+// armis:ignore cwe:22 cwe:23 cwe:73 reason:local CLI reading the user's own lockfile; path is from local detection or an explicit --lockfile flag, not untrusted input crossing a trust boundary
+func ParsePipfileLock(path string) ([]PackageEntry, error) {
+	// armis:ignore cwe:22 cwe:23 cwe:73 reason:local CLI reading the user's own lockfile; path is from local detection or an explicit --lockfile flag, not untrusted input crossing a trust boundary
+	data, err := readLockfile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var lockfile pipfileLock
+	// armis:ignore cwe:770 cwe:502 reason:data is size-bounded by readLockfile and unmarshalled into a typed struct from the user's own lockfile; no untrusted-data deserialization risk
+	if err := json.Unmarshal(data, &lockfile); err != nil {
+		return nil, fmt.Errorf("parsing Pipfile.lock: %w", err)
+	}
+
+	seen := make(map[string]bool)
+	var entries []PackageEntry
+
+	for name, pkg := range lockfile.Default {
+		entry := pipfileEntryToPackage(name, pkg)
+		if entry != nil && !seen[entry.Name+"@"+entry.Version] {
+			seen[entry.Name+"@"+entry.Version] = true
+			entries = append(entries, *entry)
+		}
+	}
+
+	for name, pkg := range lockfile.Develop {
+		entry := pipfileEntryToPackage(name, pkg)
+		if entry != nil && !seen[entry.Name+"@"+entry.Version] {
+			seen[entry.Name+"@"+entry.Version] = true
+			entries = append(entries, *entry)
+		}
+	}
+
+	return entries, nil
+}
+
+func pipfileEntryToPackage(name string, pkg pipfilePackage) *PackageEntry {
+	version := pkg.Version
+	if version == "" {
+		return nil
+	}
+
+	// Strip == prefix
+	version = strings.TrimPrefix(version, "==")
+	if version == "" {
+		return nil
+	}
+
+	// Skip non-pinned versions
+	if strings.ContainsAny(version, "><!~*") {
+		return nil
+	}
+
+	normalized := normalizePipName(name)
+	return &PackageEntry{
+		Name:    normalized,
+		Version: version,
+	}
+}

--- a/internal/supplychain/check/pipfile_test.go
+++ b/internal/supplychain/check/pipfile_test.go
@@ -1,0 +1,71 @@
+package check
+
+import (
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestParsePipfileLock(t *testing.T) {
+	t.Run("valid Pipfile.lock", func(t *testing.T) {
+		entries, err := ParsePipfileLock(filepath.Join("testdata", "Pipfile.lock"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].Name < entries[j].Name
+		})
+
+		// click (>=8.0) should be skipped — not pinned
+		expected := []PackageEntry{
+			{Name: "black", Version: "23.12.0"},
+			{Name: "flask", Version: "3.0.0"},
+			{Name: "my-package", Version: "1.0.0"},
+			{Name: "pytest", Version: "7.4.3"},
+			{Name: "requests", Version: "2.31.0"},
+			{Name: "sqlalchemy", Version: "2.0.23"},
+		}
+
+		if len(entries) != len(expected) {
+			t.Fatalf("expected %d entries, got %d: %+v", len(expected), len(entries), entries)
+		}
+
+		for i, e := range entries {
+			if e.Name != expected[i].Name || e.Version != expected[i].Version {
+				t.Errorf("entry %d: expected %s@%s, got %s@%s", i, expected[i].Name, expected[i].Version, e.Name, e.Version)
+			}
+		}
+	})
+
+	t.Run("normalizes names", func(t *testing.T) {
+		entries, err := ParsePipfileLock(filepath.Join("testdata", "Pipfile.lock"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, e := range entries {
+			if e.Name == testPkgSQLAlchemy || e.Name == "my_package" {
+				t.Errorf("name not normalized: %s", e.Name)
+			}
+		}
+	})
+
+	t.Run("skips non-pinned versions", func(t *testing.T) {
+		entries, err := ParsePipfileLock(filepath.Join("testdata", "Pipfile.lock"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, e := range entries {
+			if e.Name == "click" {
+				t.Error("should have skipped non-pinned version (>=8.0)")
+			}
+		}
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		_, err := ParsePipfileLock("testdata/nonexistent.lock")
+		if err == nil {
+			t.Fatal("expected error for nonexistent file")
+		}
+	})
+}

--- a/internal/supplychain/check/poetry.go
+++ b/internal/supplychain/check/poetry.go
@@ -1,0 +1,64 @@
+package check
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+type poetryLockfile struct {
+	Package []poetryPackage `toml:"package"`
+}
+
+type poetryPackage struct {
+	Name    string       `toml:"name"`
+	Version string       `toml:"version"`
+	Source  poetrySource `toml:"source"`
+}
+
+type poetrySource struct {
+	Type string `toml:"type"`
+}
+
+// ParsePoetryLockfile parses a poetry.lock file (TOML format).
+// armis:ignore cwe:22 cwe:23 cwe:73 reason:local CLI reading the user's own lockfile; path is from local detection or an explicit --lockfile flag, not untrusted input crossing a trust boundary
+func ParsePoetryLockfile(path string) ([]PackageEntry, error) {
+	// armis:ignore cwe:22 cwe:23 cwe:73 reason:local CLI reading the user's own lockfile; path is from local detection or an explicit --lockfile flag, not untrusted input crossing a trust boundary
+	data, err := readLockfile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var lockfile poetryLockfile
+	// armis:ignore cwe:502 cwe:770 reason:toml.Unmarshal into a typed struct does not execute code; data is size-bounded by readLockfile and is the user's own lockfile, not untrusted data
+	if err := toml.Unmarshal(data, &lockfile); err != nil {
+		return nil, fmt.Errorf("parsing poetry.lock: %w", err)
+	}
+
+	var entries []PackageEntry
+	for _, pkg := range lockfile.Package {
+		if pkg.Name == "" || pkg.Version == "" {
+			continue
+		}
+
+		if shouldSkipPoetrySource(pkg.Source) {
+			continue
+		}
+
+		entries = append(entries, PackageEntry{
+			Name:    normalizePipName(pkg.Name),
+			Version: pkg.Version,
+		})
+	}
+
+	return entries, nil
+}
+
+func shouldSkipPoetrySource(source poetrySource) bool {
+	switch strings.ToLower(source.Type) {
+	case sourceTypeGit, sourceTypeDirectory, sourceTypeFile, sourceTypeURL:
+		return true
+	}
+	return false
+}

--- a/internal/supplychain/check/poetry_test.go
+++ b/internal/supplychain/check/poetry_test.go
@@ -1,0 +1,68 @@
+package check
+
+import (
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestParsePoetryLockfile(t *testing.T) {
+	t.Run("valid poetry.lock", func(t *testing.T) {
+		entries, err := ParsePoetryLockfile(filepath.Join("testdata", "poetry.lock"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].Name < entries[j].Name
+		})
+
+		expected := []PackageEntry{
+			{Name: "flask", Version: "3.0.0"},
+			{Name: "numpy", Version: "1.26.2"},
+			{Name: "requests", Version: "2.31.0"},
+			{Name: "sqlalchemy", Version: "2.0.23"},
+		}
+
+		if len(entries) != len(expected) {
+			t.Fatalf("expected %d entries, got %d: %+v", len(expected), len(entries), entries)
+		}
+
+		for i, e := range entries {
+			if e.Name != expected[i].Name || e.Version != expected[i].Version {
+				t.Errorf("entry %d: expected %s@%s, got %s@%s", i, expected[i].Name, expected[i].Version, e.Name, e.Version)
+			}
+		}
+	})
+
+	t.Run("skips git and directory sources", func(t *testing.T) {
+		entries, err := ParsePoetryLockfile(filepath.Join("testdata", "poetry.lock"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, e := range entries {
+			if e.Name == "my-git-dep" || e.Name == "local-dep" {
+				t.Errorf("should have skipped %s", e.Name)
+			}
+		}
+	})
+
+	t.Run("normalizes names", func(t *testing.T) {
+		entries, err := ParsePoetryLockfile(filepath.Join("testdata", "poetry.lock"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, e := range entries {
+			if e.Name == testPkgSQLAlchemy {
+				t.Error("name not normalized")
+			}
+		}
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		_, err := ParsePoetryLockfile("testdata/nonexistent.lock")
+		if err == nil {
+			t.Fatal("expected error for nonexistent file")
+		}
+	})
+}

--- a/internal/supplychain/check/testdata/Pipfile.lock
+++ b/internal/supplychain/check/testdata/Pipfile.lock
@@ -1,0 +1,18 @@
+{
+    "_meta": {
+        "hash": {"sha256": "abc123"},
+        "pipfile-spec": 6,
+        "requires": {"python_version": "3.11"}
+    },
+    "default": {
+        "flask": {"version": "==3.0.0"},
+        "requests": {"version": "==2.31.0"},
+        "SQLAlchemy": {"version": "==2.0.23"},
+        "click": {"version": ">=8.0"},
+        "my_package": {"version": "==1.0.0"}
+    },
+    "develop": {
+        "pytest": {"version": "==7.4.3"},
+        "black": {"version": "==23.12.0"}
+    }
+}

--- a/internal/supplychain/check/testdata/pdm.lock
+++ b/internal/supplychain/check/testdata/pdm.lock
@@ -1,0 +1,27 @@
+[[package]]
+name = "flask"
+version = "3.0.0"
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+
+[[package]]
+name = "click"
+version = "8.1.7"
+
+[[package]]
+name = "my-git-dep"
+version = "1.0.0"
+
+[package.source]
+type = "git"
+url = "https://github.com/user/repo.git"
+
+[[package]]
+name = "local-dep"
+version = "0.1.0"
+
+[package.source]
+type = "path"
+url = "../local"

--- a/internal/supplychain/check/testdata/poetry.lock
+++ b/internal/supplychain/check/testdata/poetry.lock
@@ -1,0 +1,31 @@
+[[package]]
+name = "flask"
+version = "3.0.0"
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+
+[[package]]
+name = "SQLAlchemy"
+version = "2.0.23"
+
+[[package]]
+name = "my-git-dep"
+version = "1.0.0"
+
+[package.source]
+type = "git"
+url = "https://github.com/user/repo.git"
+
+[[package]]
+name = "local-dep"
+version = "0.1.0"
+
+[package.source]
+type = "directory"
+url = "../local"
+
+[[package]]
+name = "numpy"
+version = "1.26.2"

--- a/internal/supplychain/check/testdata/requirements.txt
+++ b/internal/supplychain/check/testdata/requirements.txt
@@ -1,0 +1,23 @@
+# Production dependencies
+flask==3.0.0
+requests==2.31.0
+SQLAlchemy==2.0.23
+numpy==1.26.2
+
+# VCS install (should be skipped)
+git+https://github.com/example/pkg.git#egg=mypkg
+
+# Local install (should be skipped)
+./local-package
+
+# With extras (should parse correctly)
+celery[redis]==5.3.6
+
+# Unpinned (should be skipped - no ==)
+boto3>=1.28.0
+
+# With environment marker
+typing-extensions==4.8.0 ; python_version < "3.11"
+
+# Underscore normalized
+my_cool_package==1.0.0

--- a/internal/supplychain/check/testdata/uv.lock
+++ b/internal/supplychain/check/testdata/uv.lock
@@ -1,0 +1,27 @@
+[[package]]
+name = "flask"
+version = "3.0.0"
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+
+[[package]]
+name = "my-local"
+version = "0.1.0"
+
+[package.source]
+type = "path"
+url = "./local"
+
+[[package]]
+name = "my-url-dep"
+version = "2.0.0"
+
+[package.source]
+type = "url"
+url = "https://example.com/my_url_dep-2.0.0-py3-none-any.whl"
+
+[[package]]
+name = "numpy"
+version = "1.26.2"

--- a/internal/supplychain/check/uv.go
+++ b/internal/supplychain/check/uv.go
@@ -1,0 +1,70 @@
+package check
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+type uvLockfile struct {
+	Package []uvPackage `toml:"package"`
+}
+
+type uvPackage struct {
+	Name    string   `toml:"name"`
+	Version string   `toml:"version"`
+	Source  uvSource `toml:"source"`
+}
+
+type uvSource struct {
+	Type string `toml:"type"`
+}
+
+// ParseUVLockfile parses a uv.lock file (TOML format).
+// armis:ignore cwe:22 cwe:23 cwe:73 reason:local CLI reading the user's own lockfile; path is from local detection or an explicit --lockfile flag, not untrusted input crossing a trust boundary
+func ParseUVLockfile(path string) ([]PackageEntry, error) {
+	// armis:ignore cwe:22 cwe:23 cwe:73 reason:local CLI reading the user's own lockfile; path is from local detection or an explicit --lockfile flag, not untrusted input crossing a trust boundary
+	data, err := readLockfile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var lockfile uvLockfile
+	// armis:ignore cwe:502 cwe:770 reason:toml.Unmarshal into a typed struct does not execute code; data is size-bounded by readLockfile and is the user's own lockfile, not untrusted data
+	if err := toml.Unmarshal(data, &lockfile); err != nil {
+		return nil, fmt.Errorf("parsing uv.lock: %w", err)
+	}
+
+	var entries []PackageEntry
+	for _, pkg := range lockfile.Package {
+		if pkg.Name == "" || pkg.Version == "" {
+			continue
+		}
+
+		if shouldSkipUVSource(pkg.Source) {
+			continue
+		}
+
+		entries = append(entries, PackageEntry{
+			Name:    normalizePipName(pkg.Name),
+			Version: pkg.Version,
+		})
+	}
+
+	return entries, nil
+}
+
+// shouldSkipUVSource drops packages that do not resolve from a package index.
+// A git/local/url dependency carries a lockfile version that has no meaning on
+// PyPI, so querying PyPI for it would either 404 or match an unrelated
+// same-named PyPI package and age-check the wrong artifact. Registry-backed
+// packages have an empty (or registry) source type, so only the non-registry
+// types are excluded — kept in sync with shouldSkipPDMSource.
+func shouldSkipUVSource(source uvSource) bool {
+	switch strings.ToLower(source.Type) {
+	case sourceTypeGit, sourceTypePath, sourceTypeDirectory, sourceTypeFile, sourceTypeURL:
+		return true
+	}
+	return false
+}

--- a/internal/supplychain/check/uv_test.go
+++ b/internal/supplychain/check/uv_test.go
@@ -1,0 +1,58 @@
+package check
+
+import (
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestParseUVLockfile(t *testing.T) {
+	t.Run("valid uv.lock", func(t *testing.T) {
+		entries, err := ParseUVLockfile(filepath.Join("testdata", "uv.lock"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].Name < entries[j].Name
+		})
+
+		expected := []PackageEntry{
+			{Name: "flask", Version: "3.0.0"},
+			{Name: "numpy", Version: "1.26.2"},
+			{Name: "requests", Version: "2.31.0"},
+		}
+
+		if len(entries) != len(expected) {
+			t.Fatalf("expected %d entries, got %d: %+v", len(expected), len(entries), entries)
+		}
+
+		for i, e := range entries {
+			if e.Name != expected[i].Name || e.Version != expected[i].Version {
+				t.Errorf("entry %d: expected %s@%s, got %s@%s", i, expected[i].Name, expected[i].Version, e.Name, e.Version)
+			}
+		}
+	})
+
+	t.Run("skips non-registry sources", func(t *testing.T) {
+		entries, err := ParseUVLockfile(filepath.Join("testdata", "uv.lock"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, e := range entries {
+			if e.Name == "my-local" {
+				t.Error("should have skipped path source")
+			}
+			if e.Name == "my-url-dep" {
+				t.Error("should have skipped url source")
+			}
+		}
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		_, err := ParseUVLockfile("testdata/nonexistent.lock")
+		if err == nil {
+			t.Fatal("expected error for nonexistent file")
+		}
+	})
+}

--- a/internal/supplychain/config.go
+++ b/internal/supplychain/config.go
@@ -38,9 +38,15 @@ func LoadConfig(dir string) (*Config, error) {
 	}
 	defer func() { _ = f.Close() }()
 
-	data, err := io.ReadAll(io.LimitReader(f, maxConfigSize))
+	// Read one byte past the cap so an oversize config is reported clearly
+	// instead of being silently truncated and failing as a confusing YAML
+	// parse error.
+	data, err := io.ReadAll(io.LimitReader(f, maxConfigSize+1))
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", ConfigFileName, err)
+	}
+	if len(data) > maxConfigSize {
+		return nil, fmt.Errorf("%s too large (max %d bytes)", ConfigFileName, maxConfigSize)
 	}
 
 	var cfg Config

--- a/internal/supplychain/config_test.go
+++ b/internal/supplychain/config_test.go
@@ -3,6 +3,7 @@ package supplychain
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -78,6 +79,26 @@ ecosystems:
 		_, err := LoadConfig(dir)
 		if err == nil {
 			t.Error("expected error for invalid YAML")
+		}
+	})
+
+	t.Run("file too large", func(t *testing.T) {
+		// A config larger than maxConfigSize must fail with a clear "too large"
+		// error rather than being silently truncated and surfacing as a confusing
+		// YAML parse error.
+		dir := t.TempDir()
+		oversized := make([]byte, maxConfigSize+1)
+		for i := range oversized {
+			oversized[i] = 'a'
+		}
+		os.WriteFile(filepath.Join(dir, ConfigFileName), oversized, 0o600) //nolint:errcheck,gosec
+
+		_, err := LoadConfig(dir)
+		if err == nil {
+			t.Fatal("expected error for oversized config file")
+		}
+		if !strings.Contains(err.Error(), "too large") {
+			t.Fatalf("expected 'too large' error, got: %v", err)
 		}
 	})
 }

--- a/internal/supplychain/detect.go
+++ b/internal/supplychain/detect.go
@@ -9,10 +9,15 @@ import (
 type Ecosystem string
 
 const (
-	EcosystemNPM  Ecosystem = "npm"
-	EcosystemPNPM Ecosystem = "pnpm"
-	EcosystemBun  Ecosystem = "bun"
-	EcosystemYarn Ecosystem = "yarn"
+	EcosystemNPM     Ecosystem = "npm"
+	EcosystemPNPM    Ecosystem = "pnpm"
+	EcosystemBun     Ecosystem = "bun"
+	EcosystemYarn    Ecosystem = "yarn"
+	EcosystemPip     Ecosystem = "pip"
+	EcosystemPoetry  Ecosystem = "poetry"
+	EcosystemPipfile Ecosystem = "pipfile"
+	EcosystemPDM     Ecosystem = "pdm"
+	EcosystemUV      Ecosystem = "uv"
 )
 
 type DetectedEcosystem struct {
@@ -20,24 +25,42 @@ type DetectedEcosystem struct {
 	LockfilePath string
 }
 
-// DetectEcosystems probes dir for well-known Node.js lockfiles and reports which
-// package-manager ecosystems are present. dir is the user's own scan target and
-// each lockfile name is a constant literal leaf, so the joined paths can only
-// resolve under dir; only os.Stat (an existence check) is performed on them.
+// lockfileCheck pairs a well-known lockfile leaf name with the ecosystem it
+// indicates. canonical marks whether that name is unique enough to walk parent
+// directories for: requirements.txt is not (pip requirements files have no fixed
+// name or location), so it participates in directory detection but not the
+// upward FindEcosystemLockfile walk.
+type lockfileCheck struct {
+	file      string
+	ecosystem Ecosystem
+	canonical bool
+}
+
+// lockfileChecks is the single source of truth for lockfile-name ↔ ecosystem
+// mapping, in detection priority order. Both DetectEcosystems (stats each name in
+// a directory) and ecosystemLockfileName (maps an ecosystem back to its canonical
+// filename) derive from it, so a new ecosystem is added in exactly one place.
+var lockfileChecks = []lockfileCheck{
+	{"package-lock.json", EcosystemNPM, true},
+	{"pnpm-lock.yaml", EcosystemPNPM, true},
+	{"bun.lock", EcosystemBun, true},
+	{"yarn.lock", EcosystemYarn, true},
+	{"poetry.lock", EcosystemPoetry, true},
+	{"Pipfile.lock", EcosystemPipfile, true},
+	{"pdm.lock", EcosystemPDM, true},
+	{"uv.lock", EcosystemUV, true},
+	{"requirements.txt", EcosystemPip, false},
+}
+
+// DetectEcosystems probes dir for well-known Node.js and Python lockfiles and
+// reports which package-manager ecosystems are present. dir is the user's own
+// scan target and each lockfile name is a constant literal leaf, so the joined
+// paths can only resolve under dir; only os.Stat (an existence check) is
+// performed on them.
 func DetectEcosystems(dir string) ([]DetectedEcosystem, error) {
 	var detected []DetectedEcosystem
 
-	checks := []struct {
-		file      string
-		ecosystem Ecosystem
-	}{
-		{"package-lock.json", EcosystemNPM},
-		{"pnpm-lock.yaml", EcosystemPNPM},
-		{"bun.lock", EcosystemBun},
-		{"yarn.lock", EcosystemYarn},
-	}
-
-	for _, c := range checks {
+	for _, c := range lockfileChecks {
 		// armis:ignore cwe:22 cwe:23 cwe:73 reason:local CLI probing the user's own project dir for well-known lockfile names; c.file is a constant literal and only os.Stat is performed, so the path is not externally controllable across a trust boundary
 		path := filepath.Join(dir, c.file)
 		// armis:ignore cwe:22 cwe:23 cwe:73 reason:c.file is a constant literal lockfile name and only os.Stat (existence check) runs, so the path is not externally controllable across a trust boundary
@@ -60,8 +83,52 @@ func DetectEcosystems(dir string) ([]DetectedEcosystem, error) {
 	}
 
 	if len(detected) == 0 {
-		return nil, fmt.Errorf("no supported lockfile found in %s\n\n  Supported: package-lock.json, pnpm-lock.yaml, bun.lock, yarn.lock\n  Try:       armis-cli supply-chain check <path-to-project>\n  Or use:    --lockfile <path-to-lockfile>", dir)
+		return nil, fmt.Errorf("no supported lockfile found in %s\n\n  Supported: package-lock.json, pnpm-lock.yaml, bun.lock, yarn.lock,\n             poetry.lock, Pipfile.lock, pdm.lock, uv.lock, requirements.txt\n  Try:       armis-cli supply-chain check <path-to-project>\n  Or use:    --lockfile <path-to-lockfile>", dir)
 	}
 
 	return detected, nil
+}
+
+// FindEcosystemLockfile locates the lockfile for a specific ecosystem by walking
+// up from startDir to the filesystem root, returning the path of the first match.
+// Package managers like poetry/pdm/pipenv are routinely invoked from a project
+// subdirectory while their lockfile lives at the project root (monorepos, CI
+// steps that cd into a service dir), so probing only the current directory would
+// silently skip enforcement. Mirrors FindConfigDir's upward walk. Returns "" when
+// no lockfile is found, or when the ecosystem is unknown.
+func FindEcosystemLockfile(startDir string, ecosystem Ecosystem) string {
+	lockfileName := ecosystemLockfileName(ecosystem)
+	if lockfileName == "" {
+		return ""
+	}
+
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		dir = startDir
+	}
+	for {
+		// armis:ignore cwe:22 cwe:23 cwe:73 reason:lockfileName is a constant literal selected by ecosystemLockfileName and only os.Stat (existence check) runs; the walked dirs are the user's own project tree, not externally controllable across a trust boundary
+		path := filepath.Join(dir, lockfileName)
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// ecosystemLockfileName returns the canonical lockfile filename for an ecosystem,
+// or "" if the ecosystem has no single well-known lockfile (e.g. pip, whose
+// requirements files have no fixed name). Derived from lockfileChecks so the
+// name lives in exactly one place.
+func ecosystemLockfileName(ecosystem Ecosystem) string {
+	for _, c := range lockfileChecks {
+		if c.ecosystem == ecosystem && c.canonical {
+			return c.file
+		}
+	}
+	return ""
 }

--- a/internal/supplychain/detect_test.go
+++ b/internal/supplychain/detect_test.go
@@ -117,3 +117,50 @@ func TestDetectEcosystems(t *testing.T) {
 		}
 	})
 }
+
+func TestFindEcosystemLockfile(t *testing.T) {
+	t.Run("finds lockfile in the start directory", func(t *testing.T) {
+		dir := t.TempDir()
+		want := filepath.Join(dir, "poetry.lock")
+		os.WriteFile(want, []byte(""), 0o644) //nolint:errcheck,gosec
+
+		got := FindEcosystemLockfile(dir, EcosystemPoetry)
+		if got != want {
+			t.Errorf("FindEcosystemLockfile = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("walks up to a parent directory", func(t *testing.T) {
+		// poetry/pdm/pipenv are routinely run from a project subdirectory while the
+		// lockfile lives at the project root; the walk must find it rather than
+		// silently skipping enforcement.
+		root := t.TempDir()
+		want := filepath.Join(root, "pdm.lock")
+		os.WriteFile(want, []byte(""), 0o644) //nolint:errcheck,gosec
+		sub := filepath.Join(root, "service", "nested")
+		if err := os.MkdirAll(sub, 0o750); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+
+		got := FindEcosystemLockfile(sub, EcosystemPDM)
+		if got != want {
+			t.Errorf("FindEcosystemLockfile from subdir = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("returns empty when no lockfile exists", func(t *testing.T) {
+		if got := FindEcosystemLockfile(t.TempDir(), EcosystemPoetry); got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("returns empty for an ecosystem without a fixed lockfile name", func(t *testing.T) {
+		// pip requirements files have no canonical name, so there is nothing to
+		// walk up for; the function must not match an unrelated file.
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte(""), 0o644) //nolint:errcheck,gosec
+		if got := FindEcosystemLockfile(dir, EcosystemPip); got != "" {
+			t.Errorf("expected empty string for pip, got %q", got)
+		}
+	})
+}

--- a/internal/supplychain/proxy.go
+++ b/internal/supplychain/proxy.go
@@ -210,7 +210,11 @@ func (p *Proxy) handleMetadataFiltering(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxProxyResponseSize))
+	// Read one byte past the cap so an oversize response is detectable rather
+	// than silently truncated: a body larger than maxProxyResponseSize yields
+	// maxProxyResponseSize+1 bytes, which would otherwise be fed to the JSON
+	// filter as incomplete data.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxProxyResponseSize+1))
 	if err != nil {
 		if p.policy.FailOpen {
 			fmt.Fprintf(os.Stderr, "[armis] supply-chain: age check unavailable for %s, allowing (fail-open): %v\n", pkgName, err)
@@ -218,6 +222,15 @@ func (p *Proxy) handleMetadataFiltering(w http.ResponseWriter, r *http.Request, 
 			return
 		}
 		http.Error(w, fmt.Sprintf("[armis] supply-chain: failed to read upstream response for %s", pkgName), http.StatusBadGateway)
+		return
+	}
+	if int64(len(body)) > maxProxyResponseSize {
+		if p.policy.FailOpen {
+			fmt.Fprintf(os.Stderr, "[armis] supply-chain: upstream response too large for %s, allowing (fail-open)\n", pkgName)
+			p.reverseProxy(w, r)
+			return
+		}
+		http.Error(w, fmt.Sprintf("[armis] supply-chain: upstream response too large for %s", pkgName), http.StatusBadGateway)
 		return
 	}
 
@@ -432,16 +445,19 @@ func (p *Proxy) reverseProxy(w http.ResponseWriter, r *http.Request) {
 }
 
 func extractPackageNameFromPath(path string) string {
+	// npm clients may request scoped metadata with percent-encoded characters
+	// (e.g. /%40scope%2Fname for @scope/name). Decode up front so scoped
+	// detection works for both encoded and decoded forms; %40→@ and %2F→/ in
+	// particular must round-trip. PathUnescape errors only on malformed escapes,
+	// in which case we keep the original and fall through to best-effort parsing.
+	if decoded, err := url.PathUnescape(path); err == nil {
+		path = decoded
+	}
+
 	path = strings.TrimPrefix(path, "/")
 	if path == "" {
 		return ""
 	}
-
-	// npm clients commonly request scoped metadata with a URL-encoded slash
-	// (e.g. /@scope%2Fname). Normalize it so scoped detection works in both
-	// the decoded (/@scope/name) and encoded forms.
-	path = strings.ReplaceAll(path, "%2F", "/")
-	path = strings.ReplaceAll(path, "%2f", "/")
 
 	// Scoped package: @scope/name
 	if strings.HasPrefix(path, "@") {

--- a/internal/supplychain/proxy_test.go
+++ b/internal/supplychain/proxy_test.go
@@ -596,6 +596,11 @@ func TestExtractPackageNameFromPath(t *testing.T) {
 		{"/@scope%2Fname", "@scope/name"},
 		{"/@scope%2fname", "@scope/name"},
 		{"/@types%2Fnode", "@types/node"},
+		// Fully percent-encoded scope, including %40 for "@". Without decoding
+		// "@", "%40types" would be misread as an unscoped package.
+		{"/%40types%2Fnode", "@types/node"},
+		{"/%40scope%2Fname", "@scope/name"},
+		{"/%40scope%2Fname%2F1.0.0", "@scope/name"},
 	}
 
 	for _, tt := range tests {
@@ -866,5 +871,91 @@ func TestProxyFailOpen_RegistryUnreachable(t *testing.T) {
 	body, _ := io.ReadAll(resp.Body)
 	if strings.Contains(string(body), "supply-chain: registry unreachable") {
 		t.Errorf("fail-open should not emit the age-check unreachable error; got body %q", string(body))
+	}
+}
+
+// oversizeUpstream returns an httptest server whose metadata response exceeds
+// maxProxyResponseSize, so handleMetadataFiltering's truncation guard fires.
+func oversizeUpstream(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		filler := make([]byte, maxProxyResponseSize+1)
+		for i := range filler {
+			filler[i] = 'a'
+		}
+		_, _ = w.Write(filler)
+	}))
+	return srv
+}
+
+func TestProxyFailClosed_ResponseTooLarge(t *testing.T) {
+	upstream := oversizeUpstream(t)
+	defer upstream.Close()
+
+	proxy, err := NewProxy(ProxyConfig{
+		Policy:      Policy{MinReleaseAge: 72 * time.Hour, FailOpen: false},
+		UpstreamURL: upstream.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewProxy: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr, _ := proxy.Start(ctx)
+	defer proxy.Close() //nolint:errcheck,gosec
+
+	req, _ := http.NewRequest(http.MethodGet, "http://"+addr+"/express", nil)
+	req.Header.Set("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704: local test proxy on 127.0.0.1
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck,gosec
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("fail-closed should return 502 when upstream response is too large, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "too large") {
+		t.Errorf("expected 'too large' error body, got %q", string(body))
+	}
+}
+
+func TestProxyFailOpen_ResponseTooLarge(t *testing.T) {
+	upstream := oversizeUpstream(t)
+	defer upstream.Close()
+
+	proxy, err := NewProxy(ProxyConfig{
+		Policy:      Policy{MinReleaseAge: 72 * time.Hour, FailOpen: true},
+		UpstreamURL: upstream.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewProxy: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr, _ := proxy.Start(ctx)
+	defer proxy.Close() //nolint:errcheck,gosec
+
+	req, _ := http.NewRequest(http.MethodGet, "http://"+addr+"/express", nil)
+	req.Header.Set("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704: local test proxy on 127.0.0.1
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck,gosec
+
+	// With fail-open an oversize upstream response falls through to the reverse
+	// proxy, which streams the upstream body verbatim (200), rather than our 502
+	// "too large" short-circuit.
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("fail-open should pass the oversize response through (200), got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(body), "supply-chain: upstream response too large") {
+		t.Errorf("fail-open should not emit the too-large error; got body %q", string(body))
 	}
 }

--- a/internal/supplychain/registry/npm.go
+++ b/internal/supplychain/registry/npm.go
@@ -162,9 +162,16 @@ func (c *Client) fetchMetadata(ctx context.Context, name string) (*registryRespo
 		return nil, fmt.Errorf("registry returned %d for %s", resp.StatusCode, name)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	// Read one byte past the cap so an oversize response is detectable: a body
+	// at exactly maxResponseSize reads to maxResponseSize, while anything larger
+	// yields maxResponseSize+1 bytes. Without this, LimitReader would silently
+	// truncate and the failure would surface as a confusing JSON parse error.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize+1))
 	if err != nil {
 		return nil, fmt.Errorf("reading response for %s: %w", name, err)
+	}
+	if int64(len(body)) > maxResponseSize {
+		return nil, fmt.Errorf("registry response for %s too large (max %d bytes)", name, maxResponseSize)
 	}
 
 	var result registryResponse

--- a/internal/supplychain/registry/npm_test.go
+++ b/internal/supplychain/registry/npm_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -96,6 +97,30 @@ func TestGetPublishDate(t *testing.T) {
 		_, err := client.GetPublishDate(context.Background(), "express", "4.18.2")
 		if err == nil {
 			t.Error("expected error for 429")
+		}
+	})
+
+	t.Run("response too large", func(t *testing.T) {
+		// A registry body larger than maxResponseSize must fail with a clear
+		// "too large" error rather than being silently truncated by LimitReader
+		// and surfacing as a confusing JSON parse error.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			filler := make([]byte, maxResponseSize+1)
+			for i := range filler {
+				filler[i] = 'a'
+			}
+			_, _ = w.Write(filler)
+		}))
+		defer server.Close()
+
+		client := NewClientWithHTTP(server.Client(), server.URL)
+		_, err := client.GetPublishDate(context.Background(), "express", "4.18.2")
+		if err == nil {
+			t.Fatal("expected error for oversized response")
+		}
+		if !strings.Contains(err.Error(), "too large") {
+			t.Fatalf("expected 'too large' error, got: %v", err)
 		}
 	})
 

--- a/internal/supplychain/registry/pypi.go
+++ b/internal/supplychain/registry/pypi.go
@@ -1,0 +1,263 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	defaultPyPIURL = "https://pypi.org"
+)
+
+var validPyPIPackageName = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$`)
+
+// pypiSeparatorRun matches any run of the PEP 503 separator characters (-, _, .).
+// PyPI canonicalizes a name by lowercasing and collapsing each such run to a
+// single hyphen, so "My__Package" and "my.package" both normalize to
+// "my-package". Collapsing runs (rather than replacing each separator
+// one-for-one) is what keeps the queried name aligned with the key PyPI files
+// the metadata under — a one-for-one replace would turn "my__pkg" into
+// "my--pkg" and 404.
+var pypiSeparatorRun = regexp.MustCompile(`[-_.]+`)
+
+type PyPIClient struct {
+	httpClient *http.Client
+	baseURL    string
+	cache      sync.Map // map[string]map[string][]pypiRelease
+	cacheLen   atomic.Int64
+}
+
+type pypiResponse struct {
+	Releases map[string][]pypiRelease `json:"releases"`
+}
+
+type pypiRelease struct {
+	UploadTime string `json:"upload_time_iso_8601"`
+}
+
+func NewPyPIClient() *PyPIClient {
+	return &PyPIClient{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		baseURL:    defaultPyPIURL,
+	}
+}
+
+// NewPyPIClientWithHTTP builds a PyPIClient with an injected HTTP client and
+// base URL. It exists for tests that point the client at an httptest server;
+// the baseURL is therefore a trusted construction-time value, not request- or
+// network-derived input. Production code uses NewPyPIClient, which hardcodes
+// the pypi.org HTTPS endpoint.
+func NewPyPIClientWithHTTP(httpClient *http.Client, baseURL string) *PyPIClient {
+	if baseURL == "" {
+		baseURL = defaultPyPIURL
+	}
+	return &PyPIClient{
+		httpClient: httpClient,
+		baseURL:    baseURL,
+	}
+}
+
+func (c *PyPIClient) GetPublishDate(ctx context.Context, name, version string) (time.Time, error) {
+	normalized := normalizePyPIName(name)
+	if !validPyPIPackageName.MatchString(normalized) {
+		return time.Time{}, fmt.Errorf("invalid PyPI package name: %q", name)
+	}
+
+	releases, err := c.fetchReleases(ctx, normalized)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	files, ok := releases[version]
+	if !ok || len(files) == 0 {
+		// PyPI keys releases by the version string as uploaded, but PEP 440
+		// treats e.g. "2.0" and "2.0.0" (and "1.0.0a1" / "1.0.0.alpha1") as the
+		// same version. A lockfile may pin a spelling that differs from PyPI's
+		// key, so fall back to a normalized comparison before giving up —
+		// otherwise the package is silently skipped with a warning instead of
+		// being age-checked, a gap in a control whose whole job is to block.
+		if files, ok = lookupReleaseNormalized(releases, version); !ok || len(files) == 0 {
+			return time.Time{}, fmt.Errorf("version %q not found for %s", version, name)
+		}
+	}
+
+	// Use the earliest upload time for the version
+	var earliest time.Time
+	for _, f := range files {
+		if f.UploadTime == "" {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, f.UploadTime)
+		if err != nil {
+			t, err = time.Parse("2006-01-02T15:04:05", f.UploadTime)
+			if err != nil {
+				continue
+			}
+		}
+		if earliest.IsZero() || t.Before(earliest) {
+			earliest = t
+		}
+	}
+
+	if earliest.IsZero() {
+		return time.Time{}, fmt.Errorf("no upload time found for %s@%s", name, version)
+	}
+
+	return earliest, nil
+}
+
+func (c *PyPIClient) GetPublishDates(ctx context.Context, packages []PackageRequest) []QueryResult {
+	results := make([]QueryResult, len(packages))
+	sem := make(chan struct{}, maxConcurrent)
+	var wg sync.WaitGroup
+
+	for i, pkg := range packages {
+		// Acquire the semaphore before spawning so that goroutine creation
+		// itself is bounded by maxConcurrent. Acquiring it inside the goroutine
+		// would launch one stack per package up front (thousands for a large
+		// lockfile) just to park them all on the channel.
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(idx int, name, version string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			publishTime, err := c.GetPublishDate(ctx, name, version)
+			results[idx] = QueryResult{
+				Name:        name,
+				Version:     version,
+				PublishTime: publishTime,
+				Err:         err,
+			}
+		}(i, pkg.Name, pkg.Version)
+	}
+
+	wg.Wait()
+	return results
+}
+
+func (c *PyPIClient) fetchReleases(ctx context.Context, name string) (map[string][]pypiRelease, error) {
+	if cached, ok := c.cache.Load(name); ok {
+		return cached.(map[string][]pypiRelease), nil
+	}
+
+	encodedName := url.PathEscape(name)
+	// armis:ignore cwe:918 reason:baseURL is a trusted construction-time config value (production NewPyPIClient hardcodes the pypi.org HTTPS constant; the URL-accepting NewPyPIClientWithHTTP is test-only); name is regex-validated above and PathEscaped, so it cannot alter the host
+	reqURL := fmt.Sprintf("%s/pypi/%s/json", c.baseURL, encodedName)
+	// armis:ignore cwe:918 reason:reqURL is built from the trusted baseURL constant + a PathEscaped, regex-validated package name, so the host is not attacker-controlled
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request for %s: %w", name, err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	// armis:ignore cwe:918 reason:c.baseURL is a trusted construction-time config value (production NewPyPIClient hardcodes the pypi.org HTTPS constant; the URL-accepting NewPyPIClientWithHTTP is test-only), so the request host is not attacker-controlled; the package name is regex-validated and PathEscaped
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: reqURL is a constant/configured registry host + regex-validated, PathEscaped package name
+	if err != nil {
+		return nil, fmt.Errorf("fetching PyPI metadata for %s: %w", name, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort close on read path
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("package %q not found on PyPI", name)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("PyPI returned %d for %s", resp.StatusCode, name)
+	}
+
+	// Read one byte past the cap so an oversize response is detectable: a body
+	// at exactly maxResponseSize reads to maxResponseSize, while anything larger
+	// yields maxResponseSize+1 bytes. Without this, LimitReader would silently
+	// truncate and the failure would surface as a confusing JSON parse error.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading PyPI response for %s: %w", name, err)
+	}
+	if int64(len(body)) > maxResponseSize {
+		return nil, fmt.Errorf("PyPI response for %s too large (max %d bytes)", name, maxResponseSize)
+	}
+
+	var result pypiResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parsing PyPI response for %s: %w", name, err)
+	}
+
+	// Memoize, but stop inserting once the cache reaches maxCacheEntries so it
+	// cannot grow without bound (CWE-770). LoadOrStore keeps the length count
+	// race-free under the concurrent GetPublishDates fan-out.
+	if c.cacheLen.Load() < maxCacheEntries {
+		if _, loaded := c.cache.LoadOrStore(name, result.Releases); !loaded {
+			c.cacheLen.Add(1)
+		}
+	}
+	return result.Releases, nil
+}
+
+// NormalizePyPIName applies PEP 503 name normalization: lowercase the name and
+// collapse every run of -, _, or . to a single hyphen. It is the single source
+// of truth for PyPI name canonicalization — the check package's lockfile parsers
+// delegate to it so the name written into a registry query always matches the
+// name PyPI files its metadata under.
+func NormalizePyPIName(name string) string {
+	return pypiSeparatorRun.ReplaceAllString(strings.ToLower(name), "-")
+}
+
+func normalizePyPIName(name string) string {
+	return NormalizePyPIName(name)
+}
+
+// lookupReleaseNormalized finds a release whose key matches version under PEP
+// 440 normalization, for when the lockfile and PyPI spell the same version
+// differently (e.g. "2.0" vs "2.0.0"). It scans the releases map, so it is the
+// O(n) fallback used only after the direct O(1) lookup misses.
+func lookupReleaseNormalized(releases map[string][]pypiRelease, version string) ([]pypiRelease, bool) {
+	target := normalizeVersion(version)
+	for key, files := range releases {
+		if normalizeVersion(key) == target {
+			return files, true
+		}
+	}
+	return nil, false
+}
+
+// normalizeVersion produces a comparison key for a PEP 440 version string that
+// is tolerant of the spellings that differ only cosmetically: it lowercases,
+// drops a leading "v", unifies pre/post/dev separators, and trims trailing
+// ".0" release segments so "2.0", "2.0.0", and "2.0.0.0" compare equal. It is a
+// pragmatic subset of full PEP 440 normalization — enough to align a lockfile
+// pin with PyPI's release key without pulling in a version-parsing dependency.
+func normalizeVersion(v string) string {
+	v = strings.ToLower(strings.TrimSpace(v))
+	v = strings.TrimPrefix(v, "v")
+	// Collapse the separators PEP 440 treats as equivalent around pre/post/dev
+	// segments (e.g. "1.0.0.alpha.1" / "1.0.0-alpha1" → "1.0.0alpha1") so only
+	// the release-number trimming below distinguishes versions.
+	v = strings.NewReplacer("-", "", "_", "", ".alpha", "alpha", ".beta", "beta",
+		".rc", "rc", ".dev", "dev", ".post", "post").Replace(v)
+
+	// Trim trailing ".0" segments from the leading numeric release portion so
+	// "2.0" and "2.0.0" share a key. Only the dotted numeric prefix is trimmed;
+	// any pre/post/dev suffix is left intact.
+	prefixEnd := len(v)
+	for i, r := range v {
+		if (r < '0' || r > '9') && r != '.' {
+			prefixEnd = i
+			break
+		}
+	}
+	release, suffix := v[:prefixEnd], v[prefixEnd:]
+	segments := strings.Split(release, ".")
+	for len(segments) > 1 && segments[len(segments)-1] == "0" {
+		segments = segments[:len(segments)-1]
+	}
+	return strings.Join(segments, ".") + suffix
+}

--- a/internal/supplychain/registry/pypi_test.go
+++ b/internal/supplychain/registry/pypi_test.go
@@ -1,0 +1,138 @@
+package registry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestPyPIGetPublishDate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/pypi/flask/json" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"releases": {
+					"3.0.0": [{"upload_time_iso_8601": "2023-09-30T12:00:00Z"}],
+					"2.3.3": [{"upload_time_iso_8601": "2023-08-15T10:00:00Z"}]
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := NewPyPIClientWithHTTP(server.Client(), server.URL)
+		publishTime, err := client.GetPublishDate(context.Background(), "flask", "3.0.0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expected := time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC)
+		if !publishTime.Equal(expected) {
+			t.Errorf("expected %v, got %v", expected, publishTime)
+		}
+	})
+
+	t.Run("package not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		client := NewPyPIClientWithHTTP(server.Client(), server.URL)
+		_, err := client.GetPublishDate(context.Background(), "nonexistent-pkg", "1.0.0")
+		if err == nil {
+			t.Error("expected error for 404")
+		}
+	})
+
+	t.Run("version not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"releases": {"1.0.0": [{"upload_time_iso_8601": "2023-01-01T00:00:00Z"}]}}`))
+		}))
+		defer server.Close()
+
+		client := NewPyPIClientWithHTTP(server.Client(), server.URL)
+		_, err := client.GetPublishDate(context.Background(), "flask", "99.99.99")
+		if err == nil {
+			t.Error("expected error for missing version")
+		}
+	})
+
+	t.Run("invalid package name", func(t *testing.T) {
+		client := NewPyPIClient()
+		_, err := client.GetPublishDate(context.Background(), "../../../etc/passwd", "1.0.0")
+		if err == nil {
+			t.Error("expected error for invalid package name")
+		}
+	})
+
+	t.Run("name normalization", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Normalized: Flask -> flask, my_package -> my-package
+			if r.URL.Path != "/pypi/my-package/json" {
+				t.Errorf("unexpected path: %s (expected normalized name)", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"releases": {"1.0.0": [{"upload_time_iso_8601": "2023-01-01T00:00:00Z"}]}}`))
+		}))
+		defer server.Close()
+
+		client := NewPyPIClientWithHTTP(server.Client(), server.URL)
+		_, err := client.GetPublishDate(context.Background(), "My_Package", "1.0.0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("matches version under PEP 440 normalization", func(t *testing.T) {
+		// Lockfile pins "2.0" but PyPI keys the release as "2.0.0" — the lookup
+		// must still resolve via normalized comparison rather than reporting the
+		// version as missing.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"releases": {"2.0.0": [{"upload_time_iso_8601": "2023-01-01T00:00:00Z"}]}}`))
+		}))
+		defer server.Close()
+
+		client := NewPyPIClientWithHTTP(server.Client(), server.URL)
+		publishTime, err := client.GetPublishDate(context.Background(), "flask", "2.0")
+		if err != nil {
+			t.Fatalf("unexpected error resolving 2.0 against 2.0.0: %v", err)
+		}
+		expected := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+		if !publishTime.Equal(expected) {
+			t.Errorf("expected %v, got %v", expected, publishTime)
+		}
+	})
+
+	t.Run("caches responses", func(t *testing.T) {
+		calls := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			calls++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"releases": {"3.0.0": [{"upload_time_iso_8601": "2023-09-30T12:00:00Z"}], "2.3.3": [{"upload_time_iso_8601": "2023-08-15T10:00:00Z"}]}}`))
+		}))
+		defer server.Close()
+
+		client := NewPyPIClientWithHTTP(server.Client(), server.URL)
+
+		_, err := client.GetPublishDate(context.Background(), "flask", "3.0.0")
+		if err != nil {
+			t.Fatalf("first call: %v", err)
+		}
+
+		_, err = client.GetPublishDate(context.Background(), "flask", "2.3.3")
+		if err != nil {
+			t.Fatalf("second call: %v", err)
+		}
+
+		if calls != 1 {
+			t.Errorf("expected 1 HTTP call (cached), got %d", calls)
+		}
+	})
+}

--- a/internal/supplychain/shell.go
+++ b/internal/supplychain/shell.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -15,12 +16,16 @@ const (
 )
 
 // validPMName bounds package-manager names to a safe shell identifier: a
-// lowercase letter followed by lowercase letters, digits, or hyphens. The
-// generated wrapper uses each name both as a shell function name and as a
-// literal command argument, so restricting it to this character set guarantees
-// no shell metacharacter (`;`, backtick, `$`, quotes, whitespace) can ever be
-// interpolated into the script written to a user's RC file.
-var validPMName = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+// lowercase letter followed by lowercase letters, digits, or hyphens, with an
+// optional trailing `.<digits>` version suffix so versioned pip variants
+// (pip3.11, pip3.12) survive sanitization. The generated wrapper uses each name
+// both as a shell function name and as a literal command argument; a dot that
+// is only ever followed by digits is not a shell metacharacter, so this still
+// guarantees no metacharacter (`;`, backtick, `$`, quotes, whitespace) can be
+// interpolated into the script written to a user's RC file. bash and zsh accept
+// dotted function names; if a given shell rejects one the wrapper for that
+// variant simply has no effect, which is no worse than leaving it unwrapped.
+var validPMName = regexp.MustCompile(`^[a-z][a-z0-9-]*(\.[0-9]+)?$`)
 
 // maxPMNames caps how many package-manager wrappers a single generated script
 // can contain. The real universe is tiny (npm, pnpm, bun, yarn), so this
@@ -102,7 +107,7 @@ func generatePosixWrapper(pms []string, cli string) string {
 	var b strings.Builder
 	b.WriteString(markerStart + "\n")
 	for _, pm := range sanitizePMNames(pms) {
-		// armis:ignore cwe:78 reason:pm is constrained to ^[a-z][a-z0-9-]*$ by sanitizePMNames; safeCli is shellQuote-escaped
+		// armis:ignore cwe:78 reason:pm is constrained to ^[a-z][a-z0-9-]*(\.[0-9]+)?$ by sanitizePMNames, so any dot is followed only by digits (not a shell metacharacter); safeCli is shellQuote-escaped
 		fmt.Fprintf(&b, "%s() {\n  command %s supply-chain wrap %s \"$@\"\n}\n", pm, safeCli, pm)
 	}
 	b.WriteString(markerEnd + "\n")
@@ -116,7 +121,7 @@ func generateFishWrapper(pms []string, cli string) string {
 	var b strings.Builder
 	b.WriteString(markerStart + "\n")
 	for _, pm := range sanitizePMNames(pms) {
-		// armis:ignore cwe:78 reason:pm is constrained to ^[a-z][a-z0-9-]*$ by sanitizePMNames; safeCli is shellQuote-escaped
+		// armis:ignore cwe:78 reason:pm is constrained to ^[a-z][a-z0-9-]*(\.[0-9]+)?$ by sanitizePMNames, so any dot is followed only by digits (not a shell metacharacter); safeCli is shellQuote-escaped
 		fmt.Fprintf(&b, "function %s\n  command %s supply-chain wrap %s $argv\nend\n", pm, safeCli, pm)
 	}
 	b.WriteString(markerEnd + "\n")
@@ -276,4 +281,59 @@ func HasInjection(path string) bool {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// pipExecutable matches pip, pip3, and versioned variants like pip3.11 / pip3.12,
+// so a project that pins a specific interpreter still gets every pip on PATH wrapped.
+var pipExecutable = regexp.MustCompile(`^pip3?(\.[0-9]+)?$`)
+
+// IsPipVariant reports whether name is pip or a versioned pip variant (pip3,
+// pip3.11, pip3.12). Every variant resolves to PyPI and shares one enforcement
+// policy, so callers canonicalize variants to "pip" for policy decisions while
+// still executing the exact binary the user invoked (pip3.12 must install into
+// the Python 3.12 environment, not a generic pip). The pattern is strict
+// (letters, digits, a single dotted numeric suffix), so it also bounds the
+// value that downstream exec.LookPath callers may treat as a trusted PM name.
+func IsPipVariant(name string) bool {
+	return pipExecutable.MatchString(name)
+}
+
+// DetectPipVariants scans $PATH for pip executables (pip, pip3, pip3.11, …) and
+// returns a deduplicated, sorted list of the command names found. pip installs
+// under several names depending on how Python was set up, and a shell wrapper
+// only shadows the exact name the user types, so all present variants must be
+// wrapped. Falls back to ["pip"] when none are found or PATH is unset.
+func DetectPipVariants() []string {
+	pathEnv := os.Getenv("PATH")
+	if pathEnv == "" {
+		return []string{"pip"}
+	}
+
+	seen := make(map[string]bool)
+	for _, dir := range filepath.SplitList(pathEnv) {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			if pipExecutable.MatchString(name) {
+				seen[name] = true
+			}
+		}
+	}
+
+	if len(seen) == 0 {
+		return []string{"pip"}
+	}
+
+	variants := make([]string, 0, len(seen))
+	for name := range seen {
+		variants = append(variants, name)
+	}
+	slices.Sort(variants)
+	return variants
 }

--- a/internal/supplychain/shell_test.go
+++ b/internal/supplychain/shell_test.go
@@ -8,6 +8,11 @@ import (
 	"testing"
 )
 
+// pipExe is the bare pip executable name, used throughout the pip-variant
+// detection tests. It is the command/binary name (distinct from the
+// EcosystemPip ecosystem identifier), so it gets its own test constant.
+const pipExe = "pip"
+
 func TestGenerateWrapper_Posix(t *testing.T) {
 	wrapper := GenerateWrapper("bash", []string{"npm"})
 
@@ -277,4 +282,117 @@ func TestEvalCommand(t *testing.T) {
 	if !strings.Contains(cmd, "npm()") {
 		t.Error("eval command should contain npm function")
 	}
+}
+
+func TestIsPipVariant(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{pipExe, true},
+		{"pip3", true},
+		{"pip3.11", true},
+		{"pip3.12", true},
+		// Distinct tools that merely share the "pip" prefix must not match.
+		{"pipx", false},
+		{"pipenv", false},
+		{"pip-compile", false},
+		{"npm", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPipVariant(tt.name); got != tt.want {
+				t.Errorf("IsPipVariant(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGenerateWrapper_WrapsVersionedPip verifies that a versioned pip variant
+// survives sanitization and is emitted as a wrapper function. Before the
+// validPMName fix, the dot in "pip3.12" caused sanitizePMNames to drop it, so
+// `pip3.12 install` silently bypassed enforcement.
+func TestGenerateWrapper_WrapsVersionedPip(t *testing.T) {
+	wrapper := GenerateWrapper("bash", []string{"pip3.12"})
+	if !strings.Contains(wrapper, "pip3.12()") {
+		t.Errorf("versioned pip variant should be wrapped, got:\n%s", wrapper)
+	}
+	if !strings.Contains(wrapper, "supply-chain wrap pip3.12") {
+		t.Errorf("wrapper should forward the exact variant name, got:\n%s", wrapper)
+	}
+}
+
+func TestDetectPipVariants(t *testing.T) {
+	t.Run("finds and sorts variants on PATH", func(t *testing.T) {
+		dir := t.TempDir()
+		for _, name := range []string{pipExe, "pip3", "pip3.12"} {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte{}, 0o755); err != nil { //nolint:gosec
+				t.Fatalf("seed %s: %v", name, err)
+			}
+		}
+		t.Setenv("PATH", dir)
+
+		got := DetectPipVariants()
+		want := []string{pipExe, "pip3", "pip3.12"}
+		if !equalStrings(got, want) {
+			t.Errorf("DetectPipVariants() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("ignores lookalike commands", func(t *testing.T) {
+		dir := t.TempDir()
+		for _, name := range []string{pipExe, "pipx", "pipenv", "pip-compile"} {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte{}, 0o755); err != nil { //nolint:gosec
+				t.Fatalf("seed %s: %v", name, err)
+			}
+		}
+		t.Setenv("PATH", dir)
+
+		for _, v := range DetectPipVariants() {
+			if v == "pipx" || v == "pipenv" || v == "pip-compile" {
+				t.Errorf("DetectPipVariants returned non-pip executable %q", v)
+			}
+		}
+	})
+
+	t.Run("deduplicates across PATH dirs", func(t *testing.T) {
+		dir1, dir2 := t.TempDir(), t.TempDir()
+		os.WriteFile(filepath.Join(dir1, pipExe), []byte{}, 0o755) //nolint:errcheck,gosec
+		os.WriteFile(filepath.Join(dir2, pipExe), []byte{}, 0o755) //nolint:errcheck,gosec
+		t.Setenv("PATH", dir1+string(os.PathListSeparator)+dir2)
+
+		got := DetectPipVariants()
+		if len(got) != 1 || got[0] != pipExe {
+			t.Errorf("expected exactly one 'pip' after dedup, got %v", got)
+		}
+	})
+
+	t.Run("falls back to pip when none found", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir())
+		got := DetectPipVariants()
+		if len(got) != 1 || got[0] != pipExe {
+			t.Errorf("expected [pip] fallback, got %v", got)
+		}
+	})
+
+	t.Run("falls back to pip when PATH is unset", func(t *testing.T) {
+		t.Setenv("PATH", "")
+		got := DetectPipVariants()
+		if len(got) != 1 || got[0] != pipExe {
+			t.Errorf("expected [pip] fallback, got %v", got)
+		}
+	})
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/supplychain/supplychain.go
+++ b/internal/supplychain/supplychain.go
@@ -88,6 +88,12 @@ func ParseDuration(s string) (time.Duration, error) {
 		if err != nil {
 			return 0, fmt.Errorf("invalid duration %q: %w", s, err)
 		}
+		// time.ParseDuration accepts signed values (e.g. "-72h"). A negative
+		// min-age is nonsensical and would effectively disable age enforcement,
+		// so reject it the same way the custom d/w paths reject negatives.
+		if d < 0 {
+			return 0, fmt.Errorf("invalid duration %q: must not be negative", s)
+		}
 		return d, nil
 	}
 }

--- a/internal/supplychain/supplychain_test.go
+++ b/internal/supplychain/supplychain_test.go
@@ -29,6 +29,11 @@ func TestParseDuration(t *testing.T) {
 		{"-Infd", 0, true},
 		{"-3d", 0, true},
 		{"-1w", 0, true},
+		// time.ParseDuration (the default branch) accepts signed values, but a
+		// negative min-age is nonsensical and would disable enforcement, so the
+		// standard-suffix path must reject negatives too.
+		{"-72h", 0, true},
+		{"-1h30m", 0, true},
 		// Extremely large 'd'/'w' values overflow int64 nanoseconds. The float→int
 		// conversion is implementation-defined and can wrap to a negative/tiny
 		// duration, silently disabling min-age enforcement, so these must error.


### PR DESCRIPTION
## Related Issue

* [PPSC-877](https://armis-security.atlassian.net/browse/PPSC-877)

## Type of Change

* [x] New feature (non-breaking change which adds functionality)

## Problem

The `supply-chain` command family enforced a minimum package release-age policy for the Node.js ecosystem only (PPSC-876, #206). Recently-published packages are an equally common supply-chain attack vector in Python (typosquatting, compromised maintainers, dependency confusion), but pip/uv/poetry/pipenv/pdm installs had no age enforcement.

## Solution

Extend release-age enforcement to the Python ecosystem with two paths that match how each tool resolves dependencies. **Proxy path (pip, uv):** a transparent registry override (`PIP_INDEX_URL` / `UV_INDEX_URL` pointing at the local proxy) strips package versions younger than the policy minimum, mirroring the npm flow; a new PyPI registry client (`registry/pypi.go`) supplies release dates and PEP 503 name normalization. **Pre-install audit path (poetry, pipenv, pdm):** these resolve from their own lockfiles and ignore registry overrides, so `wrap` instead audits the lockfile and hard-blocks the build before it runs if any package is too young (honoring the existing fail-open/closed policy). Adds lockfile parsers for `requirements.txt`, `uv.lock`, `poetry.lock`, `Pipfile.lock`, and `pdm.lock`, plus pip-variant detection so versioned binaries (`pip3`, `pip3.12`) are each wrapped and executed against their own interpreter.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

`go test ./...` passes (67.7% coverage). Parsers covered by table-driven tests against `testdata/` fixtures for every Python lockfile format; pip-variant detection and the pre-install-block routing covered in `shell_test.go` and `supply_chain_wrap_pm_test.go`.

## Reviewer Notes

No Armis Cloud auth required — only the public PyPI registry is queried. `make lint` reports 0 issues in the changed packages (the 54 tree-wide goconst/gosec hits are pre-existing on `main` in untouched files). One security-scan finding (CWE-426 at `supply_chain_wrap.go:194`) is a confirmed false positive: `pmName` is rebound by a `switch` to a hardcoded literal — or, for the single pip-variant pass-through, validated against the strict regex `^pip3?(\.[0-9]+)?$` — before reaching `exec.LookPath`; an inline `armis:ignore cwe:426 cwe:427` directive documents this at the sink.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated


[PPSC-877]: https://armis-security.atlassian.net/browse/PPSC-877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ