### PR TITLE
Fix: Align PR comment alert count with inline Code Scanning annotations

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -126,6 +126,9 @@ jobs:
 
             // Build a map of {filename: Set<lineNumber>} for lines visible in the PR diff.
             // These are the only lines GitHub Code Scanning annotates inline (added/context lines).
+            // Only '+' (added) and ' ' (context) lines are included; '-' (removed) lines are skipped
+            // because they don't exist in the new file. Lines starting with '\' (e.g. "\ No newline
+            // at end of file") are also skipped to avoid misaligning the computed line numbers.
             function parseDiffLineNumbers(patch) {
               const lines = new Set();
               if (!patch) return lines;
@@ -134,13 +137,20 @@ jobs:
                 const m = raw.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
                 if (m) { currentLine = parseInt(m[1], 10); continue; }
                 if (currentLine === 0) continue;
-                if (raw.startsWith('-')) continue;
-                lines.add(currentLine++);
+                if (raw.startsWith('-') || raw.startsWith('\\')) continue;
+                if (raw.startsWith('+') || raw.startsWith(' ')) {
+                  lines.add(currentLine++);
+                }
               }
               return lines;
             }
 
-            const diffLines = {};
+            // Use a null-prototype object to avoid prototype pollution from filenames
+            // like '__proto__' or 'constructor' that would corrupt a regular object.
+            // null sentinel means the file is changed but has no patch (e.g. large diffs
+            // or binary files) — findings for those files are always included so we never
+            // silently under-report issues on files GitHub couldn't supply a patch for.
+            const diffLines = Object.create(null);
             let page = 1;
             while (true) {
               const { data: files } = await github.rest.pulls.listFiles({
@@ -151,7 +161,7 @@ jobs:
               });
               if (!files.length) break;
               for (const f of files) {
-                if (f.patch) diffLines[f.filename] = parseDiffLineNumbers(f.patch);
+                diffLines[f.filename] = f.patch ? parseDiffLineNumbers(f.patch) : null;
               }
               if (files.length < 100) break;
               page++;
@@ -163,11 +173,15 @@ jobs:
 
             // Keep only findings whose (file, line) falls on a diff-visible line —
             // these are the only ones GitHub Code Scanning will annotate inline.
+            // Findings for files with no patch data (null sentinel) are always kept
+            // to avoid under-reporting on large or binary files.
             const results = allResults.filter(r => {
               const file = r.locations?.[0]?.physicalLocation?.artifactLocation?.uri || '';
               const line = r.locations?.[0]?.physicalLocation?.region?.startLine;
               if (!file || !line) return false;
-              return diffLines[file]?.has(line) ?? false;
+              if (!(file in diffLines)) return false;
+              const lineSet = diffLines[file];
+              return lineSet === null || lineSet.has(line);
             });
 
             // Count by severity - read from properties.severity if available

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -124,9 +124,51 @@ jobs:
           script: |
             const fs = require('fs');
 
+            // Build a map of {filename: Set<lineNumber>} for lines visible in the PR diff.
+            // These are the only lines GitHub Code Scanning annotates inline (added/context lines).
+            function parseDiffLineNumbers(patch) {
+              const lines = new Set();
+              if (!patch) return lines;
+              let currentLine = 0;
+              for (const raw of patch.split('\n')) {
+                const m = raw.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+                if (m) { currentLine = parseInt(m[1], 10); continue; }
+                if (currentLine === 0) continue;
+                if (raw.startsWith('-')) continue;
+                lines.add(currentLine++);
+              }
+              return lines;
+            }
+
+            const diffLines = {};
+            let page = 1;
+            while (true) {
+              const { data: files } = await github.rest.pulls.listFiles({
+                ...context.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+                page,
+              });
+              if (!files.length) break;
+              for (const f of files) {
+                if (f.patch) diffLines[f.filename] = parseDiffLineNumbers(f.patch);
+              }
+              if (files.length < 100) break;
+              page++;
+            }
+
             // Read SARIF results
             const sarif = JSON.parse(fs.readFileSync('armis-results.sarif', 'utf8'));
-            const results = sarif.runs?.[0]?.results || [];
+            const allResults = sarif.runs?.[0]?.results || [];
+
+            // Keep only findings whose (file, line) falls on a diff-visible line —
+            // these are the only ones GitHub Code Scanning will annotate inline.
+            const results = allResults.filter(r => {
+              const file = r.locations?.[0]?.physicalLocation?.artifactLocation?.uri || '';
+              const line = r.locations?.[0]?.physicalLocation?.region?.startLine;
+              if (!file || !line) return false;
+              return diffLines[file]?.has(line) ?? false;
+            });
 
             // Count by severity - read from properties.severity if available
             const counts = { CRITICAL: 0, HIGH: 0, MEDIUM: 0, LOW: 0, INFO: 0 };


### PR DESCRIPTION
## Related Issue

* [PPSC-781](https://armis-security.atlassian.net/browse/PPSC-781)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

When the PR Security Scan runs, the general PR comment reports a **total alert count that is higher than the number of inline Code Scanning annotations** visible in the diff. For example, the comment says \"5 total\" but only 1 inline annotation appears — the other 4 findings are on lines that were not changed in the PR.

**Root cause:** The \`Post PR Comment with Results\` step in \`reusable-security-scan.yml\` counts \`results.length\` from the raw SARIF, which includes findings from *any* line in the changed files. GitHub Code Scanning (via \`upload-sarif\`) only shows inline annotations for findings whose line falls within the PR diff — so the two counts are computed from different sets, causing a persistent mismatch that confuses users.

## Solution

Before counting and rendering findings in the PR comment, fetch the PR's changed file list via the GitHub API (\`github.rest.pulls.listFiles\`) and build a map of diff-visible line numbers per file. Then filter the SARIF results to only those whose \`(file, line)\` falls within that map — exactly the same set that GitHub Code Scanning will annotate inline.

**Key design decisions:**
- \`parseDiffLineNumbers\` includes both added (\`+\`) and context (\` \`) lines, consistent with what GitHub considers valid inline comment positions. Sentinel lines (\`\\\`) such as \"No newline at end of file\" are explicitly skipped to prevent line number misalignment.
- \`diffLines\` uses \`Object.create(null)\` (null-prototype object) to prevent prototype pollution from filenames like \`__proto__\`.
- Files with no \`patch\` data (binary files, or files whose diffs exceed GitHub's size limit) are stored as a \`null\` sentinel and their findings are always included — so we never silently under-report issues on unfilterable files.
- The filter is applied only to the PR comment step. The \`Upload SARIF to GitHub Code Scanning\` step still receives the full unfiltered SARIF, preserving complete scan history.
- Pagination is handled (100 files per page) to correctly handle large PRs.
- Findings with no file or no line number (e.g. repo-level findings) are excluded from the comment, since they cannot have inline annotations.

**The \`reusable-security-scan.yml\` change is purely additive** — all existing counting, rendering, and comment update logic is unchanged; it now simply operates on a pre-filtered \`results\` array instead of \`allResults\`.

## Testing

### Automated Tests

* [ ] Unit tests added/updated — _GitHub Actions workflow JavaScript cannot be unit-tested in the traditional sense; the \`parseDiffLineNumbers\` function logic is covered by equivalent Python unit tests in Project-Moose (\`test_github_client.py::TestParseDiffLineNumbers\`, 9 cases)_
* [x] All existing tests passing locally

### Manual Testing

Verified end-to-end via [silk-security/Project-Moose#2314](https://github.com/silk-security/Project-Moose/pull/2314) — a test PR in Project-Moose that pointed its \`pr-security-scan.yml\` at this branch (\`@fix/PPSC-781-filter-pr-diff-changes-before-commenting\`) instead of \`@main\`.

**Result:** All CI checks passed ✅ — lint, tests (4114 passed), and \`Security Scan / Armis Security Scan\` posted **"✅ No issues"**, confirming the diff-filtering step runs correctly and doesn't break the comment flow for a clean PR.

For a PR with actual findings on unchanged lines, the expected behaviour is:
1. The general PR comment total equals only the findings on diff-visible lines.
2. The \`Upload SARIF to GitHub Code Scanning\` step still uploads all findings (unaffected by this change).

## Reviewer Notes

- The fix is entirely self-contained in the \`github-script\` block.
- \`context.issue.number\` is the PR number in a \`pull_request\` event context, which is correct here since the step already guards on \`github.event_name == 'pull_request'\`.
- The \`upload-sarif\` step is intentionally left uploading the **full** SARIF. Filtering that would remove historical findings from Code Scanning and is not desirable.

## Checklist

* [x] Code follows project style guidelines
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-781]: https://armis-security.atlassian.net/browse/PPSC-781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ