### PR TITLE
[PPSC-731] feat(action): publish dedicated GitHub Action with versioned tags

### DIFF
--- a/.github/actions/armis-cli-action/action.yml
+++ b/.github/actions/armis-cli-action/action.yml
@@ -1,9 +1,19 @@
 ---
-name: 'Armis CLI Action'
+# DEPRECATED: This local composite action is superseded by the top-level
+# `action.yml` (published as `ArmisSecurity/armis-cli@v1`), which offers
+# structured inputs, checksum verification of the downloaded binary, and
+# scan-result outputs. Prefer:
+#
+#   uses: ArmisSecurity/armis-cli@v1
+#
+# This file is retained only for backward compatibility with existing
+# references and may be removed in a future major version.
+#
 # NOTE: This action supports Linux and macOS runners only.
 # For Windows runners, use the PowerShell install script directly:
 #   irm https://raw.githubusercontent.com/ArmisSecurity/armis-cli/main/scripts/install.ps1 | iex
-description: 'Run the Armis CLI in your workflow (Linux/macOS only)'
+name: 'Armis CLI Action (deprecated)'
+description: 'DEPRECATED — use ArmisSecurity/armis-cli@v1 instead. Run the Armis CLI in your workflow (Linux/macOS only)'
 author: 'ArmisSecurity'
 inputs:
   client-id:

--- a/.github/workflows/armis-cli-marketplace-sample.yml
+++ b/.github/workflows/armis-cli-marketplace-sample.yml
@@ -18,11 +18,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Run Armis CLI Action from Marketplace
-        uses: ArmisSecurity/armis-cli-action@v1
+        uses: ArmisSecurity/armis-cli@v1
         with:
+          scan-type: repo
+          scan-target: .
           client-id: ${{ secrets.ARMIS_CLIENT_ID }}
           client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}
-          args: scan repo .
 
   scan-basic:
     name: Scan with Basic auth (legacy)
@@ -32,8 +33,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Run Armis CLI Action from Marketplace
-        uses: ArmisSecurity/armis-cli-action@v1
+        uses: ArmisSecurity/armis-cli@v1
         with:
+          scan-type: repo
+          scan-target: .
           api-token: ${{ secrets.ARMIS_API_TOKEN }}
           tenant-id: ${{ secrets.ARMIS_TENANT_ID }}
-          args: scan repo .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch all tags
+        # update-aliases reads the full local tag set (git tag --sort=-v:refname)
+        # to compute LATEST_FOR_MAJOR. checkout populates tags, but mirror the
+        # goreleaser job's explicit fetch so the set is guaranteed complete and
+        # the script can't compute a stale alias or fail under set -euo pipefail.
+        run: git fetch --force --tags
+
       - name: Move major and minor tags to this release
         env:
           # The released version tag that triggered this run, e.g. "v1.10.3".

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,12 @@ name: Release
 on:
   push:
     tags:
-      # Match full semantic versions only (e.g. v1.10.3), NOT the floating
-      # major/minor aliases (v1, v1.10) that update-aliases force-pushes below.
-      # GitHub's tag glob treats "*" as matching dots, so "v*.*.*" requires two
-      # literal dots and excludes the aliases, preventing a release re-trigger loop.
+      # Match tags containing a major.minor.patch segment (e.g. v1.10.3), NOT
+      # the floating major/minor aliases (v1, v1.10) that update-aliases
+      # force-pushes below. GitHub's tag glob treats "*" as matching dots, so
+      # "v*.*.*" requires two literal dots and excludes the aliases, preventing
+      # a release re-trigger loop. Note: pre-release tags like v1.10.3-rc.1
+      # also match; rely on the regex guard in update-aliases for filtering.
       - "v*.*.*"
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,15 +165,35 @@ jobs:
 
           MAJOR="${RELEASE_TAG%%.*}"   # v1.10.3 -> v1
           MINOR="${RELEASE_TAG%.*}"    # v1.10.3 -> v1.10
-          echo "Pointing $MAJOR and $MINOR at $RELEASE_TAG ($GITHUB_SHA)"
+
+          # Find the highest stable tag for this major line so we never move
+          # the floating alias backwards (e.g. if v1.9.9 is released after
+          # v1.10.3, v1 must stay on v1.10.3, not regress to v1.9.9).
+          LATEST_FOR_MAJOR=$(git tag --sort=-v:refname \
+            | grep -E "^${MAJOR}\.[0-9]+\.[0-9]+$" \
+            | head -1)
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git tag -f "$MAJOR" "$GITHUB_SHA"
+          # Always update the minor alias — a backport to v1.9.x never shares
+          # the same minor, so this is always monotonic.
+          echo "Pointing $MINOR at $RELEASE_TAG ($GITHUB_SHA)"
           git tag -f "$MINOR" "$GITHUB_SHA"
+
+          # Only update the major alias if this release is the highest semver
+          # tag for this major line.
+          if [ "$LATEST_FOR_MAJOR" = "$RELEASE_TAG" ]; then
+            echo "Pointing $MAJOR at $RELEASE_TAG ($GITHUB_SHA)"
+            git tag -f "$MAJOR" "$GITHUB_SHA"
+          else
+            echo "Skipping $MAJOR update: $RELEASE_TAG is not the latest for $MAJOR (latest is $LATEST_FOR_MAJOR)"
+          fi
 
           # Force-push the aliases. These pushes use GITHUB_TOKEN and target
           # tags excluded by the "v*.*.*" trigger filter, so they do not
           # re-trigger this release workflow.
-          git push -f origin "$MAJOR" "$MINOR"
+          git push -f origin "$MINOR"
+          if [ "$LATEST_FOR_MAJOR" = "$RELEASE_TAG" ]; then
+            git push -f origin "$MAJOR"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,11 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      # Match full semantic versions only (e.g. v1.10.3), NOT the floating
+      # major/minor aliases (v1, v1.10) that update-aliases force-pushes below.
+      # GitHub's tag glob treats "*" as matching dots, so "v*.*.*" requires two
+      # literal dots and excludes the aliases, preventing a release re-trigger loop.
+      - "v*.*.*"
 
 permissions:
   contents: read
@@ -130,3 +134,44 @@ jobs:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true
       private-repository: true
+
+  update-aliases:
+    name: Update floating version tags
+    needs: [goreleaser]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Move major and minor tags to this release
+        env:
+          # The released version tag that triggered this run, e.g. "v1.10.3".
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          # Only operate on full semver tags (vN.M.P). Skip pre-releases so
+          # consumers pinning @vN never get a -rc/-beta build.
+          if ! printf '%s' "$RELEASE_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Skipping alias update for non-stable tag: $RELEASE_TAG"
+            exit 0
+          fi
+
+          MAJOR="${RELEASE_TAG%%.*}"   # v1.10.3 -> v1
+          MINOR="${RELEASE_TAG%.*}"    # v1.10.3 -> v1.10
+          echo "Pointing $MAJOR and $MINOR at $RELEASE_TAG ($GITHUB_SHA)"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag -f "$MAJOR" "$GITHUB_SHA"
+          git tag -f "$MINOR" "$GITHUB_SHA"
+
+          # Force-push the aliases. These pushes use GITHUB_TOKEN and target
+          # tags excluded by the "v*.*.*" trigger filter, so they do not
+          # re-trigger this release workflow.
+          git push -f origin "$MAJOR" "$MINOR"

--- a/README.md
+++ b/README.md
@@ -615,7 +615,8 @@ jobs:
 
 Use the action directly for more control over your workflow. Pin to the major version tag
 (`@v1`) to receive non-breaking updates automatically, or pin to an exact tag (`@v1.10.2`) or
-commit SHA for fully reproducible builds:
+commit SHA to freeze the action definition. Note that the action installs the latest released
+CLI binary by default, so pinning the action ref alone does not pin the CLI version itself:
 
 ```yaml
 name: Security Scan

--- a/README.md
+++ b/README.md
@@ -613,7 +613,9 @@ jobs:
 
 #### Option 2: GitHub Action
 
-Use the action directly for more control over your workflow:
+Use the action directly for more control over your workflow. Pin to the major version tag
+(`@v1`) to receive non-breaking updates automatically, or pin to an exact tag (`@v1.10.2`) or
+commit SHA for fully reproducible builds:
 
 ```yaml
 name: Security Scan
@@ -627,7 +629,7 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v4
-      - uses: ArmisSecurity/armis-cli@main
+      - uses: ArmisSecurity/armis-cli@v1
         with:
           scan-type: repo
           client-id: ${{ secrets.ARMIS_CLIENT_ID }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,18 +42,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Gradle lockfile staleness detection (warns when `build.gradle` is newer than `gradle.lockfile`), Maven `pom.xml` partial-coverage notice (direct dependencies only), and a warning for unrecognized ecosystem names in the config.
   - The `ecosystems` config field accepts both `pipenv` (the tool name shown in `--help`) and `pipfile` (the internal name) so either spelling works.
   - The install summary reports each filtered package on one line showing the too-new version, its age, and the older version installed in its place (e.g. `axios 1.17.0 (1 day old) → 1.16.1 installed`). When every package resolves to a safe version it reads as a success; packages with no older safe version are called out individually. If the package manager itself does not complete (for example a dependency pins a version that only the filtered release satisfies), the summary reports the safe version as "available" rather than claiming it was installed, and explains how to relax or exclude the constraint. A one-time explanation of why fresh releases are withheld is shown on the first filtered install in an interactive terminal (suppressed thereafter and in CI).
-- Release pipeline now maintains floating major (`v1`) and minor (`v1.10`) version tags, so the GitHub Action can be consumed via `uses: ArmisSecurity/armis-cli@v1` and receive non-breaking updates automatically (#PR)
-- Documented the one-time GitHub Marketplace publishing steps for the Armis CLI Action in `docs/DISTRIBUTION-SETUP.md` (#PR)
+- Release pipeline now maintains floating major (`v1`) and minor (`v1.10`) version tags, so the GitHub Action can be consumed via `uses: ArmisSecurity/armis-cli@v1` and receive non-breaking updates automatically (#213)
+- Documented the one-time GitHub Marketplace publishing steps for the Armis CLI Action in `docs/DISTRIBUTION-SETUP.md` (#213)
 
 ### Changed
 
 - `supply-chain init`: now wraps every supported package manager found on your `PATH` instead of only the ones with a lockfile in the current directory. The injected shell functions are global (they apply in every directory), so detecting from the current project's lockfiles left gaps — e.g. running `init` in a Go repo wrapped only `npm`/`npx`, so a later `pip install` in a Python project ran unenforced. Detection is now machine-wide; per-project enforcement is still decided dynamically at install time from the nearest `.armis-supply-chain.yaml` (the `ecosystems` scope and policy are re-read on each install), so wrapping a package manager never forces enforcement where the project hasn't opted in. When no supported package manager is on `PATH`, `init` still falls back to wrapping `npm`/`npx`.
-- CI/CD documentation and example workflows now recommend pinning the GitHub Action to `@v1` instead of `@main` (#PR)
-- Marketplace sample workflow now references the repository's own `ArmisSecurity/armis-cli@v1` action with structured inputs (#PR)
+- CI/CD documentation and example workflows now recommend pinning the GitHub Action to `@v1` instead of `@main` (#213)
+- Marketplace sample workflow now references the repository's own `ArmisSecurity/armis-cli@v1` action with structured inputs (#213)
 
 ### Deprecated
 
-- The local composite action at `.github/actions/armis-cli-action/` is deprecated in favor of the top-level `action.yml` (`ArmisSecurity/armis-cli@v1`) (#PR)
+- The local composite action at `.github/actions/armis-cli-action/` is deprecated in favor of the top-level `action.yml` (`ArmisSecurity/armis-cli@v1`) (#213)
 
 ### Removed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,9 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Release pipeline now maintains floating major (`v1`) and minor (`v1.10`) version tags, so the GitHub Action can be consumed via `uses: ArmisSecurity/armis-cli@v1` and receive non-breaking updates automatically (#213)
+- Documented the one-time GitHub Marketplace publishing steps for the Armis CLI Action in `docs/DISTRIBUTION-SETUP.md` (#213)
+
 ### Changed
 
+- CI/CD documentation and example workflows now recommend pinning the GitHub Action to `@v1` instead of `@main` (#213)
+- Marketplace sample workflow now references the repository's own `ArmisSecurity/armis-cli@v1` action with structured inputs (#213)
+
 ### Deprecated
+
+- The local composite action at `.github/actions/armis-cli-action/` is deprecated in favor of the top-level `action.yml` (`ArmisSecurity/armis-cli@v1`) (#213)
 
 ### Removed
 
@@ -42,20 +50,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Gradle lockfile staleness detection (warns when `build.gradle` is newer than `gradle.lockfile`), Maven `pom.xml` partial-coverage notice (direct dependencies only), and a warning for unrecognized ecosystem names in the config.
   - The `ecosystems` config field accepts both `pipenv` (the tool name shown in `--help`) and `pipfile` (the internal name) so either spelling works.
   - The install summary reports each filtered package on one line showing the too-new version, its age, and the older version installed in its place (e.g. `axios 1.17.0 (1 day old) → 1.16.1 installed`). When every package resolves to a safe version it reads as a success; packages with no older safe version are called out individually. If the package manager itself does not complete (for example a dependency pins a version that only the filtered release satisfies), the summary reports the safe version as "available" rather than claiming it was installed, and explains how to relax or exclude the constraint. A one-time explanation of why fresh releases are withheld is shown on the first filtered install in an interactive terminal (suppressed thereafter and in CI).
-- Release pipeline now maintains floating major (`v1`) and minor (`v1.10`) version tags, so the GitHub Action can be consumed via `uses: ArmisSecurity/armis-cli@v1` and receive non-breaking updates automatically (#213)
-- Documented the one-time GitHub Marketplace publishing steps for the Armis CLI Action in `docs/DISTRIBUTION-SETUP.md` (#213)
 
 ### Changed
 
 - `supply-chain init`: now wraps every supported package manager found on your `PATH` instead of only the ones with a lockfile in the current directory. The injected shell functions are global (they apply in every directory), so detecting from the current project's lockfiles left gaps — e.g. running `init` in a Go repo wrapped only `npm`/`npx`, so a later `pip install` in a Python project ran unenforced. Detection is now machine-wide; per-project enforcement is still decided dynamically at install time from the nearest `.armis-supply-chain.yaml` (the `ecosystems` scope and policy are re-read on each install), so wrapping a package manager never forces enforcement where the project hasn't opted in. When no supported package manager is on `PATH`, `init` still falls back to wrapping `npm`/`npx`.
-- CI/CD documentation and example workflows now recommend pinning the GitHub Action to `@v1` instead of `@main` (#213)
-- Marketplace sample workflow now references the repository's own `ArmisSecurity/armis-cli@v1` action with structured inputs (#213)
-
-### Deprecated
-
-- The local composite action at `.github/actions/armis-cli-action/` is deprecated in favor of the top-level `action.yml` (`ArmisSecurity/armis-cli@v1`) (#213)
-
-### Removed
 
 ### Fixed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,10 +42,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Gradle lockfile staleness detection (warns when `build.gradle` is newer than `gradle.lockfile`), Maven `pom.xml` partial-coverage notice (direct dependencies only), and a warning for unrecognized ecosystem names in the config.
   - The `ecosystems` config field accepts both `pipenv` (the tool name shown in `--help`) and `pipfile` (the internal name) so either spelling works.
   - The install summary reports each filtered package on one line showing the too-new version, its age, and the older version installed in its place (e.g. `axios 1.17.0 (1 day old) → 1.16.1 installed`). When every package resolves to a safe version it reads as a success; packages with no older safe version are called out individually. If the package manager itself does not complete (for example a dependency pins a version that only the filtered release satisfies), the summary reports the safe version as "available" rather than claiming it was installed, and explains how to relax or exclude the constraint. A one-time explanation of why fresh releases are withheld is shown on the first filtered install in an interactive terminal (suppressed thereafter and in CI).
+- Release pipeline now maintains floating major (`v1`) and minor (`v1.10`) version tags, so the GitHub Action can be consumed via `uses: ArmisSecurity/armis-cli@v1` and receive non-breaking updates automatically (#PR)
+- Documented the one-time GitHub Marketplace publishing steps for the Armis CLI Action in `docs/DISTRIBUTION-SETUP.md` (#PR)
 
 ### Changed
 
 - `supply-chain init`: now wraps every supported package manager found on your `PATH` instead of only the ones with a lockfile in the current directory. The injected shell functions are global (they apply in every directory), so detecting from the current project's lockfiles left gaps — e.g. running `init` in a Go repo wrapped only `npm`/`npx`, so a later `pip install` in a Python project ran unenforced. Detection is now machine-wide; per-project enforcement is still decided dynamically at install time from the nearest `.armis-supply-chain.yaml` (the `ecosystems` scope and policy are re-read on each install), so wrapping a package manager never forces enforcement where the project hasn't opted in. When no supported package manager is on `PATH`, `init` still falls back to wrapping `npm`/`npx`.
+- CI/CD documentation and example workflows now recommend pinning the GitHub Action to `@v1` instead of `@main` (#PR)
+- Marketplace sample workflow now references the repository's own `ArmisSecurity/armis-cli@v1` action with structured inputs (#PR)
+
+### Deprecated
+
+- The local composite action at `.github/actions/armis-cli-action/` is deprecated in favor of the top-level `action.yml` (`ArmisSecurity/armis-cli@v1`) (#PR)
+
+### Removed
 
 ### Fixed
 

--- a/docs/CI-INTEGRATION.md
+++ b/docs/CI-INTEGRATION.md
@@ -190,7 +190,9 @@ permissions:
 
 ### Option 2: GitHub Action
 
-Use the action directly when you need more control over your workflow.
+Use the action directly when you need more control over your workflow. Pin to the major version
+tag (`@v1`) to automatically receive non-breaking updates, or pin to an exact version (`@v1.10.2`)
+or commit SHA for fully reproducible builds. See [Version Pinning](#supply-chain-security) below.
 
 > **Note:** The GitHub Action currently supports Linux and macOS runners only. For Windows runners (`windows-latest`), use [Option 3: Manual Installation](#option-3-manual-installation) with the PowerShell install script:
 >
@@ -212,7 +214,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run Armis Security Scan
-        uses: ArmisSecurity/armis-cli@main
+        uses: ArmisSecurity/armis-cli@v1
         with:
           scan-type: repo
           client-id: ${{ secrets.ARMIS_CLIENT_ID }}
@@ -479,7 +481,7 @@ jobs:
         run: docker build -t myapp:${{ github.sha }} .
 
       - name: Run Armis Image Scan
-        uses: ArmisSecurity/armis-cli@main
+        uses: ArmisSecurity/armis-cli@v1
         with:
           scan-type: image
           scan-target: myapp:${{ github.sha }}
@@ -527,7 +529,7 @@ For images built in a previous job or CI step:
   run: docker save myapp:latest -o image.tar
 
 - name: Scan Image Tarball
-  uses: ArmisSecurity/armis-cli@main
+  uses: ArmisSecurity/armis-cli@v1
   with:
     scan-type: image
     image-tarball: image.tar
@@ -859,13 +861,18 @@ The reusable workflow's "Check for Failures" step differentiates between:
 
 ### Supply Chain Security
 
-- **Pin action versions** to specific tags or commit SHAs:
+- **Pin action versions** to a tag or commit SHA. The action publishes floating
+  major (`v1`) and minor (`v1.10`) tags that always point at the latest matching
+  release, so you can choose how much you want to track automatically:
 
   ```yaml
-  # Good: pinned to version
-  uses: ArmisSecurity/armis-cli@v1.0.0
+  # Good: floating major — receives non-breaking updates automatically
+  uses: ArmisSecurity/armis-cli@v1
 
-  # Better: pinned to commit SHA
+  # Good: pinned to an exact version — fully reproducible
+  uses: ArmisSecurity/armis-cli@v1.10.2
+
+  # Best: pinned to a commit SHA — immutable, recommended for high-security setups
   uses: ArmisSecurity/armis-cli@abc123def456
   ```
 

--- a/docs/CI-INTEGRATION.md
+++ b/docs/CI-INTEGRATION.md
@@ -42,7 +42,7 @@ on:
 
 jobs:
   scan:
-    uses: ArmisSecurity/armis-cli/.github/workflows/reusable-security-scan.yml@v1
+    uses: ArmisSecurity/armis-cli/.github/workflows/reusable-security-scan.yml@main
     secrets:
       client-id: ${{ secrets.ARMIS_CLIENT_ID }}
       client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}
@@ -128,7 +128,7 @@ permissions:
 
 jobs:
   security-scan:
-    uses: ArmisSecurity/armis-cli/.github/workflows/reusable-security-scan.yml@v1
+    uses: ArmisSecurity/armis-cli/.github/workflows/reusable-security-scan.yml@main
     with:
       fail-on: 'CRITICAL,HIGH'
       pr-comment: true
@@ -343,7 +343,7 @@ jobs:
   security-scan:
     needs: get-changed-files
     if: needs.get-changed-files.outputs.any_changed == 'true'
-    uses: ArmisSecurity/armis-cli/.github/workflows/reusable-security-scan.yml@v1
+    uses: ArmisSecurity/armis-cli/.github/workflows/reusable-security-scan.yml@main
     with:
       fail-on: 'CRITICAL,HIGH'
       include-files: ${{ needs.get-changed-files.outputs.files }}
@@ -378,7 +378,7 @@ permissions:
 
 jobs:
   scan:
-    uses: ArmisSecurity/armis-cli/.github/workflows/reusable-security-scan.yml@v1
+    uses: ArmisSecurity/armis-cli/.github/workflows/reusable-security-scan.yml@main
     with:
       fail-on: ''              # Don't fail - monitoring only
       pr-comment: false        # No PR context

--- a/docs/CI-INTEGRATION.md
+++ b/docs/CI-INTEGRATION.md
@@ -42,7 +42,7 @@ on:
 
 jobs:
   scan:
-    uses: ArmisSecurity/armis-cli/.github/workflows/reusable-security-scan.yml@main
+    uses: ArmisSecurity/armis-cli/.github/workflows/reusable-security-scan.yml@v1
     secrets:
       client-id: ${{ secrets.ARMIS_CLIENT_ID }}
       client-secret: ${{ secrets.ARMIS_CLIENT_SECRET }}
@@ -128,7 +128,7 @@ permissions:
 
 jobs:
   security-scan:
-    uses: ArmisSecurity/armis-cli/.github/workflows/reusable-security-scan.yml@main
+    uses: ArmisSecurity/armis-cli/.github/workflows/reusable-security-scan.yml@v1
     with:
       fail-on: 'CRITICAL,HIGH'
       pr-comment: true
@@ -192,7 +192,7 @@ permissions:
 
 Use the action directly when you need more control over your workflow. Pin to the major version
 tag (`@v1`) to automatically receive non-breaking updates, or pin to an exact version (`@v1.10.2`)
-or commit SHA for fully reproducible builds. See [Version Pinning](#supply-chain-security) below.
+or commit SHA for fully reproducible builds. See [Supply Chain Security](#supply-chain-security) below.
 
 > **Note:** The GitHub Action currently supports Linux and macOS runners only. For Windows runners (`windows-latest`), use [Option 3: Manual Installation](#option-3-manual-installation) with the PowerShell install script:
 >
@@ -343,7 +343,7 @@ jobs:
   security-scan:
     needs: get-changed-files
     if: needs.get-changed-files.outputs.any_changed == 'true'
-    uses: ArmisSecurity/armis-cli/.github/workflows/reusable-security-scan.yml@main
+    uses: ArmisSecurity/armis-cli/.github/workflows/reusable-security-scan.yml@v1
     with:
       fail-on: 'CRITICAL,HIGH'
       include-files: ${{ needs.get-changed-files.outputs.files }}
@@ -378,7 +378,7 @@ permissions:
 
 jobs:
   scan:
-    uses: ArmisSecurity/armis-cli/.github/workflows/reusable-security-scan.yml@main
+    uses: ArmisSecurity/armis-cli/.github/workflows/reusable-security-scan.yml@v1
     with:
       fail-on: ''              # Don't fail - monitoring only
       pr-comment: false        # No PR context

--- a/docs/CI-INTEGRATION.md
+++ b/docs/CI-INTEGRATION.md
@@ -192,7 +192,9 @@ permissions:
 
 Use the action directly when you need more control over your workflow. Pin to the major version
 tag (`@v1`) to automatically receive non-breaking updates, or pin to an exact version (`@v1.10.2`)
-or commit SHA for fully reproducible builds. See [Supply Chain Security](#supply-chain-security) below.
+or commit SHA to freeze the action definition. Note that the action installs the latest released
+CLI binary by default, so pinning the action ref alone does not pin the CLI version. See
+[Supply Chain Security](#supply-chain-security) below.
 
 > **Note:** The GitHub Action currently supports Linux and macOS runners only. For Windows runners (`windows-latest`), use [Option 3: Manual Installation](#option-3-manual-installation) with the PowerShell install script:
 >
@@ -869,12 +871,16 @@ The reusable workflow's "Check for Failures" step differentiates between:
   # Good: floating major — receives non-breaking updates automatically
   uses: ArmisSecurity/armis-cli@v1
 
-  # Good: pinned to an exact version — fully reproducible
+  # Good: pinned to an exact version — frozen action definition
   uses: ArmisSecurity/armis-cli@v1.10.2
 
   # Best: pinned to a commit SHA — immutable, recommended for high-security setups
   uses: ArmisSecurity/armis-cli@abc123def456
   ```
+
+  These refs pin the **action definition**, not the CLI binary. The action installs the
+  latest released CLI by default (from `releases/latest`), so the CLI version can still
+  advance between runs even with the action ref pinned.
 
 - The CLI installation verifies **checksums** automatically
 - Release binaries include **SLSA provenance** for verification

--- a/docs/DISTRIBUTION-SETUP.md
+++ b/docs/DISTRIBUTION-SETUP.md
@@ -143,8 +143,12 @@ This lets consumers pin at the level of stability they want:
 |-----------|----------|
 | `@v1` | Latest `v1.x.y` — non-breaking updates delivered automatically (recommended) |
 | `@v1.10` | Latest `v1.10.x` — patch updates only |
-| `@v1.10.2` | Exact version — fully reproducible |
+| `@v1.10.2` | Exact action definition — frozen action logic |
 | `@<sha>` | Immutable commit pin — strongest supply-chain guarantee |
+
+> **Note:** These refs pin the *action definition*, not the CLI binary. The action installs the
+> latest released CLI by default (`releases/latest`), so the scanned-with CLI version can advance
+> even when the action ref is pinned.
 
 Re-publishing to the Marketplace is only required when you want the Marketplace listing's
 "latest version" pointer to advance; the floating tags update on every release regardless.

--- a/docs/DISTRIBUTION-SETUP.md
+++ b/docs/DISTRIBUTION-SETUP.md
@@ -107,6 +107,48 @@ GoReleaser will automatically:
 - Update Homebrew tap formula
 - Update Scoop bucket manifest
 
+## 🛒 Publishing the GitHub Action to the Marketplace
+
+The repository ships a composite GitHub Action defined in the top-level
+[`action.yml`](../action.yml) (`name: Armis Security Scanner`). Consumers reference it as
+`uses: ArmisSecurity/armis-cli@v1`. Publishing it to the GitHub Marketplace is a **one-time
+manual step** done through the GitHub UI — it cannot be automated by the release workflow.
+
+### Prerequisites (already satisfied)
+
+- `action.yml` exists at the repository root with a unique `name`, a `description`, and a
+  `branding:` block (`icon: shield`, `color: blue`). GitHub requires `branding` for Marketplace
+  listing.
+- At least one release tag exists (the latest is created automatically by
+  [`release.yml`](../.github/workflows/release.yml)).
+
+### One-time publish steps
+
+1. Go to the repository's **Releases** page on GitHub and open (or draft) a release for the
+   latest version tag.
+2. Check **"Publish this Action to the GitHub Marketplace"**.
+3. Accept the GitHub Marketplace Developer Agreement (first time only).
+4. Choose a primary category of **Security** (and an optional secondary category such as
+   *Continuous integration*).
+5. Resolve any validation warnings GitHub surfaces (it re-validates `action.yml` and `branding`).
+6. Publish the release.
+
+### Versioning and floating tags
+
+The release workflow maintains **floating major and minor tags** (`v1`, `v1.10`) that always
+point at the latest matching stable release (see the `update-aliases` job in `release.yml`).
+This lets consumers pin at the level of stability they want:
+
+| Reference | Behavior |
+|-----------|----------|
+| `@v1` | Latest `v1.x.y` — non-breaking updates delivered automatically (recommended) |
+| `@v1.10` | Latest `v1.10.x` — patch updates only |
+| `@v1.10.2` | Exact version — fully reproducible |
+| `@<sha>` | Immutable commit pin — strongest supply-chain guarantee |
+
+Re-publishing to the Marketplace is only required when you want the Marketplace listing's
+"latest version" pointer to advance; the floating tags update on every release regardless.
+
 ## 📦 Installation Methods After Setup
 
 Once released, users can install via:

--- a/docs/ci-examples/github-actions.yml
+++ b/docs/ci-examples/github-actions.yml
@@ -32,7 +32,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Armis Security Scan
-        uses: ArmisSecurity/armis-cli@main
+        # Pin to @v1 for non-breaking updates, or @v1.10.2 / a commit SHA for
+        # fully reproducible builds.
+        uses: ArmisSecurity/armis-cli@v1
         with:
           scan-type: repo
           scan-target: '.'

--- a/docs/ci-examples/github-actions.yml
+++ b/docs/ci-examples/github-actions.yml
@@ -32,8 +32,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Armis Security Scan
-        # Pin to @v1 for non-breaking updates, or @v1.10.2 / a commit SHA for
-        # fully reproducible builds.
+        # Pin to @v1 for non-breaking updates, or @v1.10.2 / a commit SHA to
+        # freeze the action definition. The action installs the latest released
+        # CLI binary, so pinning the ref alone does not pin the CLI version.
         uses: ArmisSecurity/armis-cli@v1
         with:
           scan-type: repo


### PR DESCRIPTION
## Related Issue

* [PPSC-731](https://armis-security.atlassian.net/browse/PPSC-731)

## Type of Change

* [x] New feature (non-breaking change which adds functionality)
* [x] Documentation update

## Problem

The dedicated composite action already existed at the repo root (`ArmisSecurity/armis-cli`), but distribution wasn't versioned: docs told consumers to pin `@main` (unsafe/unpinned), no floating `v1`/`v1.10` tags existed, and the marketplace sample referenced a non-existent `ArmisSecurity/armis-cli-action@v1` repo.

## Solution

`release.yml` now runs an `update-aliases` job that force-moves floating major/minor tags (`v1`, `v1.10`) to each stable release (trigger narrowed to `v*.*.*` with a pre-release regex guard to prevent a release re-trigger loop); the broken marketplace sample is repointed to `ArmisSecurity/armis-cli@v1` with structured inputs; the duplicate local composite action is deprecated in favor of the root `action.yml`; and docs (README, CI-INTEGRATION, ci-examples, DISTRIBUTION-SETUP) now recommend `@v1`, add version-pinning guidance, and document the one-time Marketplace publish steps.

## Testing

### Automated Tests

* [ ] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

Pre-PR verify run: `make test` (2347 passed, 67.7% coverage), `make build` (binary produced) both green. All 4 changed YAML files parse cleanly and pass repo pre-commit hooks (yamllint, markdownlint, shellcheck). Tag-derivation logic dry-run confirmed `v1.10.3` → `v1` + `v1.10`, and the `v*.*.*` trigger + regex guard correctly exclude floating aliases while still building releases for historical pre-release tags. (Lint shows only pre-existing findings in a sibling workspace; one pre-existing HIGH in `internal/supplychain/check/lockfile.go` is untouched Go code, not part of this YAML/docs diff.)

## Reviewer Notes

This PR is YAML + Markdown only — no Go source changes. Note that the reusable-workflow `uses:` references intentionally stay on `@main` (pinning them to `@v1` would create a release-order chicken-and-egg). The actual Marketplace publish is a one-time manual GitHub UI step (can't be automated) and is documented in `docs/DISTRIBUTION-SETUP.md`. CHANGELOG entries use `(#PR)` placeholders — happy to update with this PR's number.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] Documentation updated (if needed)
* [x] No new warnings generated

[PPSC-731]: https://armis-security.atlassian.net/browse/PPSC-731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ