### PR TITLE
feat(supply-chain): wrap uvx for age enforcement (PPSC-934)

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ The `supply-chain` command enforces a minimum **release age** on your dependenci
 
 No Armis Cloud authentication is required: `supply-chain` queries public registries (npm, PyPI, Maven Central) directly.
 
-**Supported ecosystems:** npm, npx, pnpm, bun, yarn (Node); pip, uv, poetry, pipenv, pdm (Python); Maven, Gradle (Java).
+**Supported ecosystems:** npm, npx, pnpm, bun, yarn (Node); pip, uv, uvx, poetry, pipenv, pdm (Python); Maven, Gradle (Java).
 
 ### Audit a lockfile (CI)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Release pipeline now maintains floating major (`v1`) and minor (`v1.10`) version tags, so the GitHub Action can be consumed via `uses: ArmisSecurity/armis-cli@v1` and receive non-breaking updates automatically (#213)
 - Documented the one-time GitHub Marketplace publishing steps for the Armis CLI Action in `docs/DISTRIBUTION-SETUP.md` (#213)
+- `supply-chain`: `uvx` (uv's on-demand tool runner) is now wrapped alongside `uv`, the PyPI analogue of how `npx` is paired with `npm`. `uvx <tool>` fetches a tool from PyPI and runs it — exactly the supply-chain vector the proxy guards — so wherever `uv` is enforced, `uvx` is too. It shares uv's resolver and config, so it routes through the same transparent PyPI proxy (`UV_INDEX_URL`) and inherits uv's `ecosystems`-scope decision. Enforcement applies to tools `uvx` fetches from the registry; a tool already in the uv tool cache runs without a registry round-trip and is not re-checked. Re-run `armis-cli supply-chain init` to wrap `uvx` on machines where it is installed.
 
 ### Changed
 

--- a/internal/cmd/supply_chain.go
+++ b/internal/cmd/supply_chain.go
@@ -49,7 +49,9 @@ Supported ecosystems:
   Node:   npm, npx, pnpm, bun, yarn (transparent proxy enforcement)
           npx enforces packages it fetches; a package already in the npx cache
           or a binary in node_modules/.bin runs without a registry round-trip.
-  Python: pip, uv (transparent proxy); poetry, pipenv, pdm (pre-install block)
+  Python: pip, uv, uvx (transparent proxy); poetry, pipenv, pdm (pre-install block)
+          uvx (uv's tool runner) enforces tools it fetches; a tool already in the
+          uv tool cache runs without a registry round-trip.
   Java:   maven (pom.xml), gradle (gradle.lockfile) (pre-install block)
 
 No Armis Cloud authentication is required — supply-chain queries public registries

--- a/internal/cmd/supply_chain_init.go
+++ b/internal/cmd/supply_chain_init.go
@@ -32,7 +32,7 @@ can enforce age policies on package installations. The shell functions are globa
 (they apply in every directory), so init wraps what is installed on the machine,
 not just what a single project uses; whether enforcement actually runs is decided
 per-project at install time from the nearest .armis-supply-chain.yaml. Node PMs
-(npm, npx, pnpm, bun, yarn) and pip/uv use a transparent proxy that filters
+(npm, npx, pnpm, bun, yarn) and pip/uv/uvx use a transparent proxy that filters
 registry responses. poetry, pipenv, pdm, mvn, and gradle use a pre-install check
 that blocks the build if violations are found.
 
@@ -125,9 +125,9 @@ func reportNothingInScope(installed []string) error {
 // allSupportedPMs is the set of fixed package-manager command names init looks
 // for on PATH. pip is intentionally omitted: its variants (pip, pip3, pip3.12)
 // are matched by pattern inside DetectInstalledPMs, since each interpreter ships
-// its own pip binary. npx is omitted too — it is not detected directly but paired
-// with npm below, mirroring how the wrap gate treats it as part of the npm
-// ecosystem.
+// its own pip binary. npx and uvx are omitted too — they are not detected
+// directly but paired with npm/uv below, mirroring how the wrap gate treats them
+// as part of the npm/uv ecosystem.
 var allSupportedPMs = []string{
 	pmNPM, pmPNPM, pmBun, pmYarn,
 	pmUV, pmPoetry, pmPipenv, pmPDM,
@@ -208,6 +208,15 @@ func detectWrappablePMs() (pms []string, installed []string) {
 		addPM(pmNPX)
 	}
 
+	// uvx is uv's on-demand tool runner (`uvx X` ≡ `uv tool run X`), the PyPI
+	// analogue of npx: it fetches a tool from PyPI and runs it, so wherever uv is
+	// wrapped its runner should be too. Pair it after scoping so it inherits uv's
+	// in-scope decision, and guard with a PATH check so a missing uvx binary is
+	// never shadowed by an Armis wrapper error. Mirrors the npx pairing above.
+	if seen[pmUV] && supplychain.IsOnPath(pmUVX) {
+		addPM(pmUVX)
+	}
+
 	// An empty pms here means every installed PM was scoped out. We deliberately do
 	// NOT fall back to npm: the caller uses the non-empty `installed` list to report
 	// that nothing is in scope, rather than wrapping a package manager the user
@@ -225,22 +234,26 @@ func detectWrappablePMs() (pms []string, installed []string) {
 //     dozen of these; listing each by name would bury the summary even though they
 //     all resolve to PyPI and share one policy. The verbatim wrapper block below
 //     still names every variant, so no information is lost — this is the digest.
-//   - npx is annotated "(paired with npm)" rather than listed as a plain find,
-//     because it is the one entry init adds without detecting it: it ships with
-//     npm and is wrapped wherever npm is in scope (see detectWrappablePMs). Making
-//     that explicit keeps the summary honest about what was on PATH vs. inferred.
+//   - npx is annotated "(paired with npm)" and uvx "(paired with uv)" rather than
+//     listed as plain finds, because they are the entries init adds without
+//     detecting them: each ships with / shares config with its base PM and is
+//     wrapped wherever that PM is in scope (see detectWrappablePMs). Making that
+//     explicit keeps the summary honest about what was on PATH vs. inferred.
 //
 // Remaining names are shown as-is, bolded, in sorted order so the line is stable
-// regardless of PATH scan order or where npx was appended.
+// regardless of PATH scan order or where npx/uvx were appended.
 func summarizeDetectedPMs(s *output.Styles, pms []string) string {
 	var others []string
 	pipVariants := 0
 	hasNPX := false
+	hasUVX := false
 
 	for _, pm := range pms {
 		switch {
 		case pm == pmNPX:
 			hasNPX = true
+		case pm == pmUVX:
+			hasUVX = true
 		case supplychain.IsPipVariant(pm):
 			pipVariants++
 		default:
@@ -249,7 +262,7 @@ func summarizeDetectedPMs(s *output.Styles, pms []string) string {
 	}
 	sort.Strings(others)
 
-	parts := make([]string, 0, len(others)+2)
+	parts := make([]string, 0, len(others)+3)
 	for _, pm := range others {
 		parts = append(parts, s.Bold.Render(pm))
 	}
@@ -265,10 +278,13 @@ func summarizeDetectedPMs(s *output.Styles, pms []string) string {
 	if hasNPX {
 		parts = append(parts, s.Bold.Render(pmNPX)+s.MutedText.Render(" (paired with npm)"))
 	}
+	if hasUVX {
+		parts = append(parts, s.Bold.Render(pmUVX)+s.MutedText.Render(" (paired with uv)"))
+	}
 
-	// Keep pip and npx at the end of the line: pip carries a parenthetical and npx
-	// is the inferred entry, so trailing them reads more naturally than interleaving
-	// by alphabetical position.
+	// Keep pip and the paired runners (npx, uvx) at the end of the line: pip carries
+	// a parenthetical and the runners are inferred entries, so trailing them reads
+	// more naturally than interleaving by alphabetical position.
 	return strings.Join(parts, ", ")
 }
 

--- a/internal/cmd/supply_chain_init.go
+++ b/internal/cmd/supply_chain_init.go
@@ -235,10 +235,13 @@ func detectWrappablePMs() (pms []string, installed []string) {
 //     all resolve to PyPI and share one policy. The verbatim wrapper block below
 //     still names every variant, so no information is lost — this is the digest.
 //   - npx is annotated "(paired with npm)" and uvx "(paired with uv)" rather than
-//     listed as plain finds, because they are the entries init adds without
-//     detecting them: each ships with / shares config with its base PM and is
-//     wrapped wherever that PM is in scope (see detectWrappablePMs). Making that
-//     explicit keeps the summary honest about what was on PATH vs. inferred.
+//     listed as plain finds, because neither is part of the primary detection set
+//     (allSupportedPMs omits both). Each is paired with its base PM — and wrapped
+//     only when confirmed present on PATH via the IsOnPath guards in
+//     detectWrappablePMs — rather than being scanned for independently. The
+//     annotation tells the user these came along with their base PM (npm/uv), so
+//     the summary stays honest about which entries the main scan surfaced vs.
+//     which the pairing logic added.
 //
 // Remaining names are shown as-is, bolded, in sorted order so the line is stable
 // regardless of PATH scan order or where npx/uvx were appended.

--- a/internal/cmd/supply_chain_init_test.go
+++ b/internal/cmd/supply_chain_init_test.go
@@ -201,6 +201,63 @@ func TestDetectWrappablePMs_NpxAbsentWhenNpmScopedOut(t *testing.T) {
 	}
 }
 
+func TestDetectWrappablePMs_PairsUvxWithUv(t *testing.T) {
+	// uv and uvx both on PATH: uvx must be wrapped alongside uv so ad-hoc
+	// `uvx <tool>` runs are filtered through the same PyPI proxy.
+	seedPMsOnPath(t, pmUV, pmUVX)
+	chdirTemp(t)
+
+	pms, _ := detectWrappablePMs()
+	if !containsPM(pms, pmUV) || !containsPM(pms, pmUVX) {
+		t.Errorf("detectWrappablePMs() = %v, want both uv and uvx", pms)
+	}
+}
+
+func TestDetectWrappablePMs_UvxNotPairedWithoutUv(t *testing.T) {
+	// A machine with poetry but no uv never wraps uv, so uvx must not appear:
+	// the runner is paired only where uv itself is in scope.
+	seedPMsOnPath(t, pmPoetry)
+	chdirTemp(t)
+
+	pms, _ := detectWrappablePMs()
+	if containsPM(pms, pmUVX) {
+		t.Errorf("detectWrappablePMs() = %v, must not contain uvx without uv", pms)
+	}
+}
+
+func TestDetectWrappablePMs_UvxNotWrappedWhenAbsentFromPath(t *testing.T) {
+	// uv on PATH but uvx not installed: the pairing guard must prevent wrapping a
+	// missing uvx binary. Unconditionally wrapping it would shadow "command not found"
+	// with an Armis wrapper error.
+	seedPMsOnPath(t, pmUV)
+	chdirTemp(t)
+
+	pms, _ := detectWrappablePMs()
+	if containsPM(pms, pmUVX) {
+		t.Errorf("detectWrappablePMs() = %v, must not wrap uvx when it is not on PATH", pms)
+	}
+}
+
+func TestDetectWrappablePMs_UvxAbsentWhenUvScopedOut(t *testing.T) {
+	// uvx is paired AFTER ecosystem scoping, so it must inherit uv's exclusion:
+	// with uv and npm both on PATH but the config scoping enforcement to npm only,
+	// uv is out of scope — and uvx must follow it out, never wrapped on its own.
+	seedPMsOnPath(t, pmUV, pmNPM)
+	dir := chdirTemp(t)
+	if err := os.WriteFile(filepath.Join(dir, supplychain.ConfigFileName),
+		[]byte("version: 1\necosystems:\n  - npm\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	pms, _ := detectWrappablePMs()
+	if containsPM(pms, pmUVX) {
+		t.Errorf("detectWrappablePMs() = %v, must not contain uvx when uv is scoped out", pms)
+	}
+	if !containsPM(pms, pmNPM) {
+		t.Errorf("detectWrappablePMs() = %v, want npm (the in-scope PM)", pms)
+	}
+}
+
 func TestDetectWrappablePMs_HonorsEcosystemScope(t *testing.T) {
 	// npm and pnpm are both on PATH but the config scopes enforcement to pnpm only,
 	// so init must wrap only pnpm.
@@ -328,6 +385,13 @@ func TestSummarizeDetectedPMs(t *testing.T) {
 			name: "pip only",
 			pms:  []string{"pip3", "pip3.12"},
 			want: "pip (2 variants)",
+		},
+		{
+			// uvx is annotated "(paired with uv)" and trails the line, mirroring npx.
+			// When both runners are present, npx precedes uvx (npm before uv).
+			name: "uvx is annotated as paired with uv",
+			pms:  []string{"uv", "npm", "uvx", "npx"},
+			want: "npm, uv, npx (paired with npm), uvx (paired with uv)",
 		},
 	}
 

--- a/internal/cmd/supply_chain_wrap.go
+++ b/internal/cmd/supply_chain_wrap.go
@@ -39,6 +39,7 @@ const (
 	pmYarn   = "yarn"
 	pmPip    = "pip"
 	pmUV     = "uv"
+	pmUVX    = "uvx"
 	pmPoetry = "poetry"
 	pmPipenv = "pipenv"
 	pmPDM    = "pdm"
@@ -61,7 +62,7 @@ func init() {
 
 var allowedPMs = map[string]bool{
 	pmNPM: true, pmNPX: true, pmPNPM: true, pmBun: true, pmYarn: true,
-	pmPip: true, pmUV: true, pmPoetry: true, pmPipenv: true, pmPDM: true,
+	pmPip: true, pmUV: true, pmUVX: true, pmPoetry: true, pmPipenv: true, pmPDM: true,
 	pmMaven: true, pmGradle: true,
 }
 
@@ -83,7 +84,7 @@ func runSupplyChainWrap(cmd *cobra.Command, args []string) error {
 	canonical := canonicalPM(pmName)
 
 	if !allowedPMs[canonical] {
-		return fmt.Errorf("unsupported package manager: %s (allowed: npm, npx, pnpm, bun, yarn, pip, uv, poetry, pipenv, pdm, mvn, gradle)", pmName)
+		return fmt.Errorf("unsupported package manager: %s (allowed: npm, npx, pnpm, bun, yarn, pip, uv, uvx, poetry, pipenv, pdm, mvn, gradle)", pmName)
 	}
 
 	if os.Getenv(envSCActive) == "1" {
@@ -127,12 +128,12 @@ func canonicalPM(pm string) string {
 func runProxyWrap(cmd *cobra.Command, pmName string, pmArgs []string) error {
 	policy := resolveWrapPolicy()
 
-	// pip and uv resolve from the PyPI Simple API, a different protocol from the
-	// npm registry, so the proxy must run in PyPI mode (PEP 691/700 JSON file
+	// pip, uv, and uvx resolve from the PyPI Simple API, a different protocol from
+	// the npm registry, so the proxy must run in PyPI mode (PEP 691/700 JSON file
 	// filtering). All other proxied PMs (npm/npx/pnpm/bun/yarn) speak the npm registry.
 	mode := supplychain.ModeNPM
 	switch canonicalPM(pmName) {
-	case pmPip, pmUV:
+	case pmPip, pmUV, pmUVX:
 		mode = supplychain.ModePyPI
 	}
 
@@ -208,6 +209,8 @@ func execPM(pm string, args []string, extraEnv []string) (int, error) {
 		pmName = pmPip
 	case pmUV:
 		pmName = pmUV
+	case pmUVX:
+		pmName = pmUVX
 	case pmPoetry:
 		pmName = pmPoetry
 	case pmPipenv:
@@ -225,7 +228,7 @@ func execPM(pm string, args []string, extraEnv []string) (int, error) {
 		// numeric components so no taint flows from pm into pmName.
 		canonical, ok := supplychain.CanonicalPipVariant(pm)
 		if !ok {
-			return 1, fmt.Errorf("unsupported package manager: %s (allowed: npm, npx, pnpm, bun, yarn, pip, uv, poetry, pipenv, pdm, mvn, gradle)", pm)
+			return 1, fmt.Errorf("unsupported package manager: %s (allowed: npm, npx, pnpm, bun, yarn, pip, uv, uvx, poetry, pipenv, pdm, mvn, gradle)", pm)
 		}
 		pmName = canonical
 	}
@@ -663,7 +666,9 @@ func registryEnvForPM(pm, registryURL string) []string {
 			fmt.Sprintf("npm_config_registry=%s", registryURL),
 			fmt.Sprintf("YARN_NPM_REGISTRY_SERVER=%s", registryURL),
 		}
-	case pmUV:
+	case pmUV, pmUVX:
+		// uvx is uv's on-demand tool runner (`uvx X` ≡ `uv tool run X`); it shares
+		// uv's resolver and config, so it honors the same UV_INDEX_URL override.
 		// registryURL is built by the caller with a trailing slash, so trim it
 		// before appending the PEP 503 "/simple/" path to avoid a "//simple/"
 		// double slash. Clients normalize it today, but the PyPI proxy handler
@@ -920,6 +925,13 @@ func pmToEcosystem(pm string) supplychain.Ecosystem {
 	case pmPip:
 		return supplychain.EcosystemPip
 	case pmUV:
+		return supplychain.EcosystemUV
+	case pmUVX:
+		// uvx is uv's package runner, not a distinct ecosystem: it resolves from
+		// PyPI and has no lockfile of its own. Mapping it to EcosystemUV lets the
+		// config "ecosystems" scoping gate treat uvx exactly like uv — `ecosystems:
+		// [uv]` enforces both, and scoping uv out (e.g. `ecosystems: [npm]`) passes
+		// uvx through too, so the two never diverge. Mirrors npx → EcosystemNPM.
 		return supplychain.EcosystemUV
 	case pmPoetry:
 		return supplychain.EcosystemPoetry

--- a/internal/cmd/supply_chain_wrap_pm_test.go
+++ b/internal/cmd/supply_chain_wrap_pm_test.go
@@ -17,6 +17,8 @@ func TestCanonicalPM(t *testing.T) {
 		{"pip3.11", pmPip},
 		{"pip3.12", pmPip},
 		{pmUV, pmUV},
+		// uvx is a distinct binary, not a pip/uv variant — it must not collapse.
+		{pmUVX, pmUVX},
 		{pmNPM, pmNPM},
 		{pmPoetry, pmPoetry},
 		// pipx / pipenv are distinct tools, not pip variants — must not collapse.
@@ -55,6 +57,9 @@ func TestRequiresPreInstallBlock(t *testing.T) {
 		{pmGradle, true},
 		{pmPip, false},
 		{pmUV, false},
+		// uvx is uv's runner: like uv it uses the transparent proxy, never the
+		// pre-install lockfile audit (it has no lockfile of its own).
+		{pmUVX, false},
 		{pmNPM, false},
 		// npx is the npm runner: like npm it uses the transparent proxy, never the
 		// pre-install lockfile audit (it has no lockfile of its own).
@@ -96,6 +101,9 @@ func TestPmToEcosystem(t *testing.T) {
 		{pmYarn, supplychain.EcosystemYarn},
 		{pmPip, supplychain.EcosystemPip},
 		{pmUV, supplychain.EcosystemUV},
+		// uvx maps to the uv ecosystem so the config "ecosystems" scoping gate
+		// treats it exactly like uv (scoping uv in/out includes uvx too).
+		{pmUVX, supplychain.EcosystemUV},
 		{"unknown-pm", ""},
 	}
 
@@ -129,6 +137,8 @@ func TestRegistryEnvForPM(t *testing.T) {
 		{pmYarn, "YARN_NPM_REGISTRY_SERVER", url},
 		{pmPip, "PIP_INDEX_URL", "http://127.0.0.1:9999/simple/"},
 		{pmUV, "UV_INDEX_URL", "http://127.0.0.1:9999/simple/"},
+		// uvx shares uv's config, so it gets the same PyPI index override as uv.
+		{pmUVX, "UV_INDEX_URL", "http://127.0.0.1:9999/simple/"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Adds `uvx` support to the supply-chain feature — the PyPI analogue of how `npx` is paired with `npm`.

`uvx <tool>` (≡ `uv tool run <tool>`) fetches a tool from PyPI on demand and runs it — exactly the supply-chain vector the proxy guards. Previously it was **not** wrapped, so `uvx` bypassed age enforcement entirely, even on machines where `uv` itself was wrapped. This closes that gap.

## What changed

**Core** (`internal/cmd/supply_chain_wrap.go`)
- Added `pmUVX` constant + to the allowlist
- Routed `uvx` through the transparent **PyPI proxy** (not the pre-install block), sharing uv's `UV_INDEX_URL` override — `uvx` shares uv's resolver and config
- Added `pmUVX` case to `execPM`'s hardcoded-name switch
- `pmToEcosystem` maps `uvx → EcosystemUV` so the config `ecosystems` scope treats it exactly like `uv`

**Init / detection** (`internal/cmd/supply_chain_init.go`)
- Pairs `uvx` with `uv` (guarded by a PATH check, **after** ecosystem scoping so it inherits uv's in/out-of-scope decision)
- Init preview annotates it `(paired with uv)`

**Docs** — help text (`supply-chain` + `init`), README ecosystem list, CHANGELOG `[Unreleased]`

**Tests** — 4 new uvx pairing tests (`PairsUvxWithUv`, `UvxNotPairedWithoutUv`, `UvxNotWrappedWhenAbsentFromPath`, `UvxAbsentWhenUvScopedOut`) plus uvx rows added to the `canonicalPM` / `requiresPreInstallBlock` / `pmToEcosystem` / `registryEnvForPM` / `summarizeDetectedPMs` tables

## Coverage caveat (documented)

Enforcement covers tools `uvx` **fetches from the registry**; a tool already in uv's tool cache runs without a registry round-trip and is not re-checked — mirroring the existing npx cache behavior. This is stated explicitly in the help text and CHANGELOG so coverage isn't overstated.

## Testing

- `go build ./...` — passes
- `go test ./internal/cmd/ ./internal/supplychain/...` — all pass
- `golangci-lint run` — 0 issues
- End-to-end: `init --mode env` emits both `uv()` and `uvx()` wrappers; `supply-chain wrap uvx` is accepted and routes to exec

## Ticket

PPSC-934 (under epic PPSC-875 — Supply Chain Package Age Policy Enforcement)