### PR TITLE
[PPSC-995] feat(supply-chain): add -o/--output flag to check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,9 @@ armis-cli supply-chain check --min-age 7d --exclude "@myorg/*" --fail-on medium
 
 # Machine-readable output for CI
 armis-cli supply-chain check --format sarif --fail-on high
+
+# Write results to a file (format auto-detected from the extension)
+armis-cli supply-chain check -o supply-chain.sarif --fail-on high
 ```
 
 By default `check` only reports packages that are **new** versus the base branch lockfile (auto-detected from `origin/main`). Use `--all` to audit every package, and `--fail-open` to pass when the registry is unreachable.

--- a/internal/cmd/supply_chain_check.go
+++ b/internal/cmd/supply_chain_check.go
@@ -71,6 +71,13 @@ func init() {
 	scCheckCmd.Flags().StringVar(&scLockfile, "lockfile", "", "Explicit lockfile path (overrides auto-detection)")
 	scCheckCmd.Flags().BoolVar(&scAll, "all", false, "Check all packages (disable auto-diff against base branch)")
 	scCheckCmd.Flags().BoolVar(&scFailOpen, "fail-open", false, "Exit 0 on registry errors (fail-open for CI availability)")
+	// --output is a persistent flag on scanCmd, but supply-chain is a sibling of
+	// scan in the command tree and does not inherit it. Register it locally so
+	// `supply-chain check` matches the scan commands: ResolveOutput already
+	// consumes outputFile (file writing, extension-based format auto-detection,
+	// color disabling). -o has no shorthand conflict in the supply-chain subtree.
+	// armis:ignore cwe:73 cwe:22 reason:outputFile is the user-controlled --output CLI flag naming a file on their own machine (same pattern as scan's --output, suppressed at the ResolveOutput/NewFileOutput sink); no trust boundary is crossed
+	scCheckCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write output to file (auto-detects format from extension: .json, .sarif, .xml)")
 
 	supplyChainCmd.AddCommand(scCheckCmd)
 }

--- a/internal/cmd/supply_chain_check_test.go
+++ b/internal/cmd/supply_chain_check_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -250,5 +251,62 @@ func TestRunSupplyChainCheck_EcosystemScopeSkips(t *testing.T) {
 
 	if err := runSupplyChainCheck(cmd, []string{"."}); err != nil {
 		t.Fatalf("expected clean skip, got error: %v", err)
+	}
+}
+
+// TestRunSupplyChainCheck_OutputFlagWritesFile verifies the --output flag is
+// honored end-to-end: results are written to the named file (not stdout) and
+// the format is auto-detected from the extension. An empty lockfile yields zero
+// packages to check, so RunCheck short-circuits before any registry query while
+// the full output pipeline (ResolveOutput → formatter → file) still runs. This
+// is the path that was silently dead before --output was registered on the
+// supply-chain check command.
+func TestRunSupplyChainCheck_OutputFlagWritesFile(t *testing.T) {
+	dir := chdirTemp(t)
+	// An npm lockfile with no packages: nothing to check, no network access.
+	if err := os.WriteFile(filepath.Join(dir, "package-lock.json"),
+		[]byte(`{"lockfileVersion":3,"packages":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	outPath := filepath.Join(dir, "report.sarif")
+
+	// Save/restore every package-level var the check command reads so this test
+	// can't leak state into others sharing the cmd package.
+	origLockfile, origAll, origMinAge, origFormat, origOutput, origFailOn :=
+		scLockfile, scAll, scMinAge, format, outputFile, failOn
+	t.Cleanup(func() {
+		scLockfile, scAll, scMinAge, format, outputFile, failOn =
+			origLockfile, origAll, origMinAge, origFormat, origOutput, origFailOn
+	})
+	scLockfile = "package-lock.json"
+	scAll = true // skip base-lockfile git detection
+	scMinAge = "72h"
+	format = "human"     // left at default; extension should override to SARIF
+	outputFile = outPath // simulate -o report.sarif
+	failOn = []string{"CRITICAL"}
+
+	cmd := newWrapTestCmd() // command with a live context
+	cmd.Flags().StringVar(&scMinAge, "min-age", "72h", "")
+	cmd.Flags().StringSliceVar(&scExclude, "exclude", nil, "")
+	cmd.Flags().BoolVar(&scFailOpen, "fail-open", false, "")
+	// --format must exist (unchanged) so ResolveOutput can consult its .Changed
+	// state to decide whether to auto-detect the format from the extension.
+	cmd.Flags().StringVarP(&format, "format", "f", "human", "")
+
+	if err := runSupplyChainCheck(cmd, []string{"."}); err != nil {
+		t.Fatalf("runSupplyChainCheck: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath) //nolint:gosec // test-controlled temp path
+	if err != nil {
+		t.Fatalf("expected output written to %s: %v", outPath, err)
+	}
+	content := string(data)
+	// Format auto-detected from the .sarif extension: a SARIF document carries a
+	// $schema and runs array. If --output were ignored, the file would not exist;
+	// if extension detection failed, this would be human-styled text instead.
+	if !strings.Contains(content, "$schema") || !strings.Contains(content, "runs") {
+		t.Errorf("output file does not look like SARIF (extension auto-detection failed):\n%s", content)
 	}
 }

--- a/internal/cmd/supply_chain_check_test.go
+++ b/internal/cmd/supply_chain_check_test.go
@@ -282,8 +282,7 @@ func TestRunSupplyChainCheck_OutputFlagWritesFile(t *testing.T) {
 	scLockfile = "package-lock.json"
 	scAll = true // skip base-lockfile git detection
 	scMinAge = "72h"
-	format = "human"     // left at default; extension should override to SARIF
-	outputFile = outPath // simulate -o report.sarif
+	format = "human" // left at default; extension should override to SARIF
 	failOn = []string{"CRITICAL"}
 
 	cmd := newWrapTestCmd() // command with a live context
@@ -293,6 +292,16 @@ func TestRunSupplyChainCheck_OutputFlagWritesFile(t *testing.T) {
 	// --format must exist (unchanged) so ResolveOutput can consult its .Changed
 	// state to decide whether to auto-detect the format from the extension.
 	cmd.Flags().StringVarP(&format, "format", "f", "human", "")
+	// Register -o/--output bound to outputFile exactly as init() does, then drive
+	// the value through the flag (not a direct outputFile = outPath assignment).
+	// This exercises the flag→var binding the PR adds: if the flag were not bound
+	// to outputFile, .Set would not reach the var ResolveOutput reads and the file
+	// would never be written. (Registration on the real scCheckCmd is guarded
+	// separately by TestSupplyChainCheckOutputFlagRegistered.)
+	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "")
+	if err := cmd.Flags().Set("output", outPath); err != nil {
+		t.Fatalf("set --output: %v", err)
+	}
 
 	if err := runSupplyChainCheck(cmd, []string{"."}); err != nil {
 		t.Fatalf("runSupplyChainCheck: %v", err)
@@ -308,5 +317,34 @@ func TestRunSupplyChainCheck_OutputFlagWritesFile(t *testing.T) {
 	// if extension detection failed, this would be human-styled text instead.
 	if !strings.Contains(content, "$schema") || !strings.Contains(content, "runs") {
 		t.Errorf("output file does not look like SARIF (extension auto-detection failed):\n%s", content)
+	}
+}
+
+// TestSupplyChainCheckOutputFlagRegistered guards the exact regression this PR
+// fixes: the real scCheckCmd (built by init()) must expose -o/--output bound to
+// the outputFile var that runSupplyChainCheck reads. Unlike the functional test
+// above — which constructs its own command — this asserts against the package's
+// actual command, so it fails if init() ever stops registering the flag, binds
+// it to the wrong variable, or drops the -o shorthand.
+func TestSupplyChainCheckOutputFlagRegistered(t *testing.T) {
+	f := scCheckCmd.Flags().Lookup("output")
+	if f == nil {
+		t.Fatal("supply-chain check must register the --output flag")
+	}
+	if f.Shorthand != "o" {
+		t.Errorf("--output shorthand = %q, want %q", f.Shorthand, "o")
+	}
+
+	// Setting the flag must reach the outputFile var runSupplyChainCheck reads.
+	orig := outputFile
+	t.Cleanup(func() {
+		outputFile = orig
+		_ = f.Value.Set(orig)
+	})
+	if err := scCheckCmd.Flags().Set("output", "out.sarif"); err != nil {
+		t.Fatalf("set --output: %v", err)
+	}
+	if outputFile != "out.sarif" {
+		t.Errorf("--output not bound to outputFile: outputFile = %q, want %q", outputFile, "out.sarif")
 	}
 }

--- a/internal/supplychain/check/npm.go
+++ b/internal/supplychain/check/npm.go
@@ -17,6 +17,13 @@ type packageLockFile struct {
 }
 
 type packageLockInfo struct {
+	// Name is the real registry package name, present only when it cannot be
+	// derived from the node_modules/ key — i.e. npm aliases
+	// ("alias": "npm:real-pkg@1.2.3"), where the key holds the local alias and
+	// this field holds the package actually fetched from the registry. When set
+	// it must win over the key, or we'd query the registry for the alias (which
+	// usually does not exist at that version) and silently skip the real package.
+	Name     string `json:"name"`
 	Version  string `json:"version"`
 	Resolved string `json:"resolved"`
 	Link     bool   `json:"link"`
@@ -55,7 +62,13 @@ func ParseNPMLockfile(path string) ([]PackageEntry, error) {
 			continue
 		}
 
-		name := extractPackageName(key)
+		// Prefer the explicit "name" field (set for npm aliases) over the name
+		// derived from the node_modules/ key, so an alias is audited under the
+		// real registry package it resolves to rather than the local alias.
+		name := info.Name
+		if name == "" {
+			name = extractPackageName(key)
+		}
 		if name == "" {
 			continue
 		}

--- a/internal/supplychain/check/npm_test.go
+++ b/internal/supplychain/check/npm_test.go
@@ -73,6 +73,48 @@ func TestParseNPMLockfile(t *testing.T) {
 		}
 	})
 
+	t.Run("npm alias uses real registry name", func(t *testing.T) {
+		// An npm alias ("alias": "npm:real-pkg@1.2.3") records the local alias as
+		// the node_modules/ key but the real registry package in the "name" field.
+		// The entry must be audited under "path-to-regexp" (which exists at 6.3.0),
+		// not "path-to-regexp-updated" (the alias, which does not), or the package
+		// silently escapes the age check with a "version not found" warning.
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "alias.json")
+		content := `{"lockfileVersion":3,"packages":{` +
+			`"node_modules/path-to-regexp-updated":{"name":"path-to-regexp","version":"6.3.0","resolved":"https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz"},` +
+			`"node_modules/express":{"version":"4.18.2","resolved":"https://registry.npmjs.org/express/-/express-4.18.2.tgz"}}}`
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		entries, err := ParseNPMLockfile(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var aliasVer string
+		var sawAlias, sawUpdated bool
+		for _, e := range entries {
+			switch e.Name {
+			case "path-to-regexp":
+				sawAlias = true
+				aliasVer = e.Version
+			case "path-to-regexp-updated":
+				sawUpdated = true
+			}
+		}
+		if !sawAlias {
+			t.Error(`alias must be audited under the real name "path-to-regexp"`)
+		}
+		if sawUpdated {
+			t.Error(`alias must not be audited under the local alias "path-to-regexp-updated"`)
+		}
+		if aliasVer != "6.3.0" {
+			t.Errorf("alias version = %q, want 6.3.0", aliasVer)
+		}
+	})
+
 	t.Run("file not found", func(t *testing.T) {
 		_, err := ParseNPMLockfile("nonexistent.json")
 		if err == nil {

--- a/internal/supplychain/registry/npm.go
+++ b/internal/supplychain/registry/npm.go
@@ -35,8 +35,18 @@ type Client struct {
 	cacheLen    atomic.Int64
 }
 
+// registryResponse models the subset of npm package metadata we need. The npm
+// "time" object maps version strings to ISO-8601 publish dates, but it also
+// carries non-date keys whose values are NOT strings — notably "unpublished",
+// an object of the form {"time":"...","versions":[...]} present on any package
+// that ever had a version unpublished. Typing the whole map as
+// map[string]string makes one such object abort json.Unmarshal for the entire
+// document, losing the publish dates of every version (so the package silently
+// escapes the age policy — exactly the typosquat-shaped packages we most want
+// to gate). json.RawMessage defers decoding so each value is parsed lazily, by
+// version, in GetPublishDate.
 type registryResponse struct {
-	Time map[string]string `json:"time"`
+	Time map[string]json.RawMessage `json:"time"`
 }
 
 // PackageRequest identifies a single package version to look up. It is shared
@@ -89,9 +99,17 @@ func (c *Client) GetPublishDate(ctx context.Context, name, version string) (time
 		return time.Time{}, err
 	}
 
-	timeStr, ok := resp.Time[version]
+	raw, ok := resp.Time[version]
 	if !ok {
 		return time.Time{}, fmt.Errorf("version %q not found in registry metadata for %s", version, name)
+	}
+
+	// A version key's value is always an ISO-8601 string. Decode just this entry
+	// (the map is json.RawMessage so non-date keys like "unpublished" never reach
+	// here) and fail clearly if the registry ever hands back a non-string value.
+	var timeStr string
+	if err := json.Unmarshal(raw, &timeStr); err != nil {
+		return time.Time{}, fmt.Errorf("publish time for %s@%s is not a string: %w", name, version, err)
 	}
 
 	t, err := time.Parse(time.RFC3339, timeStr)

--- a/internal/supplychain/registry/npm_test.go
+++ b/internal/supplychain/registry/npm_test.go
@@ -79,6 +79,35 @@ func TestGetPublishDate(t *testing.T) {
 		}
 	})
 
+	t.Run("time map with unpublished object", func(t *testing.T) {
+		// npm includes non-date keys in "time" whose values are objects, not
+		// strings — most commonly "unpublished": {"time":"...","versions":[...]}
+		// on any package that ever unpublished a version. The whole "time" map
+		// must still parse (json.RawMessage), and the requested version's date
+		// must decode correctly rather than the object aborting the parse and
+		// losing every version's publish date.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"time":{` +
+				`"created":"2025-12-04T21:32:57.747Z",` +
+				`"modified":"2025-12-09T03:31:24.890Z",` +
+				`"99.99.1":"2025-12-04T21:33:00.000Z",` +
+				`"99.99.2":"2025-12-05T10:00:00.000Z",` +
+				`"unpublished":{"time":"2025-12-09T03:31:24.890Z","versions":[]}}}`))
+		}))
+		defer server.Close()
+
+		client := NewClientWithHTTP(server.Client(), server.URL)
+		publishTime, err := client.GetPublishDate(context.Background(), "path-to-regexp-updated", "99.99.1")
+		if err != nil {
+			t.Fatalf("unpublished object must not break parsing: %v", err)
+		}
+		expected := time.Date(2025, 12, 4, 21, 33, 0, 0, time.UTC)
+		if !publishTime.Equal(expected) {
+			t.Errorf("expected %v, got %v", expected, publishTime)
+		}
+	})
+
 	t.Run("invalid package name", func(t *testing.T) {
 		client := NewClient()
 		_, err := client.GetPublishDate(context.Background(), "../../../etc/passwd", "1.0.0")


### PR DESCRIPTION
## Related Issue

* [PPSC-995](https://armis.atlassian.net/browse/PPSC-995)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)

## Problem

`supply-chain check` could only emit results to stdout: unlike the `scan` subcommands it had no `-o/--output` flag, because `supply-chain` is a *sibling* of `scan` in the Cobra tree and does not inherit `scan`'s persistent `--output`. While wiring that up, two npm audit-evasion bugs surfaced where packages silently escaped the age check — npm aliases (`"alias": "npm:real-pkg@1.2.3"`) were audited under the local alias key instead of the real registry name, and a non-date `"unpublished"` object key in the registry `time` map aborted JSON decode of the whole document, losing every version's publish date.

## Solution

Register `-o/--output` locally on `supply-chain check` so it reuses the existing `ResolveOutput` pipeline (file writing + extension-based format auto-detection for `.json`/`.sarif`/`.xml`). Prefer the explicit lockfile `name` field over the `node_modules/` key so aliases are audited under their real registry package, and decode the registry `time` map as `json.RawMessage` so non-date keys are parsed lazily per-version instead of crashing the document.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

`/pre-pr-verify` gate: gofmt clean, golangci-lint 0 issues, 2587 tests passed (71.6% coverage), build OK, security scan 0 open findings.

## Reviewer Notes

The `armis:ignore cwe:73 cwe:22` on the new `--output` flag mirrors the existing `scan --output` pattern — `outputFile` is the user-controlled CLI flag naming a file on their own machine, suppressed at the same `ResolveOutput`/`NewFileOutput` sink. No CHANGELOG entry added; this repo updates `docs/CHANGELOG.md` in a dedicated release PR.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated


[PPSC-995]: https://armis-security.atlassian.net/browse/PPSC-995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ