### PR TITLE
[PPSC-984] fix(auth): route region-pinned uploads to correct data plane

### DIFF
--- a/internal/auth/client.go
+++ b/internal/auth/client.go
@@ -17,9 +17,37 @@ const (
 	// maxResponseSize limits auth response body to prevent memory exhaustion attacks
 	maxResponseSize = 1 << 20 // 1MB
 
-	// ProductionBaseURL is the default Armis API endpoint.
+	// ProductionBaseURL is the default Armis API endpoint (US region / primary).
 	ProductionBaseURL = "https://moose.armis.com"
 )
+
+// RegionalBaseURL returns the Armis API base URL for the given region code.
+//
+// The data plane (/api/v1/ingest/*) is physically region-pinned: a JWT issued
+// for one region is rejected by another region's endpoint with a 401. The auth
+// endpoint (/api/v1/auth/token) auto-discovers the region server-side, so the
+// 401 only surfaces on upload — which is why the base URL must encode the region.
+//
+// Region codes are the values issued in the JWT "region" claim (us1, eu1, au1).
+// There are currently two production data planes:
+//   - us1 (primary) -> https://moose.armis.com
+//   - eu1           -> https://eu.moose.armis.com
+//
+// au1 is a valid auth region but has no dedicated data plane yet, so it
+// falls through to the primary host rather than a fabricated one. Unknown or
+// empty regions also fall back to the primary host, so callers may pass an
+// unvalidated flag/env value directly. The explicit allowlist (rather than
+// interpolating the region into the host) prevents an attacker-controlled
+// region from redirecting credentials to an arbitrary host (CWE-918).
+func RegionalBaseURL(region string) string {
+	switch region {
+	case "eu1":
+		return "https://eu.moose.armis.com"
+	default:
+		// "", "us1", "au1", and anything unrecognized resolve to the primary host.
+		return ProductionBaseURL
+	}
+}
 
 // AuthError represents an authentication failure with HTTP status context.
 // This allows callers to distinguish between different failure modes

--- a/internal/auth/client_test.go
+++ b/internal/auth/client_test.go
@@ -77,3 +77,28 @@ func TestAuthClient_SuccessfulAuth(t *testing.T) {
 		t.Errorf("expected region 'us-east-1', got %q", result.Region)
 	}
 }
+
+func TestRegionalBaseURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		region string
+		want   string
+	}{
+		{"empty region falls back to production", "", ProductionBaseURL},
+		{"eu1 maps to EU data plane", "eu1", "https://eu.moose.armis.com"},
+		{"us1 (primary) uses production host", "us1", ProductionBaseURL},
+		{"au1 has no data plane yet, uses production host", "au1", ProductionBaseURL},
+		{"unknown region falls back to production", "mars1", ProductionBaseURL},
+		{"injection attempt falls back to production", "eu1.evil.com", ProductionBaseURL},
+		{"path injection falls back to production", "eu1/path", ProductionBaseURL},
+		{"uppercase region falls back to production", "EU1", ProductionBaseURL},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RegionalBaseURL(tt.region); got != tt.want {
+				t.Errorf("RegionalBaseURL(%q) = %q, want %q", tt.region, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -280,13 +280,19 @@ func getEnvOrDefaultInt(key string, defaultValue int) int {
 }
 
 // getAPIBaseURL returns the Armis API base URL, allowing override via ARMIS_API_URL env var for testing.
-// armis:ignore cwe:918 reason:ARMIS_API_URL is operator-configured; not reachable from external input
+//
+// Precedence: ARMIS_API_URL override > --dev > --region > production. The region
+// must feed the upload endpoint as well as the token exchange; otherwise a
+// region-scoped JWT is presented to the global host and rejected with a 401.
 func getAPIBaseURL() string {
 	if override := os.Getenv("ARMIS_API_URL"); override != "" {
-		return override
+		return override // armis:ignore cwe:918 reason:ARMIS_API_URL is operator-configured; not reachable from external input
 	}
 	if useDev {
 		return devBaseURL
+	}
+	if region != "" {
+		return auth.RegionalBaseURL(region)
 	}
 	return productionBaseURL
 }

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -124,6 +124,8 @@ func TestGetEnvOrDefaultInt(t *testing.T) {
 }
 
 func TestGetAPIBaseURL(t *testing.T) {
+	const testRegion = "eu1"
+
 	t.Run("returns dev URL when useDev is true", func(t *testing.T) {
 		useDev = true
 		defer func() { useDev = false }()
@@ -162,6 +164,48 @@ func TestGetAPIBaseURL(t *testing.T) {
 		defer func() {
 			_ = os.Unsetenv("ARMIS_API_URL")
 			useDev = false
+		}()
+
+		result := getAPIBaseURL()
+		if result != testURL {
+			t.Errorf("Expected env override URL %s, got %s", testURL, result)
+		}
+	})
+
+	t.Run("returns regional URL when region is set", func(t *testing.T) {
+		useDev = false
+		region = testRegion
+		defer func() { region = "" }()
+
+		result := getAPIBaseURL()
+		want := "https://eu.moose.armis.com"
+		if result != want {
+			t.Errorf("Expected regional URL %s, got %s", want, result)
+		}
+	})
+
+	t.Run("useDev takes precedence over region", func(t *testing.T) {
+		useDev = true
+		region = testRegion
+		defer func() {
+			useDev = false
+			region = ""
+		}()
+
+		result := getAPIBaseURL()
+		if result != devBaseURL {
+			t.Errorf("Expected dev URL %s, got %s", devBaseURL, result)
+		}
+	})
+
+	t.Run("ARMIS_API_URL takes precedence over region", func(t *testing.T) {
+		useDev = false
+		region = testRegion
+		testURL := "http://test-server:9090"
+		_ = os.Setenv("ARMIS_API_URL", testURL)
+		defer func() {
+			_ = os.Unsetenv("ARMIS_API_URL")
+			region = ""
 		}()
 
 		result := getAPIBaseURL()

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -126,6 +126,11 @@ func TestGetEnvOrDefaultInt(t *testing.T) {
 func TestGetAPIBaseURL(t *testing.T) {
 	const testRegion = "eu1"
 
+	// Keep the test hermetic: a developer/CI ARMIS_API_URL export must not leak
+	// into the dev/production/regional subtests, which expect the resolved URL.
+	// The override-specific subtests below set ARMIS_API_URL explicitly.
+	t.Setenv("ARMIS_API_URL", "")
+
 	t.Run("returns dev URL when useDev is true", func(t *testing.T) {
 		useDev = true
 		defer func() { useDev = false }()

--- a/internal/install/validate.go
+++ b/internal/install/validate.go
@@ -6,13 +6,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"regexp"
 	"time"
 
 	"github.com/ArmisSecurity/armis-cli/internal/auth"
 )
-
-var validRegion = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 
 const (
 	validateTimeout    = 15 * time.Second
@@ -32,13 +29,7 @@ func resolveBaseURL() string {
 	if override := os.Getenv("ARMIS_API_URL"); override != "" {
 		return override // armis:ignore cwe:918 reason:operator-configured env var; HTTPS enforced by NewAuthClient caller
 	}
-	if region := os.Getenv("ARMIS_REGION"); region != "" {
-		if !validRegion.MatchString(region) {
-			return auth.ProductionBaseURL
-		}
-		return "https://moose." + region + ".armis.com"
-	}
-	return auth.ProductionBaseURL
+	return auth.RegionalBaseURL(os.Getenv("ARMIS_REGION"))
 }
 
 func validateCredentialsWithURL(clientID, clientSecret, baseURL string) error {

--- a/internal/install/validate.go
+++ b/internal/install/validate.go
@@ -24,11 +24,11 @@ func ValidateCredentials(clientID, clientSecret string) error {
 	return validateCredentialsWithURL(clientID, clientSecret, resolveBaseURL())
 }
 
-// armis:ignore cwe:918 reason:ARMIS_API_URL is operator-configured; HTTPS enforced by auth.NewAuthClient below
 func resolveBaseURL() string {
 	if override := os.Getenv("ARMIS_API_URL"); override != "" {
-		return override // armis:ignore cwe:918 reason:operator-configured env var; HTTPS enforced by NewAuthClient caller
+		return override // armis:ignore cwe:918 reason:operator-configured env var; HTTPS enforced by auth.NewAuthClient
 	}
+	// The region path is allowlisted in auth.RegionalBaseURL (no host interpolation), so it needs no suppression.
 	return auth.RegionalBaseURL(os.Getenv("ARMIS_REGION"))
 }
 


### PR DESCRIPTION
## Related Issue

* [PPSC-984](https://armis.atlassian.net/browse/PPSC-984)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

`--region eu1` (and `ARMIS_REGION=eu1`) authenticated successfully but then failed the upload with a 401. The auth endpoint auto-discovers the region server-side, but the data plane (`/api/v1/ingest/*`) is physically region-pinned, so a region-scoped JWT presented to the global `moose.armis.com` host was rejected. Separately, `install/validate.go` built the regional host by string-interpolating the region into `moose.<region>.armis.com`, which is both the wrong URL format for eu1 (the correct host is `eu.moose.armis.com`) and an SSRF-prone pattern (CWE-918) that constructed a host from an unvalidated input.

## Solution

Added `auth.RegionalBaseURL`, an explicit region→host allowlist (eu1 → `eu.moose.armis.com`; everything else falls back to the primary host), and routed `getAPIBaseURL` through it so the upload endpoint matches the JWT's region. Replaced the unsafe string-interpolation in `install/validate.go` with the same allowlist, eliminating the SSRF surface and the wrong eu1 format in one move.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

`TestRegionalBaseURL` covers eu1/us1/au1/empty plus injection attempts (`eu1.evil.com`, `eu1/path`, `EU1`); `TestGetAPIBaseURL` adds the region path and its precedence vs `--dev` and `ARMIS_API_URL`. Full suite green (2596 passed, 71.4% coverage), lint clean, build OK, security scan clean.

## Reviewer Notes

The allowlist intentionally hardcodes hosts rather than deriving them, as defense-in-depth against an attacker-controlled `--region`/`ARMIS_REGION` redirecting credentials to an arbitrary host. au1 is a valid auth region with no data plane yet, so it falls through to the primary host rather than a fabricated one. Server-driven endpoint discovery (the auth response already returns a `region`) is a reasonable future evolution but was deliberately not adopted here to keep the credential-bearing host on a static allowlist.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [ ] Documentation updated (if needed)


[PPSC-984]: https://armis-security.atlassian.net/browse/PPSC-984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ