### PR TITLE
[PPSC-958] fix(supply-chain): correct PyPI prerelease misclassification

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `supply-chain`: the filter summary for PyPI installs no longer mislabels withheld stable releases as prereleases. Package filenames (e.g. `filelock-3.29.2.tar.gz`) were being read as prereleases, which printed the misleading `withheld N prereleases; a default install was unaffected` line for versions a default `uv`/`uvx`/`pip` install would have selected. The summary now reflects the real outcome — `filtered N too-new releases → installed safe versions` — and each line leads with the installed safe version and its age, with the skipped version shown as a trailing clause (PPSC-958)
+
 ### Security
 
 ---

--- a/internal/cmd/supply_chain_wrap.go
+++ b/internal/cmd/supply_chain_wrap.go
@@ -289,7 +289,7 @@ const maxBlockedDisplay = 5
 // empty NewVersion when no safe fallback existed.
 type pkgFilterResult struct {
 	Name       string
-	OldVersion string         // youngest blocked version, normalized semver (what the PM wanted)
+	OldVersion string         // youngest blocked version, normalized version string — SemVer (npm) or PEP 440 (PyPI) (what the PM wanted)
 	OldAge     time.Duration  // age of that version at install time
 	Severity   model.Severity // severity classification of that age
 	NewVersion string         // resolved fallback version, "" if none was available

--- a/internal/cmd/supply_chain_wrap.go
+++ b/internal/cmd/supply_chain_wrap.go
@@ -289,10 +289,11 @@ const maxBlockedDisplay = 5
 // empty NewVersion when no safe fallback existed.
 type pkgFilterResult struct {
 	Name       string
-	OldVersion string         // youngest blocked version (what the PM wanted)
+	OldVersion string         // youngest blocked version, normalized semver (what the PM wanted)
 	OldAge     time.Duration  // age of that version at install time
 	Severity   model.Severity // severity classification of that age
 	NewVersion string         // resolved fallback version, "" if none was available
+	NewAge     time.Duration  // age of the resolved version, 0 when unknown
 }
 
 func printBlockSummary(blocked []supplychain.BlockedPackage, allowed []supplychain.InstalledPackage, checked int, policy supplychain.Policy, pmName string, installOK bool) {
@@ -309,9 +310,9 @@ func printBlockSummary(blocked []supplychain.BlockedPackage, allowed []supplycha
 		return
 	}
 
-	allowedVersions := make(map[string]string, len(allowed))
+	allowedVersions := make(map[string]supplychain.InstalledPackage, len(allowed))
 	for _, pkg := range allowed {
-		allowedVersions[pkg.Name] = pkg.Version
+		allowedVersions[pkg.Name] = pkg
 	}
 
 	results := groupBlockedByPackage(filterRelevantBlocked(blocked), allowedVersions, policy.MinReleaseAge)
@@ -385,19 +386,20 @@ func printBlockSummary(blocked []supplychain.BlockedPackage, allowed []supplycha
 		displayCount = maxBlockedDisplay
 	}
 
-	// Pad the name, version, and age columns to a common width so the "→ installed"
-	// outcomes line up vertically across rows. Widths are computed over the rows
-	// actually shown (not the full result set) so a truncated list still aligns.
+	// Pad the name, installed-version, and installed-age columns to a common width
+	// so the trailing "— skipped …" clauses line up vertically across rows. Widths
+	// are computed over the rows actually shown (not the full result set) so a
+	// truncated list still aligns.
 	var cols colWidths
 	for _, r := range results[:displayCount] {
 		if n := len(r.Name); n > cols.name {
 			cols.name = n
 		}
-		if n := len(r.OldVersion); n > cols.version {
-			cols.version = n
+		if n := len(r.NewVersion); n > cols.newVersion {
+			cols.newVersion = n
 		}
-		if n := len(ageToken(r.OldAge)); n > cols.age {
-			cols.age = n
+		if n := len(optionalAgeToken(r.NewAge)); n > cols.newAge {
+			cols.newAge = n
 		}
 	}
 	for _, r := range results[:displayCount] {
@@ -446,16 +448,26 @@ func printBlockSummary(blocked []supplychain.BlockedPackage, allowed []supplycha
 // is computed on the unstyled strings: len() on a lipgloss-rendered value counts
 // invisible ANSI escape bytes, so columns must be padded before .Render().
 type colWidths struct {
-	name    int
-	version int
-	age     int
+	name       int
+	newVersion int // width of the installed/resolved version column
+	newAge     int // width of the installed version's age token column
 }
 
-// ageToken formats a blocked version's age as it appears on the line, e.g.
-// "(1 day old)". Centralized so the column-width measurement and the rendered
-// output cannot drift apart.
+// ageToken formats a version's age as it appears on the line, e.g. "(1 day
+// old)". Centralized so the column-width measurement and the rendered output
+// cannot drift apart.
 func ageToken(age time.Duration) string {
 	return fmt.Sprintf("(%s old)", formatDurationShort(age))
+}
+
+// optionalAgeToken is ageToken for the installed version, which may be unknown
+// (age 0 — e.g. an undatable release the proxy could not stamp). It returns ""
+// in that case so the line omits the age rather than printing "(0 minutes old)".
+func optionalAgeToken(age time.Duration) string {
+	if age <= 0 {
+		return ""
+	}
+	return ageToken(age)
 }
 
 // rightPad appends spaces so s occupies at least width columns. It pads the
@@ -467,50 +479,65 @@ func rightPad(s string, width int) string {
 	return s
 }
 
-// printPkgFilterLine renders one package's filter outcome on a single line:
-// glyph, name, the blocked version and its age, an arrow, and the resolved
-// version (or an inline warning when none existed). The leading glyph depends on
-// context: when every package resolved (mixed == false) the header already
-// signals success, so the line shows the severity dot to convey how fresh the
-// blocked version was; in the mixed case the header is neutral, so a per-line
-// ✓/⚠ carries the resolved-vs-unresolved tone. When the blocked versions were all
-// prereleases (prerelease == true) the policy didn't change a default install, so
-// the line stays neutral — a muted dot, never a colored severity tier that would
-// imply averted risk. The resolved-version wording is "installed" only when the
-// PM completed (installOK); otherwise it reads "available" — the safe version
-// exists, but we cannot claim it was installed. cols pads each column so the
-// arrows and outcomes line up across rows.
+// printPkgFilterLine renders one package's filter outcome on a single line, led
+// by what was actually installed and trailed by what was skipped:
+//
+//	● superdialog  0.2.3 installed (8 days old) — skipped 0.2.5 (6 hours old)
+//
+// Leading with the resolved version is deliberate: the headline fact is that a
+// safe, older version is what the user ended up with, not that a newer one was
+// withheld. The skipped version is demoted to a trailing clause for context.
+//
+// The leading glyph depends on context: when every package resolved
+// (mixed == false) the header already signals success, so the line shows the
+// severity dot to convey how fresh the *skipped* version was; in the mixed case
+// the header is neutral, so a per-line ✓ carries the resolved tone. When the
+// blocked versions were all prereleases (prerelease == true) the policy didn't
+// change a default install, so the line stays neutral — a muted dot, never a
+// colored severity tier that would imply averted risk. The resolved-version
+// wording is "installed" only when the PM completed (installOK); otherwise it
+// reads "available" — the safe version exists, but we cannot claim it was
+// installed. When no safe fallback existed (NewVersion == "") the line inverts:
+// it leads with a warning instead of an install. cols pads the columns so the
+// skipped clauses line up across rows.
 func printPkgFilterLine(s *output.Styles, r pkgFilterResult, mixed, installOK, prerelease bool, cols colWidths) {
+	skipped := fmt.Sprintf("— skipped %s %s", r.OldVersion, ageToken(r.OldAge))
+
+	// No safe fallback: there is nothing "installed" to lead with, so invert the
+	// line — warn first, then name what was skipped.
+	if r.NewVersion == "" {
+		fmt.Fprintf(os.Stderr, "  %s %s %s  %s\n",
+			s.WarningText.Render("⚠"),
+			s.Bold.Render(rightPad(r.Name, cols.name)),
+			s.WarningText.Render("no older safe version (install may fail)"),
+			s.MutedText.Render(skipped))
+		return
+	}
+
 	resolvedWord := "installed"
 	if !installOK {
 		resolvedWord = "available"
 	}
 
-	var glyph, outcome string
+	var glyph string
 	switch {
-	case r.NewVersion == "":
-		glyph = s.WarningText.Render("⚠")
-		outcome = s.WarningText.Render("no older safe version (install may fail)")
 	case prerelease:
 		// Withheld a prerelease the resolver wouldn't have chosen: no risk tier to
 		// convey, so use a neutral muted dot rather than a severity color.
 		glyph = s.MutedText.Render(output.SeverityDot)
-		outcome = fmt.Sprintf("%s %s", s.SuccessText.Render(r.NewVersion), s.MutedText.Render(resolvedWord))
 	case mixed:
 		glyph = s.SuccessText.Render(output.IconSuccess)
-		outcome = fmt.Sprintf("%s %s", s.SuccessText.Render(r.NewVersion), s.MutedText.Render(resolvedWord))
 	default:
 		glyph = severityDot(s, r.Severity)
-		outcome = fmt.Sprintf("%s %s", s.SuccessText.Render(r.NewVersion), s.MutedText.Render(resolvedWord))
 	}
 
-	fmt.Fprintf(os.Stderr, "  %s %s %s %s  %s  %s\n",
+	fmt.Fprintf(os.Stderr, "  %s %s %s %s %s  %s\n",
 		glyph,
 		s.Bold.Render(rightPad(r.Name, cols.name)),
-		s.MutedText.Render(rightPad(r.OldVersion, cols.version)),
-		s.MutedText.Render(rightPad(ageToken(r.OldAge), cols.age)),
-		s.MutedText.Render("→"),
-		outcome)
+		s.SuccessText.Render(rightPad(r.NewVersion, cols.newVersion)),
+		s.MutedText.Render(resolvedWord),
+		s.MutedText.Render(rightPad(optionalAgeToken(r.NewAge), cols.newAge)),
+		s.MutedText.Render(skipped))
 }
 
 // groupBlockedByPackage collapses blocked versions into one result per package.
@@ -518,18 +545,20 @@ func printPkgFilterLine(s *output.Styles, r pkgFilterResult, mixed, installOK, p
 // have installed as "latest" — and pairs it with the resolved fallback from
 // allowedVersions. Results are sorted youngest-first (ties broken by name) so
 // the freshest, riskiest package leads the list and output is deterministic.
-func groupBlockedByPackage(blocked []supplychain.BlockedPackage, allowedVersions map[string]string, threshold time.Duration) []pkgFilterResult {
+func groupBlockedByPackage(blocked []supplychain.BlockedPackage, allowedVersions map[string]supplychain.InstalledPackage, threshold time.Duration) []pkgFilterResult {
 	byName := make(map[string]pkgFilterResult, len(blocked))
 	for _, b := range blocked {
 		if existing, ok := byName[b.Name]; ok && existing.OldAge <= b.Age {
 			continue // already holding a younger (or equally young) version
 		}
+		resolved := allowedVersions[b.Name]
 		byName[b.Name] = pkgFilterResult{
 			Name:       b.Name,
-			OldVersion: b.Version,
+			OldVersion: blockedDisplayVersion(b),
 			OldAge:     b.Age,
 			Severity:   supplychain.ClassifySeverity(b.Age, threshold),
-			NewVersion: allowedVersions[b.Name],
+			NewVersion: resolved.Version,
+			NewAge:     resolved.Age,
 		}
 	}
 
@@ -616,7 +645,10 @@ func markRationaleShown() {
 func filterRelevantBlocked(blocked []supplychain.BlockedPackage) []supplychain.BlockedPackage {
 	relevant := make([]supplychain.BlockedPackage, 0, len(blocked))
 	for _, b := range blocked {
-		if isPrerelease(b.Version) {
+		// Classify on the normalized semver, never the raw Version: a PyPI
+		// Version is a filename ("filelock-3.29.2.tar.gz") whose first '-' would
+		// fool isPrerelease into treating every package as a prerelease.
+		if isPrerelease(blockedDisplayVersion(b)) {
 			continue
 		}
 		relevant = append(relevant, b)
@@ -625,6 +657,16 @@ func filterRelevantBlocked(blocked []supplychain.BlockedPackage) []supplychain.B
 		return blocked
 	}
 	return relevant
+}
+
+// blockedDisplayVersion returns the normalized semver to show and classify for a
+// blocked package: the proxy-supplied DisplayVersion when present, falling back
+// to the raw Version (npm semver, or a PyPI filename that could not be parsed).
+func blockedDisplayVersion(b supplychain.BlockedPackage) string {
+	if b.DisplayVersion != "" {
+		return b.DisplayVersion
+	}
+	return b.Version
 }
 
 func isPrerelease(version string) bool {

--- a/internal/cmd/supply_chain_wrap.go
+++ b/internal/cmd/supply_chain_wrap.go
@@ -460,9 +460,10 @@ func ageToken(age time.Duration) string {
 	return fmt.Sprintf("(%s old)", formatDurationShort(age))
 }
 
-// optionalAgeToken is ageToken for the installed version, which may be unknown
-// (age 0 — e.g. an undatable release the proxy could not stamp). It returns ""
-// in that case so the line omits the age rather than printing "(0 minutes old)".
+// optionalAgeToken is ageToken for an age that may be unknown — the resolved
+// version's age, or a blocked PyPI file the proxy could not stamp (Age == 0), or
+// a non-positive value from clock skew. It returns "" in those cases so the line
+// omits the age rather than printing a false "(0 minutes old)".
 func optionalAgeToken(age time.Duration) string {
 	if age <= 0 {
 		return ""
@@ -501,7 +502,13 @@ func rightPad(s string, width int) string {
 // it leads with a warning instead of an install. cols pads the columns so the
 // skipped clauses line up across rows.
 func printPkgFilterLine(s *output.Styles, r pkgFilterResult, mixed, installOK, prerelease bool, cols colWidths) {
-	skipped := fmt.Sprintf("— skipped %s %s", r.OldVersion, ageToken(r.OldAge))
+	// Omit the age when it is unknown (OldAge == 0 for an undatable PyPI file, or
+	// non-positive under clock skew) rather than claiming a precise "(0 minutes
+	// old)". The version alone is still actionable.
+	skipped := fmt.Sprintf("— skipped %s", r.OldVersion)
+	if tok := optionalAgeToken(r.OldAge); tok != "" {
+		skipped += " " + tok
+	}
 
 	// No safe fallback: there is nothing "installed" to lead with, so invert the
 	// line — warn first, then name what was skipped.
@@ -645,10 +652,10 @@ func markRationaleShown() {
 func filterRelevantBlocked(blocked []supplychain.BlockedPackage) []supplychain.BlockedPackage {
 	relevant := make([]supplychain.BlockedPackage, 0, len(blocked))
 	for _, b := range blocked {
-		// Classify on the normalized semver, never the raw Version: a PyPI
+		// Classify on the normalized version, never the raw Version: a PyPI
 		// Version is a filename ("filelock-3.29.2.tar.gz") whose first '-' would
-		// fool isPrerelease into treating every package as a prerelease.
-		if isPrerelease(blockedDisplayVersion(b)) {
+		// fool the SemVer check into treating every package as a prerelease.
+		if supplychain.IsPrerelease(blockedDisplayVersion(b)) {
 			continue
 		}
 		relevant = append(relevant, b)
@@ -669,11 +676,6 @@ func blockedDisplayVersion(b supplychain.BlockedPackage) string {
 	return b.Version
 }
 
-func isPrerelease(version string) bool {
-	parts := strings.SplitN(version, "-", 2)
-	return len(parts) == 2 && parts[0] != ""
-}
-
 // allResultsPrerelease reports whether every grouped result is a prerelease. It
 // drives the honest "withheld a prerelease" framing: when this holds, the proxy
 // only blocked versions a default install would never have selected (resolvers
@@ -685,7 +687,7 @@ func allResultsPrerelease(results []pkgFilterResult) bool {
 		return false
 	}
 	for _, r := range results {
-		if !isPrerelease(r.OldVersion) {
+		if !supplychain.IsPrerelease(r.OldVersion) {
 			return false
 		}
 	}

--- a/internal/cmd/supply_chain_wrap_summary_test.go
+++ b/internal/cmd/supply_chain_wrap_summary_test.go
@@ -177,6 +177,32 @@ func TestPrintBlockSummary_PyPIFilenameNotPrerelease(t *testing.T) {
 	}
 }
 
+func TestPrintBlockSummary_UndatableSkippedOmitsAge(t *testing.T) {
+	// A PyPI file the proxy could not date is blocked with Age == 0 (fail-closed).
+	// The skipped clause must NOT claim a precise "(0 minutes old)" — it should
+	// name the version and omit the age entirely.
+	forceNoColor(t)
+	blocked := []supplychain.BlockedPackage{
+		{Name: "mystery", Version: "mystery-1.0.0.tar.gz", DisplayVersion: "1.0.0", Age: 0},
+	}
+	allowed := []supplychain.InstalledPackage{{Name: "mystery", Version: "0.9.0", Age: 30 * 24 * time.Hour}}
+
+	out := captureStderr(t, func() {
+		printBlockSummary(blocked, allowed, 1, testPolicy(), pmUV, true)
+	})
+
+	if strings.Contains(out, "0 minutes old") {
+		t.Errorf("undatable skipped version must not claim a precise age; got:\n%s", out)
+	}
+	flat := strings.Join(strings.Fields(out), " ")
+	if !strings.Contains(flat, "— skipped 1.0.0") {
+		t.Errorf("expected the skipped version named without an age; got:\n%s", out)
+	}
+	if strings.Contains(flat, "skipped 1.0.0 (") {
+		t.Errorf("skipped clause should carry no age token for an undatable file; got:\n%s", out)
+	}
+}
+
 func TestPrintBlockSummary_MixedUnresolved(t *testing.T) {
 	// Tier C: one package resolved, one with no safe fallback → neutral header
 	// (no "installed safe"), per-line warning for the unresolved package.
@@ -300,6 +326,9 @@ func TestAllResultsPrerelease(t *testing.T) {
 		{"single stable", []pkgFilterResult{{OldVersion: testVersion}}, false},
 		{"mixed", []pkgFilterResult{{OldVersion: testVersion + "-beta"}, {OldVersion: "2.0.0"}}, false},
 		{"all prerelease", []pkgFilterResult{{OldVersion: testVersion + "-alpha"}, {OldVersion: "2.0.0-rc.1"}}, true},
+		// PEP 440 prereleases (no SemVer dash) must count as prereleases too.
+		{"pep440 rc", []pkgFilterResult{{OldVersion: "1.0.0rc1"}}, true},
+		{"pep440 mixed with stable", []pkgFilterResult{{OldVersion: "1.0.0b2"}, {OldVersion: "2.0.0"}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/cmd/supply_chain_wrap_summary_test.go
+++ b/internal/cmd/supply_chain_wrap_summary_test.go
@@ -99,11 +99,12 @@ func TestPrintBlockSummary_AllPassZeroChecked(t *testing.T) {
 }
 
 func TestPrintBlockSummary_SingleResolved(t *testing.T) {
-	// Tier B: one package filtered and resolved → success header, old→new line,
-	// terse Disable hint, and NO divider/heavy chrome.
+	// Tier B: one package filtered and resolved → success header, an
+	// installed-leads/skipped-trails line, terse Disable hint, and NO
+	// divider/heavy chrome.
 	forceNoColor(t)
-	blocked := []supplychain.BlockedPackage{{Name: "axios", Version: "1.17.0", Age: 24 * time.Hour}}
-	allowed := []supplychain.InstalledPackage{{Name: "axios", Version: "1.16.1"}}
+	blocked := []supplychain.BlockedPackage{{Name: "axios", Version: "1.17.0", DisplayVersion: "1.17.0", Age: 24 * time.Hour}}
+	allowed := []supplychain.InstalledPackage{{Name: "axios", Version: "1.16.1", Age: 10 * 24 * time.Hour}}
 
 	out := captureStderr(t, func() {
 		printBlockSummary(blocked, allowed, 5, testPolicy(), pmNPM, true)
@@ -112,10 +113,10 @@ func TestPrintBlockSummary_SingleResolved(t *testing.T) {
 	wantSubstrings := []string{
 		"filtered 1 too-new release → installed safe version (3-day policy)",
 		"axios",
-		"1.17.0",
-		"(1 day old)",
-		"→",
-		"1.16.1 installed",
+		// The line leads with what was installed and its age...
+		"1.16.1 installed (10 days old)",
+		// ...and trails with the skipped version and its age.
+		"— skipped 1.17.0 (1 day old)",
 		"Disable: ARMIS_SUPPLY_CHAIN=off",
 	}
 	for _, want := range wantSubstrings {
@@ -123,12 +124,56 @@ func TestPrintBlockSummary_SingleResolved(t *testing.T) {
 			t.Errorf("missing %q; got:\n%s", want, out)
 		}
 	}
+	// The installed (resolved) version must appear before the skipped one on the
+	// line — the flip is the whole point of the layout.
+	if i, j := strings.Index(out, "1.16.1 installed"), strings.Index(out, "skipped 1.17.0"); i < 0 || j < 0 || i > j {
+		t.Errorf("installed version should lead the skipped version; got:\n%s", out)
+	}
 	// Short list must not draw the divider or the full copy-paste incantation.
 	if strings.Contains(out, strings.Repeat("─", scSepLen)) {
 		t.Errorf("short list should not draw a divider; got:\n%s", out)
 	}
 	if strings.Contains(out, "ARMIS_SUPPLY_CHAIN=off npm install") {
 		t.Errorf("short list should use the terse disable hint; got:\n%s", out)
+	}
+}
+
+func TestPrintBlockSummary_PyPIFilenameNotPrerelease(t *testing.T) {
+	// Regression: a PyPI BlockedPackage carries a *filename* in Version
+	// ("filelock-3.29.2.tar.gz"). The summary must classify on DisplayVersion, not
+	// the filename — splitting the filename on its first '-' would otherwise read
+	// every PyPI package as a "filelock" prerelease and wrongly print "withheld N
+	// prereleases; a default install was unaffected". These are real stable
+	// releases the proxy downgraded, so the honest framing is a successful filter.
+	forceNoColor(t)
+	blocked := []supplychain.BlockedPackage{
+		{Name: "filelock", Version: "filelock-3.29.2.tar.gz", DisplayVersion: "3.29.2", Age: 11 * time.Minute},
+		{Name: "superdialog", Version: "superdialog-0.2.5.tar.gz", DisplayVersion: "0.2.5", Age: 6 * time.Hour},
+	}
+	allowed := []supplychain.InstalledPackage{
+		{Name: "filelock", Version: "3.29.1", Age: 9 * 24 * time.Hour},
+		{Name: "superdialog", Version: "0.2.3", Age: 8 * 24 * time.Hour},
+	}
+
+	out := captureStderr(t, func() {
+		printBlockSummary(blocked, allowed, 2, testPolicy(), pmUV, true)
+	})
+
+	if strings.Contains(out, "withheld") || strings.Contains(out, "a default install was unaffected") {
+		t.Errorf("PyPI filenames must not be misread as prereleases; got:\n%s", out)
+	}
+	if !strings.Contains(out, "filtered 2 too-new releases → installed safe versions (3-day policy)") {
+		t.Errorf("expected a genuine-filter success header; got:\n%s", out)
+	}
+	// Clean parsed versions on the line, never the raw filename.
+	if strings.Contains(out, ".tar.gz") {
+		t.Errorf("line should show the parsed version, not the filename; got:\n%s", out)
+	}
+	// Collapse runs of spaces so column-alignment padding does not break the
+	// substring match (versions are right-padded to a common width).
+	flat := strings.Join(strings.Fields(out), " ")
+	if !strings.Contains(flat, "0.2.3 installed (8 days old) — skipped 0.2.5 (6 hours old)") {
+		t.Errorf("expected installed-leads/skipped-trails layout with parsed versions; got:\n%s", out)
 	}
 }
 
@@ -303,7 +348,9 @@ func TestGroupBlockedByPackage_CollapsesToYoungest(t *testing.T) {
 		{Name: "axios", Version: "1.17.0", Age: 48 * time.Hour},
 		{Name: "axios", Version: "1.18.0", Age: 2 * time.Hour},
 	}
-	allowed := map[string]string{"axios": "1.16.1"}
+	allowed := map[string]supplychain.InstalledPackage{
+		"axios": {Name: "axios", Version: "1.16.1", Age: 10 * 24 * time.Hour},
+	}
 
 	got := groupBlockedByPackage(blocked, allowed, 72*time.Hour)
 	if len(got) != 1 {
@@ -318,6 +365,11 @@ func TestGroupBlockedByPackage_CollapsesToYoungest(t *testing.T) {
 	if got[0].NewVersion != "1.16.1" {
 		t.Errorf("NewVersion = %q, want 1.16.1", got[0].NewVersion)
 	}
+	// The resolved version's age must flow through so the line can show
+	// "1.16.1 installed (10 days old)".
+	if got[0].NewAge != 10*24*time.Hour {
+		t.Errorf("NewAge = %v, want 240h", got[0].NewAge)
+	}
 }
 
 func TestGroupBlockedByPackage_SortYoungestFirst(t *testing.T) {
@@ -327,7 +379,7 @@ func TestGroupBlockedByPackage_SortYoungestFirst(t *testing.T) {
 		{Name: "fresh", Version: "1.0.0", Age: 1 * time.Hour},
 		{Name: "mid", Version: "1.0.0", Age: 12 * time.Hour},
 	}
-	got := groupBlockedByPackage(blocked, map[string]string{}, 72*time.Hour)
+	got := groupBlockedByPackage(blocked, map[string]supplychain.InstalledPackage{}, 72*time.Hour)
 	wantOrder := []string{"fresh", "mid", "old"}
 	for i, w := range wantOrder {
 		if got[i].Name != w {

--- a/internal/cmd/supply_chain_wrap_summary_test.go
+++ b/internal/cmd/supply_chain_wrap_summary_test.go
@@ -177,6 +177,34 @@ func TestPrintBlockSummary_PyPIFilenameNotPrerelease(t *testing.T) {
 	}
 }
 
+func TestPrintBlockSummary_UnparseableFilenameNotPrerelease(t *testing.T) {
+	// Regression for the IsPrerelease fix: when pypiVersionFromFilename cannot
+	// parse a filename, DisplayVersion is empty and blockedDisplayVersion falls
+	// back to the raw Version (the filename itself). The old SemVer branch flagged
+	// any '-' after the first byte, so "filelock-3.29.2.tar.gz" (head "filelock")
+	// was read as a prerelease — driving the wrong "withheld a prerelease; a
+	// default install was unaffected" framing for a real stable release the proxy
+	// downgraded. With the digit-before-'-' guard it must be framed as a genuine
+	// filter. This is the one path that exercises the empty-DisplayVersion
+	// fallback through the full summary, not the IsPrerelease helper in isolation.
+	forceNoColor(t)
+	blocked := []supplychain.BlockedPackage{
+		{Name: "filelock", Version: "filelock-3.29.2.tar.gz", DisplayVersion: "", Age: 11 * time.Minute},
+	}
+	allowed := []supplychain.InstalledPackage{{Name: "filelock", Version: "3.29.1", Age: 9 * 24 * time.Hour}}
+
+	out := captureStderr(t, func() {
+		printBlockSummary(blocked, allowed, 1, testPolicy(), pmUV, true)
+	})
+
+	if strings.Contains(out, "withheld") || strings.Contains(out, "a default install was unaffected") {
+		t.Errorf("an unparseable PyPI filename must not be misread as a prerelease; got:\n%s", out)
+	}
+	if !strings.Contains(out, "filtered 1 too-new release → installed safe version (3-day policy)") {
+		t.Errorf("expected a genuine-filter success header; got:\n%s", out)
+	}
+}
+
 func TestPrintBlockSummary_UndatableSkippedOmitsAge(t *testing.T) {
 	// A PyPI file the proxy could not date is blocked with Age == 0 (fail-closed).
 	// The skipped clause must NOT claim a precise "(0 minutes old)" — it should

--- a/internal/supplychain/proxy.go
+++ b/internal/supplychain/proxy.go
@@ -50,14 +50,36 @@ const (
 )
 
 type BlockedPackage struct {
-	Name    string
+	Name string
+	// Version is the raw artifact identifier the proxy removed: a wheel/sdist
+	// filename for PyPI (e.g. "filelock-3.29.2.tar.gz"), a semver string for npm.
+	// It records exactly which file/version was withheld and is what the proxy
+	// tests assert against.
 	Version string
-	Age     time.Duration
+	// DisplayVersion is the normalized semver shown to the user and used for
+	// prerelease classification. For npm it equals Version; for PyPI it is parsed
+	// out of the filename (e.g. "3.29.2"). Empty when a filename cannot be parsed,
+	// in which case callers fall back to Version. Keeping classification on this
+	// field — not the raw Version — stops a PyPI filename like
+	// "filelock-3.29.2.tar.gz" from being misread as a "filelock" prerelease.
+	DisplayVersion string
+	Age            time.Duration
 }
 
 type InstalledPackage struct {
 	Name    string
 	Version string
+	// Age is how old the resolved safe version was at install time — the figure
+	// behind the summary's "0.2.3 installed (8 days old)". Zero when unknown.
+	Age time.Duration
+}
+
+// allowedVersion is the proxy's internal record of the safe version it resolved
+// "latest" to for one package, paired with that version's age so the summary can
+// report how old the installed version was, not just its number.
+type allowedVersion struct {
+	version string
+	age     time.Duration
 }
 
 type Proxy struct {
@@ -70,7 +92,7 @@ type Proxy struct {
 	server       *http.Server
 	blocked      []BlockedPackage
 	blockedMu    sync.Mutex
-	allowed      map[string]string // package name → latest allowed version
+	allowed      map[string]allowedVersion // package name → resolved safe version
 	allowedMu    sync.Mutex
 	checked      int
 	checkedMu    sync.Mutex
@@ -130,7 +152,7 @@ func NewProxy(cfg ProxyConfig) (*Proxy, error) {
 		},
 		revProxy:     revProxy,
 		skipPackages: skipSet,
-		allowed:      make(map[string]string),
+		allowed:      make(map[string]allowedVersion),
 	}, nil
 }
 
@@ -205,8 +227,8 @@ func (p *Proxy) Allowed() []InstalledPackage {
 	p.allowedMu.Lock()
 	defer p.allowedMu.Unlock()
 	result := make([]InstalledPackage, 0, len(p.allowed))
-	for name, version := range p.allowed {
-		result = append(result, InstalledPackage{Name: name, Version: version})
+	for name, av := range p.allowed {
+		result = append(result, InstalledPackage{Name: name, Version: av.version, Age: av.age})
 	}
 	return result
 }
@@ -429,9 +451,12 @@ func (p *Proxy) filterMetadata(body []byte, pkgName string) ([]byte, []BlockedPa
 		if age < p.policy.MinReleaseAge {
 			versionsToRemove[version] = true
 			blocked = append(blocked, BlockedPackage{
-				Name:    pkgName,
-				Version: version,
-				Age:     age,
+				Name: pkgName,
+				// npm versions are already semver, so the raw and display forms
+				// coincide — no filename to parse, unlike PyPI.
+				Version:        version,
+				DisplayVersion: version,
+				Age:            age,
 			})
 		}
 	}
@@ -476,8 +501,17 @@ func (p *Proxy) filterMetadata(body []byte, pkgName string) ([]byte, []BlockedPa
 		}
 	}
 	if latestVersion != "" && p.allowed != nil {
+		// Age of the resolved version, parsed from the (still-present) time map
+		// entry. Unparseable or absent → zero, and the summary simply omits the
+		// age rather than guessing.
+		var latestAge time.Duration
+		if ts, ok := timeMap[latestVersion]; ok {
+			if t, err := time.Parse(time.RFC3339, ts); err == nil {
+				latestAge = now.Sub(t)
+			}
+		}
 		p.allowedMu.Lock()
-		p.allowed[pkgName] = latestVersion
+		p.allowed[pkgName] = allowedVersion{version: latestVersion, age: latestAge}
 		p.allowedMu.Unlock()
 	}
 
@@ -581,7 +615,15 @@ func (p *Proxy) filterPyPISimple(body []byte, pkgName string) ([]byte, []Blocked
 			if !ok {
 				age = 0
 			}
-			blocked = append(blocked, BlockedPackage{Name: pkgName, Version: filename, Age: age})
+			// Version is the filename (what the user sees and what makes the block
+			// actionable); DisplayVersion is the semver parsed from it, used for
+			// prerelease classification and the clean number shown in the summary.
+			blocked = append(blocked, BlockedPackage{
+				Name:           pkgName,
+				Version:        filename,
+				DisplayVersion: pypiVersionFromFilename(filename),
+				Age:            age,
+			})
 			continue
 		}
 		kept = append(kept, f)
@@ -618,7 +660,7 @@ func (p *Proxy) filterPyPISimple(body []byte, pkgName string) ([]byte, []Blocked
 		}
 		if bestVersion != "" {
 			p.allowedMu.Lock()
-			p.allowed[pkgName] = bestVersion
+			p.allowed[pkgName] = allowedVersion{version: bestVersion, age: bestAge}
 			p.allowedMu.Unlock()
 		}
 	}

--- a/internal/supplychain/proxy.go
+++ b/internal/supplychain/proxy.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -487,7 +488,7 @@ func (p *Proxy) filterMetadata(body []byte, pkgName string) ([]byte, []BlockedPa
 			if version == npmTimeKeyCreated || version == npmTimeKeyModified {
 				continue
 			}
-			if isPrerelease(version) {
+			if IsPrerelease(version) {
 				continue
 			}
 			t, err := time.Parse(time.RFC3339, timeStr)
@@ -646,7 +647,7 @@ func (p *Proxy) filterPyPISimple(body []byte, pkgName string) ([]byte, []Blocked
 		for _, f := range kept {
 			fname := jsonString(f["filename"])
 			ver := pypiVersionFromFilename(fname)
-			if ver == "" || isPrerelease(ver) {
+			if ver == "" || IsPrerelease(ver) {
 				continue
 			}
 			age, ok := pypiFileAge(f["upload-time"], now)
@@ -798,9 +799,31 @@ func isMetadataRequest(path string) bool {
 	return true
 }
 
-func isPrerelease(version string) bool {
-	parts := strings.SplitN(version, "-", 2)
-	return len(parts) == 2 && parts[0] != ""
+// pep440Prerelease matches a PEP 440 pre-release (aN/bN/cN/rcN and the long
+// spellings alpha/beta/pre/preview) or development-release (devN) segment. These
+// attach to the numeric release with an optional ".", "-", or "_" separator and,
+// unlike SemVer, without a leading "-" tag — e.g. "1.0.0rc1", "1.0.0b2",
+// "1.0.0.dev1". Longer spellings precede shorter ones in the alternation so
+// "alpha" is preferred over a bare "a" (Go's regexp is leftmost-first). PEP 440
+// post-releases (".postN") are stable and are intentionally NOT matched.
+var pep440Prerelease = regexp.MustCompile(`(?i)[0-9][._-]?(?:alpha|beta|preview|pre|rc|dev|a|b|c)[0-9]*`)
+
+// IsPrerelease reports whether a version string denotes a pre-release in either
+// ecosystem's grammar. It is the single source of truth shared by the proxy and
+// the CLI summary so the two can never drift (a past divergence is what let PyPI
+// filenames be misclassified). It recognizes:
+//
+//   - SemVer/npm: any "-" suffix on a non-empty version ("2.0.0-alpha.1").
+//   - PyPI/PEP 440: dash-less pre/dev markers on the release ("2.0.0rc1",
+//     "1.0.0b2", "1.0.0.dev1").
+//
+// Valid stable versions in one ecosystem never match the other's pre-release
+// syntax, so a unified check is safe for both. Post-releases stay stable.
+func IsPrerelease(version string) bool {
+	if i := strings.IndexByte(version, '-'); i > 0 {
+		return true
+	}
+	return pep440Prerelease.MatchString(version)
 }
 
 // extractPyPIPackageNameFromPath pulls the project name from a PyPI Simple API

--- a/internal/supplychain/proxy.go
+++ b/internal/supplychain/proxy.go
@@ -57,11 +57,12 @@ type BlockedPackage struct {
 	// It records exactly which file/version was withheld and is what the proxy
 	// tests assert against.
 	Version string
-	// DisplayVersion is the normalized semver shown to the user and used for
-	// prerelease classification. For npm it equals Version; for PyPI it is parsed
-	// out of the filename (e.g. "3.29.2"). Empty when a filename cannot be parsed,
-	// in which case callers fall back to Version. Keeping classification on this
-	// field — not the raw Version — stops a PyPI filename like
+	// DisplayVersion is the normalized version string shown to the user and used
+	// for prerelease classification. For npm it equals Version (a SemVer string);
+	// for PyPI it is parsed out of the filename and may be a PEP 440 version
+	// ("3.29.2", "1.0.0rc1", "1.0.0.dev1"). Empty when a filename cannot be
+	// parsed, in which case callers fall back to Version. Keeping classification
+	// on this field — not the raw Version — stops a PyPI filename like
 	// "filelock-3.29.2.tar.gz" from being misread as a "filelock" prerelease.
 	DisplayVersion string
 	Age            time.Duration
@@ -813,14 +814,19 @@ var pep440Prerelease = regexp.MustCompile(`(?i)[0-9][._-]?(?:alpha|beta|preview|
 // the CLI summary so the two can never drift (a past divergence is what let PyPI
 // filenames be misclassified). It recognizes:
 //
-//   - SemVer/npm: any "-" suffix on a non-empty version ("2.0.0-alpha.1").
+//   - SemVer/npm: a "-" suffix on a version whose head is numeric
+//     ("2.0.0-alpha.1").
 //   - PyPI/PEP 440: dash-less pre/dev markers on the release ("2.0.0rc1",
 //     "1.0.0b2", "1.0.0.dev1").
 //
-// Valid stable versions in one ecosystem never match the other's pre-release
-// syntax, so a unified check is safe for both. Post-releases stay stable.
+// The SemVer branch requires a digit before the "-" so a raw, unparseable PyPI
+// filename used as a fallback (e.g. "filelock-3.29.2.tar.gz", head "filelock")
+// is not misread as a prerelease — the very failure mode this helper exists to
+// prevent. Valid stable versions in one ecosystem never match the other's
+// pre-release syntax, so a unified check is safe for both. Post-releases stay
+// stable.
 func IsPrerelease(version string) bool {
-	if i := strings.IndexByte(version, '-'); i > 0 {
+	if i := strings.IndexByte(version, '-'); i > 0 && strings.ContainsAny(version[:i], "0123456789") {
 		return true
 	}
 	return pep440Prerelease.MatchString(version)

--- a/internal/supplychain/proxy.go
+++ b/internal/supplychain/proxy.go
@@ -809,24 +809,35 @@ func isMetadataRequest(path string) bool {
 // post-releases (".postN") are stable and are intentionally NOT matched.
 var pep440Prerelease = regexp.MustCompile(`(?i)[0-9][._-]?(?:alpha|beta|preview|pre|rc|dev|a|b|c)[0-9]*`)
 
+// semverNumericHead matches the part before a SemVer pre-release "-" only when it
+// is a numeric dotted release core (optionally "v"-prefixed): "1", "1.2",
+// "1.2.3", "v2.0.0". A raw PyPI filename fallback's head ("filelock", "pkg2",
+// "4ti2") is NOT a bare numeric core, so it never qualifies — including the
+// digit-bearing and digit-leading project names that a looser "contains/starts
+// with a digit" test would misfire on.
+var semverNumericHead = regexp.MustCompile(`^[vV]?[0-9]+(?:\.[0-9]+)*$`)
+
 // IsPrerelease reports whether a version string denotes a pre-release in either
 // ecosystem's grammar. It is the single source of truth shared by the proxy and
 // the CLI summary so the two can never drift (a past divergence is what let PyPI
 // filenames be misclassified). It recognizes:
 //
-//   - SemVer/npm: a "-" suffix on a version whose head is numeric
-//     ("2.0.0-alpha.1").
+//   - SemVer/npm: a "-" suffix on a version whose head is a numeric release core
+//     ("2.0.0-alpha.1", "v1.2.3-beta").
 //   - PyPI/PEP 440: dash-less pre/dev markers on the release ("2.0.0rc1",
 //     "1.0.0b2", "1.0.0.dev1").
 //
-// The SemVer branch requires a digit before the "-" so a raw, unparseable PyPI
-// filename used as a fallback (e.g. "filelock-3.29.2.tar.gz", head "filelock")
-// is not misread as a prerelease — the very failure mode this helper exists to
-// prevent. Valid stable versions in one ecosystem never match the other's
-// pre-release syntax, so a unified check is safe for both. Post-releases stay
-// stable.
+// The SemVer branch fires only when the head before "-" is a bare numeric core
+// (see semverNumericHead). That guards against a raw, unparseable PyPI filename
+// used as a fallback being misread as a prerelease — not just hyphenated names
+// like "filelock-3.29.2.tar.gz" but digit-bearing/-leading ones like
+// "pkg2-1.0.tar.gz" or the real package "4ti2-1.0.tar.gz", which a looser
+// "contains a digit" check would wrongly flag. This is the very failure mode the
+// helper exists to prevent. Valid stable versions in one ecosystem never match
+// the other's pre-release syntax, so a unified check is safe for both.
+// Post-releases stay stable.
 func IsPrerelease(version string) bool {
-	if i := strings.IndexByte(version, '-'); i > 0 && strings.ContainsAny(version[:i], "0123456789") {
+	if i := strings.IndexByte(version, '-'); i > 0 && semverNumericHead.MatchString(version[:i]) {
 		return true
 	}
 	return pep440Prerelease.MatchString(version)

--- a/internal/supplychain/proxy_test.go
+++ b/internal/supplychain/proxy_test.go
@@ -1246,12 +1246,18 @@ func TestIsPrerelease(t *testing.T) {
 		// Raw PyPI filenames reach IsPrerelease when pypiVersionFromFilename
 		// fails to parse them and callers fall back to the raw Version. A hyphen
 		// in the project name must NOT be read as a SemVer prerelease tag — the
-		// SemVer branch requires a digit before the "-".
+		// SemVer branch fires only when the head before "-" is a bare numeric
+		// release core, so an alphabetic name (or one merely containing/leading
+		// with a digit) never qualifies.
 		{"filelock-3.29.2.tar.gz", false},
 		{"my-package-1.0.tar.gz", false},
-		// SemVer prereleases carry a '-' suffix.
+		{"pkg2-1.0.tar.gz", false}, // digit inside the project name
+		{"4ti2-1.0.tar.gz", false}, // real package whose name STARTS with a digit
+		// SemVer prereleases carry a '-' suffix on a numeric (optionally
+		// v-prefixed) release core.
 		{"2.0.0-alpha.1", true},
 		{"2.0.0-rc.1", true},
+		{"v1.2.3-beta", true},
 		// PEP 440 prereleases are dash-less: a/b/c/rc/alpha/beta/pre/preview/dev.
 		{"1.0.0a1", true},
 		{"1.0.0b2", true},

--- a/internal/supplychain/proxy_test.go
+++ b/internal/supplychain/proxy_test.go
@@ -1201,6 +1201,71 @@ func TestProxyFilterPyPISimple_AllowedPopulated(t *testing.T) {
 	}
 }
 
+func TestProxyFilterPyPISimple_SkipsPEP440PrereleaseFallback(t *testing.T) {
+	// A PEP 440 prerelease (1.0.0rc1 — no SemVer '-') that is old enough to pass
+	// the age policy must NOT be chosen as the resolved "safe" version: a default
+	// pip/uv install resolves to the newest *stable* release, so offering an rc as
+	// the fallback would install something the user never asked for. The newest
+	// stable release should win instead.
+	now := time.Now()
+	oldStable := now.Add(-60 * 24 * time.Hour).UTC().Format(time.RFC3339) // 1.0.0  — stable, safe
+	oldRC := now.Add(-30 * 24 * time.Hour).UTC().Format(time.RFC3339)     // 1.1.0rc1 — prerelease, safe by age but must be skipped
+	young := now.Add(-1 * time.Hour).UTC().Format(time.RFC3339)           // 1.2.0  — blocked (too new)
+
+	p, err := NewProxy(ProxyConfig{Policy: Policy{MinReleaseAge: 72 * time.Hour}, Mode: ModePyPI})
+	if err != nil {
+		t.Fatalf("NewProxy: %v", err)
+	}
+
+	body := pypiSimpleBody("widget", []struct{ filename, uploadTime string }{
+		{"widget-1.0.0-py3-none-any.whl", oldStable},
+		{"widget-1.1.0rc1-py3-none-any.whl", oldRC},
+		{"widget-1.2.0-py3-none-any.whl", young},
+	})
+	if _, blocked := p.filterPyPISimple([]byte(body), "widget"); len(blocked) != 1 {
+		t.Fatalf("expected 1 blocked file, got %d: %+v", len(blocked), blocked)
+	}
+
+	allowed := p.Allowed()
+	if len(allowed) != 1 || allowed[0].Version != "1.0.0" {
+		t.Errorf("Allowed() = %+v, want the newest STABLE [{widget 1.0.0}], not the rc", allowed)
+	}
+}
+
+func TestIsPrerelease(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		// Stable — SemVer and PEP 440 release/post forms.
+		{"3.29.2", false},
+		{"0.2.5", false},
+		{"6.0", false},
+		{"1.2.3+local", false},
+		{"1.0.0.post1", false}, // post-release is a stable release
+		// SemVer prereleases carry a '-' suffix.
+		{"2.0.0-alpha.1", true},
+		{"2.0.0-rc.1", true},
+		// PEP 440 prereleases are dash-less: a/b/c/rc/alpha/beta/pre/preview/dev.
+		{"1.0.0a1", true},
+		{"1.0.0b2", true},
+		{"1.0.0c1", true},
+		{"1.0.0rc1", true},
+		{"1.0.0.dev1", true},
+		{"1.0.0alpha", true},
+		{"1.0.0beta3", true},
+		{"1.0.0preview1", true},
+		{"1.0.0.post1.dev2", true}, // a dev release on top of a post is still pre-final
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			if got := IsPrerelease(tt.version); got != tt.want {
+				t.Errorf("IsPrerelease(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPypiVersionFromFilename(t *testing.T) {
 	tests := []struct {
 		filename string

--- a/internal/supplychain/proxy_test.go
+++ b/internal/supplychain/proxy_test.go
@@ -1243,6 +1243,12 @@ func TestIsPrerelease(t *testing.T) {
 		{"6.0", false},
 		{"1.2.3+local", false},
 		{"1.0.0.post1", false}, // post-release is a stable release
+		// Raw PyPI filenames reach IsPrerelease when pypiVersionFromFilename
+		// fails to parse them and callers fall back to the raw Version. A hyphen
+		// in the project name must NOT be read as a SemVer prerelease tag — the
+		// SemVer branch requires a digit before the "-".
+		{"filelock-3.29.2.tar.gz", false},
+		{"my-package-1.0.tar.gz", false},
 		// SemVer prereleases carry a '-' suffix.
 		{"2.0.0-alpha.1", true},
 		{"2.0.0-rc.1", true},

--- a/internal/supplychain/proxy_test.go
+++ b/internal/supplychain/proxy_test.go
@@ -700,7 +700,7 @@ func TestProxyFilterMetadata_DistTagsUpdated(t *testing.T) {
 
 	proxy := &Proxy{
 		policy:  Policy{MinReleaseAge: 72 * time.Hour},
-		allowed: make(map[string]string),
+		allowed: make(map[string]allowedVersion),
 	}
 
 	filtered, blocked := proxy.filterMetadata(body, "express")
@@ -764,7 +764,7 @@ func TestProxyFilterMetadata_UnblockedChannelTagPreserved(t *testing.T) {
 
 	proxy := &Proxy{
 		policy:  Policy{MinReleaseAge: 72 * time.Hour},
-		allowed: make(map[string]string),
+		allowed: make(map[string]allowedVersion),
 	}
 
 	filtered, blocked := proxy.filterMetadata(body, "express")
@@ -810,7 +810,7 @@ func TestProxyFilterMetadata_AllBlocked(t *testing.T) {
 
 	proxy := &Proxy{
 		policy:  Policy{MinReleaseAge: 72 * time.Hour},
-		allowed: make(map[string]string),
+		allowed: make(map[string]allowedVersion),
 	}
 
 	filtered, blocked := proxy.filterMetadata(body, "evil-pkg")


### PR DESCRIPTION
## Related Issue

* [PPSC-958](https://armis-security.atlassian.net/browse/PPSC-958)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

The supply-chain filter summary printed `withheld N prereleases; a default install was unaffected` for PyPI packages that were actually **stable** releases the proxy downgraded — the opposite of what happened. Root cause: for PyPI, `BlockedPackage.Version` holds a *filename* (`filelock-3.29.2.tar.gz`), but `isPrerelease()` split on the first `-` and read every PyPI package as a prerelease, tripping the `onlyPrerelease` framing.

## Solution

Classification now runs on a normalized `DisplayVersion` (semver parsed from the filename) rather than the raw `Version`, so PyPI filenames are no longer misread (genuine npm prereleases like `2.0.0-alpha.1` still classify correctly). The per-line summary is also flipped to lead with the installed safe version and its age, demoting the skipped version to a trailing clause (`● superdialog 0.2.3 installed (8 days old) — skipped 0.2.5 (6 hours old)`); this required threading the resolved version's age through the proxy (`InstalledPackage.Age`), which was previously computed then discarded.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

Rendered all four summary tiers (resolved / mixed-unresolved / install-failed / genuine-prerelease) and confirmed correct framing. Added regression test `TestPrintBlockSummary_PyPIFilenameNotPrerelease` using the reported `filelock`/`superdialog` filenames. Full suite green (2545 passed, 71.3% coverage), `golangci-lint` 0 issues, diff security scan clean.

## Reviewer Notes

`BlockedPackage.Version` stays the raw filename intentionally (it's what makes a block actionable and what proxy tests assert on); only the new `DisplayVersion` is used for classification/display.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] Documentation updated (CHANGELOG entry under [Unreleased])
* [x] No new warnings generated

[PPSC-958]: https://armis-security.atlassian.net/browse/PPSC-958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ