### PR TITLE
[PPSC-997] feat(supply-chain): lead status with a live protection verdict

### DIFF
--- a/internal/cmd/supply_chain_status.go
+++ b/internal/cmd/supply_chain_status.go
@@ -75,12 +75,15 @@ func runSupplyChainStatus(_ *cobra.Command, _ []string) error {
 	fmt.Fprintf(os.Stderr, "\n")
 
 	fmt.Fprintf(os.Stderr, "%s\n", s.SectionTitle.Render("Ecosystems"))
-	ecosystems, err := supplychain.DetectEcosystems(dir)
-	if err != nil {
+	// Walk upward (not just the current directory) so the report matches what the
+	// wrapper would actually enforce: lockfiles at a monorepo/project root are found
+	// even when status runs from a nested subdirectory.
+	ecosystems := supplychain.DetectEcosystemsUpward(dir)
+	if len(ecosystems) == 0 {
 		fmt.Fprintf(os.Stderr, "  %s\n", s.MutedText.Render("(none detected)"))
 	} else {
 		for _, e := range ecosystems {
-			fmt.Fprintf(os.Stderr, "  %-6s %s\n", s.Bold.Render(string(e.Ecosystem)), e.LockfilePath)
+			fmt.Fprintf(os.Stderr, "  %-6s %s\n", s.Bold.Render(string(e.Ecosystem)), displayLockfilePath(e.LockfilePath))
 		}
 	}
 	fmt.Fprintf(os.Stderr, "\n")
@@ -121,6 +124,25 @@ func printEnvStatus(s *output.Styles, key, desc string) {
 	} else {
 		fmt.Fprintf(os.Stderr, "  %s %s %s\n", s.Bold.Render(key), s.MutedText.Render("(unset)"), s.MutedText.Render("— "+desc))
 	}
+}
+
+// displayLockfilePath renders an absolute lockfile path for status output. When
+// the file lives under (or above) the current working directory it is shown
+// relative to the cwd, so an in-directory lockfile reads as "package-lock.json"
+// (as before the upward walk) while a parent-directory one reads as
+// "../package-lock.json" — making it obvious the enforced lockfile is not in the
+// directory the user is standing in. Falls back to the absolute path when a
+// relative form cannot be computed (e.g. a different volume on Windows).
+func displayLockfilePath(abs string) string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return abs
+	}
+	rel, err := filepath.Rel(cwd, abs)
+	if err != nil {
+		return abs
+	}
+	return rel
 }
 
 type statusJSON struct {
@@ -192,16 +214,15 @@ func runSupplyChainStatusJSON(dir string) error {
 		result.Policy.Exclusions = []string{}
 	}
 
-	// `status` reports a best-effort snapshot: a missing lockfile is a valid
-	// empty state, and an unreadable one (permission/I/O) likewise just yields no
-	// ecosystems here rather than failing the whole status read. Either way the
-	// error is intentionally not surfaced — mirroring the human-output path.
-	// armis:ignore cwe:770 cwe:253 reason:result bounded to one entry per known lockfile type (4); a no-lockfile or unreadable-lockfile error is a valid empty state for status output, deliberately ignored
-	ecosystems, _ := supplychain.DetectEcosystems(dir) //nolint:errcheck // no-lockfile is a valid empty state for status
+	// Walk upward so the JSON snapshot matches enforcement (and the human output):
+	// a lockfile at a parent/monorepo root is reported even from a subdirectory.
+	// An empty result is a valid "nothing enforceable from here" state.
+	// armis:ignore cwe:770 reason:result bounded to one entry per known lockfile type; an empty result is a valid no-lockfile state for status output
+	ecosystems := supplychain.DetectEcosystemsUpward(dir)
 	for _, e := range ecosystems {
 		result.Ecosystems = append(result.Ecosystems, statusEcosystemJSON{
 			Name:         string(e.Ecosystem),
-			LockfilePath: e.LockfilePath,
+			LockfilePath: displayLockfilePath(e.LockfilePath),
 		})
 	}
 	if result.Ecosystems == nil {

--- a/internal/cmd/supply_chain_status.go
+++ b/internal/cmd/supply_chain_status.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/ArmisSecurity/armis-cli/internal/output"
 	"github.com/ArmisSecurity/armis-cli/internal/supplychain"
@@ -16,8 +17,17 @@ var scStatusJSON bool
 var scStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show current supply-chain policy and configuration",
-	Long: `Display the current supply-chain policy configuration, detected ecosystems,
-and shell injection status.
+	Long: `Display the current supply-chain policy and where enforcement is wired in.
+
+Sections:
+  Policy            Active rules (min age, exclusions), from the nearest
+                    .armis-supply-chain.yaml searched upward, or defaults.
+  Ecosystems        Lockfiles found from the current directory upward — what an
+                    install run here would audit. Empty does NOT mean unprotected:
+                    wrapped commands still enforce in any project with a lockfile.
+  Shell Integration Which shells have the wrappers installed, and the exact
+                    commands each one guards (npm, pip, …). This is machine-wide.
+  Environment       The ARMIS_SUPPLY_CHAIN* control variables.
 
 Reads from .armis-supply-chain.yaml if present, otherwise shows defaults.`,
 	Example: `  armis-cli supply-chain status`,
@@ -75,12 +85,13 @@ func runSupplyChainStatus(_ *cobra.Command, _ []string) error {
 	fmt.Fprintf(os.Stderr, "\n")
 
 	fmt.Fprintf(os.Stderr, "%s\n", s.SectionTitle.Render("Ecosystems"))
+	fmt.Fprintf(os.Stderr, "  %s\n", s.MutedText.Render("Lockfiles found from here upward (what an install in this directory would audit)"))
 	// Walk upward (not just the current directory) so the report matches what the
 	// wrapper would actually enforce: lockfiles at a monorepo/project root are found
 	// even when status runs from a nested subdirectory.
 	ecosystems := supplychain.DetectEcosystemsUpward(dir)
 	if len(ecosystems) == 0 {
-		fmt.Fprintf(os.Stderr, "  %s\n", s.MutedText.Render("(none detected)"))
+		fmt.Fprintf(os.Stderr, "  %s\n", s.MutedText.Render("(none here) — enforcement still applies when you run a wrapped command in a project that has a lockfile"))
 	} else {
 		for _, e := range ecosystems {
 			fmt.Fprintf(os.Stderr, "  %-6s %s\n", s.Bold.Render(string(e.Ecosystem)), displayLockfilePath(e.LockfilePath))
@@ -94,11 +105,19 @@ func runSupplyChainStatus(_ *cobra.Command, _ []string) error {
 		fmt.Fprintf(os.Stderr, "  %s\n", s.MutedText.Render("(no shells detected)"))
 	} else {
 		for _, sh := range shells {
-			status := s.MutedText.Render("not installed")
-			if supplychain.HasInjection(sh.RCFile) {
-				status = s.SuccessText.Render("active")
+			if !supplychain.HasInjection(sh.RCFile) {
+				fmt.Fprintf(os.Stderr, "  %-6s %s (%s)\n", s.Bold.Render(sh.Name), sh.RCFile, s.MutedText.Render("not installed"))
+				continue
 			}
-			fmt.Fprintf(os.Stderr, "  %-6s %s (%s)\n", s.Bold.Render(sh.Name), sh.RCFile, status)
+			fmt.Fprintf(os.Stderr, "  %-6s %s (%s)\n", s.Bold.Render(sh.Name), sh.RCFile, s.SuccessText.Render("active"))
+			// Surface which commands the injected block actually wraps. status
+			// already reads this RC file to test for the marker; showing the wrapped
+			// set turns a bare "active" into "active, and these 9 commands are
+			// guarded" — the single fact that tells a user enforcement is live even
+			// when no lockfile sits in the current directory.
+			if pms := supplychain.WrappedPMs(sh.RCFile); len(pms) > 0 {
+				fmt.Fprintf(os.Stderr, "         %s %s\n", s.MutedText.Render("wraps:"), s.MutedText.Render(strings.Join(pms, ", ")))
+			}
 		}
 	}
 
@@ -165,9 +184,10 @@ type statusEcosystemJSON struct {
 }
 
 type statusShellJSON struct {
-	Name   string `json:"name"`
-	RCFile string `json:"rc_file"`
-	Active bool   `json:"active"`
+	Name   string   `json:"name"`
+	RCFile string   `json:"rc_file"`
+	Active bool     `json:"active"`
+	Wraps  []string `json:"wraps"`
 }
 
 type statusEnvJSON struct {
@@ -232,10 +252,18 @@ func runSupplyChainStatusJSON(dir string) error {
 	// armis:ignore cwe:770 reason:DetectShells returns at most one entry per known shell (bash/zsh/fish); the result set is bounded by a fixed allowlist, not by attacker input
 	shells := supplychain.DetectShells()
 	for _, sh := range shells {
+		active := supplychain.HasInjection(sh.RCFile)
+		wraps := []string{}
+		if active {
+			if pms := supplychain.WrappedPMs(sh.RCFile); len(pms) > 0 {
+				wraps = pms
+			}
+		}
 		result.Shells = append(result.Shells, statusShellJSON{
 			Name:   sh.Name,
 			RCFile: sh.RCFile,
-			Active: supplychain.HasInjection(sh.RCFile),
+			Active: active,
+			Wraps:  wraps,
 		})
 	}
 	if result.Shells == nil {

--- a/internal/cmd/supply_chain_status.go
+++ b/internal/cmd/supply_chain_status.go
@@ -19,6 +19,11 @@ var scStatusCmd = &cobra.Command{
 	Short: "Show current supply-chain policy and configuration",
 	Long: `Display the current supply-chain policy and where enforcement is wired in.
 
+The first line is the verdict — whether protection is on right now:
+  Protected   wrappers are installed and ARMIS_SUPPLY_CHAIN is not off
+  Disabled    ARMIS_SUPPLY_CHAIN=off overrides all enforcement
+  Not active  no shell wrappers installed (run: armis-cli supply-chain init)
+
 Sections:
   Policy            Active rules (min age, exclusions), from the nearest
                     .armis-supply-chain.yaml searched upward, or defaults.
@@ -40,6 +45,95 @@ func init() {
 	supplyChainCmd.AddCommand(scStatusCmd)
 }
 
+// computeVerdict mirrors the wrap-time gate (supply_chain_wrap.go): an explicit
+// ARMIS_SUPPLY_CHAIN=off disables everything regardless of how it is wired up;
+// otherwise protection is live only if at least one shell has the wrappers
+// installed. uniqueWrapped is the deduplicated command set across shells. The
+// result feeds both the human headline and the --json `verdict` object, so the
+// two can never disagree.
+func computeVerdict(uniqueWrapped []string) statusVerdictJSON {
+	if strings.EqualFold(os.Getenv("ARMIS_SUPPLY_CHAIN"), "off") {
+		return statusVerdictJSON{
+			State:    "disabled",
+			Headline: "Disabled — ARMIS_SUPPLY_CHAIN=off overrides all enforcement",
+		}
+	}
+	if len(uniqueWrapped) == 0 {
+		return statusVerdictJSON{
+			State:    "inactive",
+			Headline: "Not active — no shell wrappers installed. Run: armis-cli supply-chain init",
+		}
+	}
+	// Count the collapsed set (pip + its variants count as one manager) so the
+	// headline number matches the "bun, npm, …, pip (+N variants)" detail; the
+	// raw function count would say "16 commands" next to 8 visible names.
+	managers := len(collapsePipVariants(uniqueWrapped))
+	return statusVerdictJSON{
+		State:        "protected",
+		Headline:     fmt.Sprintf("Protected — %s wrapped (%s)", countNoun(managers, "command"), summarizePMs(uniqueWrapped)),
+		WrappedCount: managers,
+	}
+}
+
+// collapsePipVariants folds pip and its interpreter-specific variants (pip3,
+// pip3.12, …) into a single "pip (+N variants)" token, leaving every other
+// command untouched and in order. A machine with many Python interpreters wraps
+// a dozen pip3.x names that otherwise bury the distinct managers (npm, pnpm, …);
+// collapsing them keeps the wrapped set readable without losing the count.
+func collapsePipVariants(pms []string) []string {
+	var pipVariants int
+	var out []string
+	for _, pm := range pms {
+		if supplychain.IsPipVariant(pm) {
+			pipVariants++
+			continue
+		}
+		out = append(out, pm)
+	}
+	if pipVariants > 0 {
+		if extra := pipVariants - 1; extra > 0 {
+			out = append(out, fmt.Sprintf("pip (+%s)", countNoun(extra, "variant")))
+		} else {
+			out = append(out, "pip")
+		}
+	}
+	return out
+}
+
+// summarizePMs renders a wrapped-command list compactly for the one-line
+// headline: pip variants are collapsed (collapsePipVariants), then at most the
+// first few names are shown with a "+N more" tail so the verdict stays to one
+// line even on a machine that wraps everything.
+func summarizePMs(pms []string) string {
+	const maxShown = 4
+
+	display := collapsePipVariants(pms)
+	if len(display) <= maxShown {
+		return strings.Join(display, ", ")
+	}
+	return fmt.Sprintf("%s, +%d more", strings.Join(display[:maxShown], ", "), len(display)-maxShown)
+}
+
+// uniqueWrappedPMs returns the deduplicated command set wrapped across all
+// detected shells, preserving first-seen order. Most machines wrap the same set
+// in every shell, so this is what the headline counts (8 commands, not 16).
+func uniqueWrappedPMs(shells []supplychain.Shell) []string {
+	seen := make(map[string]bool)
+	var all []string
+	for _, sh := range shells {
+		if !supplychain.HasInjection(sh.RCFile) {
+			continue
+		}
+		for _, pm := range supplychain.WrappedPMs(sh.RCFile) {
+			if !seen[pm] {
+				seen[pm] = true
+				all = append(all, pm)
+			}
+		}
+	}
+	return all
+}
+
 func runSupplyChainStatus(_ *cobra.Command, _ []string) error {
 	dir := "."
 
@@ -51,6 +145,19 @@ func runSupplyChainStatus(_ *cobra.Command, _ []string) error {
 
 	fmt.Fprintf(os.Stderr, "%s\n", s.HeaderBanner.Render("Supply Chain Status"))
 	fmt.Fprintf(os.Stderr, "%s\n\n", s.FooterSeparator.Render("═══════════════════"))
+
+	// Lead with the verdict: the whole point of `status` is to answer "is
+	// protection on right now?" without making the reader cross-reference the
+	// sections below. Detect shells once and reuse the result for both the
+	// headline and the Shell Integration section.
+	shells := supplychain.DetectShells()
+	verdict := computeVerdict(uniqueWrappedPMs(shells))
+	switch verdict.State {
+	case "protected":
+		fmt.Fprintf(os.Stderr, "%s %s\n\n", s.SuccessText.Render(output.IconSuccess), s.Bold.Render(verdict.Headline))
+	default:
+		fmt.Fprintf(os.Stderr, "%s %s\n\n", s.WarningText.Render("⚠"), s.Bold.Render(verdict.Headline))
+	}
 
 	cfg, configDir, err := loadConfigUpward(dir)
 	if err != nil {
@@ -100,7 +207,6 @@ func runSupplyChainStatus(_ *cobra.Command, _ []string) error {
 	fmt.Fprintf(os.Stderr, "\n")
 
 	fmt.Fprintf(os.Stderr, "%s\n", s.SectionTitle.Render("Shell Integration"))
-	shells := supplychain.DetectShells()
 	if len(shells) == 0 {
 		fmt.Fprintf(os.Stderr, "  %s\n", s.MutedText.Render("(no shells detected)"))
 	} else {
@@ -114,9 +220,10 @@ func runSupplyChainStatus(_ *cobra.Command, _ []string) error {
 			// already reads this RC file to test for the marker; showing the wrapped
 			// set turns a bare "active" into "active, and these 9 commands are
 			// guarded" — the single fact that tells a user enforcement is live even
-			// when no lockfile sits in the current directory.
+			// when no lockfile sits in the current directory. pip variants are
+			// collapsed so a dozen pip3.x names don't drown out the distinct managers.
 			if pms := supplychain.WrappedPMs(sh.RCFile); len(pms) > 0 {
-				fmt.Fprintf(os.Stderr, "         %s %s\n", s.MutedText.Render("wraps:"), s.MutedText.Render(strings.Join(pms, ", ")))
+				fmt.Fprintf(os.Stderr, "         %s %s\n", s.MutedText.Render("wraps:"), s.MutedText.Render(strings.Join(collapsePipVariants(pms), ", ")))
 			}
 		}
 	}
@@ -165,10 +272,21 @@ func displayLockfilePath(abs string) string {
 }
 
 type statusJSON struct {
+	Verdict     statusVerdictJSON     `json:"verdict"`
 	Policy      statusPolicyJSON      `json:"policy"`
 	Ecosystems  []statusEcosystemJSON `json:"ecosystems"`
 	Shells      []statusShellJSON     `json:"shells"`
 	Environment statusEnvJSON         `json:"environment"`
+}
+
+// statusVerdictJSON is the machine-readable headline: a stable `state` enum
+// (protected | disabled | inactive) so CI can gate on protection with
+// `jq -e '.verdict.state == "protected"'` instead of inferring it from the
+// shells array, plus the human one-liner and the wrapped-command count.
+type statusVerdictJSON struct {
+	State        string `json:"state"`
+	Headline     string `json:"headline"`
+	WrappedCount int    `json:"wrapped_count"`
 }
 
 type statusPolicyJSON struct {
@@ -253,6 +371,9 @@ func runSupplyChainStatusJSON(dir string) error {
 	shells := supplychain.DetectShells()
 	for _, sh := range shells {
 		active := supplychain.HasInjection(sh.RCFile)
+		// JSON keeps the full, uncollapsed command list (pip3.11, pip3.12, …) so
+		// machine consumers get exact data; the human view collapses pip variants
+		// for readability, but a script may want every name.
 		wraps := []string{}
 		if active {
 			if pms := supplychain.WrappedPMs(sh.RCFile); len(pms) > 0 {
@@ -269,6 +390,10 @@ func runSupplyChainStatusJSON(dir string) error {
 	if result.Shells == nil {
 		result.Shells = []statusShellJSON{}
 	}
+
+	// Headline verdict, computed from the same signals as the human output so the
+	// two never disagree.
+	result.Verdict = computeVerdict(uniqueWrappedPMs(shells))
 
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")

--- a/internal/cmd/supply_chain_status.go
+++ b/internal/cmd/supply_chain_status.go
@@ -52,6 +52,7 @@ func init() {
 // result feeds both the human headline and the --json `verdict` object, so the
 // two can never disagree.
 func computeVerdict(uniqueWrapped []string) statusVerdictJSON {
+	// armis:ignore cwe:285 cwe:284 cwe:862 cwe:863 reason:this only *reports* protection state for `status` output and enforces nothing; the actual gate is supply_chain_wrap.go (envSCOff), and ARMIS_SUPPLY_CHAIN=off is a documented user-controlled master switch for the user's own machine, not a crossable authorization boundary
 	if strings.EqualFold(os.Getenv("ARMIS_SUPPLY_CHAIN"), "off") {
 		return statusVerdictJSON{
 			State:    "disabled",
@@ -76,10 +77,14 @@ func computeVerdict(uniqueWrapped []string) statusVerdictJSON {
 }
 
 // collapsePipVariants folds pip and its interpreter-specific variants (pip3,
-// pip3.12, …) into a single "pip (+N variants)" token, leaving every other
-// command untouched and in order. A machine with many Python interpreters wraps
-// a dozen pip3.x names that otherwise bury the distinct managers (npm, pnpm, …);
-// collapsing them keeps the wrapped set readable without losing the count.
+// pip3.12, …) into a single "pip (+N variants)" token. Every non-pip command
+// keeps its relative order; the collapsed pip token is appended once at the end
+// regardless of where pip appeared in the input (so e.g. ["pip","npm"] renders
+// as ["npm","pip"]). That trailing placement is intentional — pip is the noisy
+// family and reads best grouped last — and the wrappers never emit pip first in
+// practice. A machine with many Python interpreters wraps a dozen pip3.x names
+// that otherwise bury the distinct managers (npm, pnpm, …); collapsing them
+// keeps the wrapped set readable without losing the count.
 func collapsePipVariants(pms []string) []string {
 	var pipVariants int
 	var out []string
@@ -121,9 +126,9 @@ func uniqueWrappedPMs(shells []supplychain.Shell) []string {
 	seen := make(map[string]bool)
 	var all []string
 	for _, sh := range shells {
-		if !supplychain.HasInjection(sh.RCFile) {
-			continue
-		}
+		// WrappedPMs already returns nil for an unreadable file or one with no
+		// injected block, so it is its own presence check — no separate
+		// HasInjection read is needed (that would open each RC file twice).
 		for _, pm := range supplychain.WrappedPMs(sh.RCFile) {
 			if !seen[pm] {
 				seen[pm] = true

--- a/internal/cmd/supply_chain_status_test.go
+++ b/internal/cmd/supply_chain_status_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestCollapsePipVariants(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "no pip leaves the list untouched",
+			in:   []string{"npm", "pnpm", "bun"},
+			want: []string{"npm", "pnpm", "bun"},
+		},
+		{
+			name: "bare pip only renders as plain pip",
+			in:   []string{"npm", "pip"},
+			want: []string{"npm", "pip"},
+		},
+		{
+			name: "pip plus variants collapse to a single token with the extra count",
+			in:   []string{"npm", "pip", "pip3", "pip3.11", "pip3.12"},
+			want: []string{"npm", "pip (+3 variants)"},
+		},
+		{
+			name: "a single versioned variant with no bare pip still collapses",
+			in:   []string{"uv", "pip3.12"},
+			want: []string{"uv", "pip"},
+		},
+		{
+			name: "exactly one extra variant uses the singular noun",
+			in:   []string{"pip", "pip3"},
+			want: []string{"pip (+1 variant)"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := collapsePipVariants(tt.in)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("collapsePipVariants(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSummarizePMs(t *testing.T) {
+	t.Run("short lists render in full", func(t *testing.T) {
+		got := summarizePMs([]string{"npm", "pnpm"})
+		if got != "npm, pnpm" {
+			t.Errorf("summarizePMs = %q, want %q", got, "npm, pnpm")
+		}
+	})
+
+	t.Run("long lists truncate with a +N more tail", func(t *testing.T) {
+		// 7 distinct managers (no pip) → show 4, then "+3 more".
+		got := summarizePMs([]string{"npm", "pnpm", "bun", "yarn", "uv", "poetry", "pdm"})
+		if !strings.HasSuffix(got, ", +3 more") {
+			t.Errorf("summarizePMs = %q, want a '+3 more' suffix", got)
+		}
+		if strings.Count(got, ",") != 4 { // 4 names shown (3 commas) + the "+3 more" comma
+			t.Errorf("summarizePMs = %q, expected exactly 4 names before the tail", got)
+		}
+	})
+
+	t.Run("pip variants are collapsed before truncating", func(t *testing.T) {
+		// 3 managers + a pile of pip variants must read as 4 tokens, not be
+		// pushed into a "+N more" by the pip3.x noise.
+		// pip + 4 variants (pip3, pip3.11, pip3.12, pip3.13) → "pip (+4 variants)".
+		got := summarizePMs([]string{"npm", "pnpm", "uv", "pip", "pip3", "pip3.11", "pip3.12", "pip3.13"})
+		want := "npm, pnpm, uv, pip (+4 variants)"
+		if got != want {
+			t.Errorf("summarizePMs = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestComputeVerdict(t *testing.T) {
+	t.Run("ARMIS_SUPPLY_CHAIN=off is disabled regardless of wrappers", func(t *testing.T) {
+		t.Setenv("ARMIS_SUPPLY_CHAIN", "OFF") // case-insensitive, mirrors the wrap gate
+		v := computeVerdict([]string{"npm", "pnpm"})
+		if v.State != "disabled" {
+			t.Errorf("State = %q, want disabled", v.State)
+		}
+		if !strings.Contains(v.Headline, "ARMIS_SUPPLY_CHAIN=off") {
+			t.Errorf("Headline = %q, want it to name the override", v.Headline)
+		}
+	})
+
+	t.Run("no wrappers is inactive and points at init", func(t *testing.T) {
+		t.Setenv("ARMIS_SUPPLY_CHAIN", "")
+		v := computeVerdict(nil)
+		if v.State != "inactive" {
+			t.Errorf("State = %q, want inactive", v.State)
+		}
+		if !strings.Contains(v.Headline, "supply-chain init") {
+			t.Errorf("Headline = %q, want it to suggest init", v.Headline)
+		}
+		if v.WrappedCount != 0 {
+			t.Errorf("WrappedCount = %d, want 0", v.WrappedCount)
+		}
+	})
+
+	t.Run("wrappers present is protected with a collapsed count", func(t *testing.T) {
+		t.Setenv("ARMIS_SUPPLY_CHAIN", "")
+		// 3 managers + 3 pip-family names → 4 distinct managers (pip counts once).
+		v := computeVerdict([]string{"npm", "pnpm", "uv", "pip", "pip3", "pip3.12"})
+		if v.State != "protected" {
+			t.Errorf("State = %q, want protected", v.State)
+		}
+		if v.WrappedCount != 4 {
+			t.Errorf("WrappedCount = %d, want 4 (pip family counts once)", v.WrappedCount)
+		}
+		if !strings.HasPrefix(v.Headline, "Protected — 4 commands wrapped") {
+			t.Errorf("Headline = %q, want it to lead with the collapsed count", v.Headline)
+		}
+	})
+}

--- a/internal/supplychain/detect.go
+++ b/internal/supplychain/detect.go
@@ -93,6 +93,54 @@ func DetectEcosystems(dir string) ([]DetectedEcosystem, error) {
 	return detected, nil
 }
 
+// DetectEcosystemsUpward reports which package-manager ecosystems are enforceable
+// from startDir, mirroring how the wrapper actually discovers lockfiles at install
+// time. Each canonical ecosystem's lockfile is located by walking up from startDir
+// to the filesystem root (as FindEcosystemLockfile does), so a lockfile sitting at
+// a monorepo or project root is reported even when the command runs from a nested
+// subdirectory — the same directories enforcement searches. Non-canonical
+// ecosystems (pip's requirements.txt has no fixed name or location, and enforcement
+// never walks up for it) are probed only in startDir itself.
+//
+// Unlike DetectEcosystems, this is for status/reporting: an empty result is a
+// normal "nothing enforceable from here" state, returned as an empty slice rather
+// than an error. Returned paths are absolute so callers can render them however
+// they like (e.g. relative to the cwd).
+func DetectEcosystemsUpward(startDir string) []DetectedEcosystem {
+	base, err := filepath.Abs(startDir)
+	if err != nil {
+		base = startDir
+	}
+
+	var detected []DetectedEcosystem
+	for _, c := range lockfileChecks {
+		if c.canonical {
+			// FindUpward stats a constant-literal leaf name against the user's own
+			// project tree (existence check only) — same bounded, in-tree probe as
+			// DetectEcosystems, just across parent directories too.
+			if p := FindUpward(base, c.file); p != "" {
+				detected = append(detected, DetectedEcosystem{
+					Ecosystem:    c.ecosystem,
+					LockfilePath: p,
+				})
+			}
+			continue
+		}
+		// requirements.txt (pip): no canonical name, so there is nothing to walk up
+		// for — probe only the start directory, matching enforcement.
+		// armis:ignore cwe:22 cwe:23 cwe:73 reason:c.file is a constant literal lockfile name and only os.Stat (existence check) runs against the user's own project dir, so the path is not externally controllable across a trust boundary
+		path := filepath.Join(base, c.file)
+		// armis:ignore cwe:22 cwe:23 cwe:73 reason:c.file is a constant literal lockfile leaf and only os.Stat (existence check) runs, so the path is not externally controllable across a trust boundary
+		if _, err := os.Stat(path); err == nil {
+			detected = append(detected, DetectedEcosystem{
+				Ecosystem:    c.ecosystem,
+				LockfilePath: path,
+			})
+		}
+	}
+	return detected
+}
+
 // FindEcosystemLockfile locates the lockfile for a specific ecosystem by walking
 // up from startDir to the filesystem root, returning the path of the first match.
 // Package managers like poetry/pdm/pipenv are routinely invoked from a project

--- a/internal/supplychain/detect_test.go
+++ b/internal/supplychain/detect_test.go
@@ -118,6 +118,73 @@ func TestDetectEcosystems(t *testing.T) {
 	})
 }
 
+func TestDetectEcosystemsUpward(t *testing.T) {
+	t.Run("detects a canonical lockfile in the start directory", func(t *testing.T) {
+		dir := t.TempDir()
+		want := filepath.Join(dir, "package-lock.json")
+		os.WriteFile(want, []byte("{}"), 0o644) //nolint:errcheck,gosec
+
+		got := DetectEcosystemsUpward(dir)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 ecosystem, got %d (%v)", len(got), got)
+		}
+		if got[0].Ecosystem != EcosystemNPM {
+			t.Errorf("expected npm, got %s", got[0].Ecosystem)
+		}
+		if got[0].LockfilePath != want {
+			t.Errorf("LockfilePath = %q, want %q", got[0].LockfilePath, want)
+		}
+	})
+
+	t.Run("walks up to find a parent-directory lockfile", func(t *testing.T) {
+		// This is the behavior status was missing: a lockfile at the project/monorepo
+		// root must be reported even when status runs from a nested subdirectory,
+		// because that is the lockfile the wrapper would actually enforce.
+		root := t.TempDir()
+		want := filepath.Join(root, "poetry.lock")
+		os.WriteFile(want, []byte(""), 0o644) //nolint:errcheck,gosec
+		sub := filepath.Join(root, "service", "nested")
+		if err := os.MkdirAll(sub, 0o750); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+
+		got := DetectEcosystemsUpward(sub)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 ecosystem from subdir, got %d (%v)", len(got), got)
+		}
+		if got[0].Ecosystem != EcosystemPoetry || got[0].LockfilePath != want {
+			t.Errorf("got %+v, want poetry at %q", got[0], want)
+		}
+	})
+
+	t.Run("does not walk up for pip's non-canonical requirements.txt", func(t *testing.T) {
+		// requirements.txt has no fixed name or location and enforcement never walks
+		// up for it, so a parent-directory requirements.txt must not be reported from
+		// a subdirectory — otherwise status would claim enforcement that won't happen.
+		root := t.TempDir()
+		os.WriteFile(filepath.Join(root, "requirements.txt"), []byte(""), 0o644) //nolint:errcheck,gosec
+		sub := filepath.Join(root, "sub")
+		if err := os.MkdirAll(sub, 0o750); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+
+		if got := DetectEcosystemsUpward(sub); len(got) != 0 {
+			t.Errorf("expected no ecosystems from subdir (pip is not canonical), got %v", got)
+		}
+
+		// But it is detected when present in the start directory itself.
+		if got := DetectEcosystemsUpward(root); len(got) != 1 || got[0].Ecosystem != EcosystemPip {
+			t.Errorf("expected pip detected in its own directory, got %v", got)
+		}
+	})
+
+	t.Run("returns empty (not error) when nothing is enforceable", func(t *testing.T) {
+		if got := DetectEcosystemsUpward(t.TempDir()); len(got) != 0 {
+			t.Errorf("expected empty result, got %v", got)
+		}
+	})
+}
+
 func TestFindEcosystemLockfile(t *testing.T) {
 	t.Run("finds lockfile in the start directory", func(t *testing.T) {
 		dir := t.TempDir()

--- a/internal/supplychain/shell.go
+++ b/internal/supplychain/shell.go
@@ -360,6 +360,55 @@ func HasInjection(path string) bool {
 	return strings.Contains(string(content), markerStart)
 }
 
+// wrappedPMLine matches a single package-manager wrapper declaration inside an
+// injected block, capturing the command name. It accepts both shapes the
+// generators emit: POSIX/zsh `name() {` and fish `function name`. The name class
+// mirrors validPMName (lowercase, digits, hyphen, dotted numeric suffix), so it
+// captures versioned pip variants (pip3.12) without matching arbitrary lines.
+var wrappedPMLine = regexp.MustCompile(`(?m)^(?:function\s+([a-z][a-z0-9.-]*)|([a-z][a-z0-9.-]*)\(\)\s*\{)`)
+
+// WrappedPMs returns the package-manager command names wrapped by the injected
+// block in path, in the order they appear (deduplicated). It is the read-side
+// companion to InjectFunctions: `supply-chain status` already reads the RC file
+// to test for the marker (HasInjection), and this surfaces *which* commands the
+// block guards so status can show "npm, pnpm, pip, …" instead of a bare "active".
+// Returns nil when the file is unreadable or contains no injected block, so an
+// absent or never-initialized shell is a normal empty result, not an error.
+func WrappedPMs(path string) []string {
+	// armis:ignore cwe:22 cwe:23 cwe:73 reason:path is a shell RC file under the current user's own $HOME (see DetectShells); reading the user's RC file to report which commands are wrapped is the purpose of `supply-chain status`
+	content, err := os.ReadFile(path) //nolint:gosec // user's own RC file
+	if err != nil {
+		return nil
+	}
+
+	// Scope parsing to the injected block: a user may define their own functions
+	// named npm/pip elsewhere in the RC file, and those are not armis wrappers.
+	text := string(content)
+	start := strings.Index(text, markerStart)
+	if start == -1 {
+		return nil
+	}
+	block := text[start:]
+	if end := strings.Index(block, markerEnd); end != -1 {
+		block = block[:end]
+	}
+
+	var pms []string
+	seen := make(map[string]bool)
+	for _, m := range wrappedPMLine.FindAllStringSubmatch(block, -1) {
+		name := m[1] // fish: `function name`
+		if name == "" {
+			name = m[2] // posix: `name() {`
+		}
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		pms = append(pms, name)
+	}
+	return pms
+}
+
 // HasCurrentInjection reports whether path already contains the exact wrapper
 // block that would be written for the given shell and PMs. Unlike HasInjection,
 // which only checks for the marker, this verifies the content matches so callers

--- a/internal/supplychain/shell.go
+++ b/internal/supplychain/shell.go
@@ -363,9 +363,10 @@ func HasInjection(path string) bool {
 // wrappedPMLine matches a single package-manager wrapper declaration inside an
 // injected block, capturing the command name. It accepts both shapes the
 // generators emit: POSIX/zsh `name() {` and fish `function name`. The name class
-// mirrors validPMName (lowercase, digits, hyphen, dotted numeric suffix), so it
-// captures versioned pip variants (pip3.12) without matching arbitrary lines.
-var wrappedPMLine = regexp.MustCompile(`(?m)^(?:function\s+([a-z][a-z0-9.-]*)|([a-z][a-z0-9.-]*)\(\)\s*\{)`)
+// mirrors validPMName exactly (lowercase start, then lowercase/digit/hyphen, with
+// at most one dotted-numeric suffix), so it captures versioned pip variants
+// (pip3.12) while rejecting names the generators never emit (e.g. foo.bar).
+var wrappedPMLine = regexp.MustCompile(`(?m)^(?:function\s+([a-z][a-z0-9-]*(?:\.[0-9]+)?)|([a-z][a-z0-9-]*(?:\.[0-9]+)?)\(\)\s*\{)`)
 
 // WrappedPMs returns the package-manager command names wrapped by the injected
 // block in path, in the order they appear (deduplicated). It is the read-side
@@ -388,10 +389,17 @@ func WrappedPMs(path string) []string {
 	if start == -1 {
 		return nil
 	}
-	block := text[start:]
-	if end := strings.Index(block, markerEnd); end != -1 {
-		block = block[:end]
+	// Require the closing marker: parse strictly between markerStart and markerEnd.
+	// A block with no end marker is malformed (a truncated/hand-edited RC file), and
+	// parsing to EOF would sweep in any user-defined npm/pip functions written after
+	// it — exactly the misattribution this scoping exists to prevent. Treat it as no
+	// injected block rather than risk reporting non-armis functions as wrapped.
+	rest := text[start:]
+	end := strings.Index(rest, markerEnd)
+	if end == -1 {
+		return nil
 	}
+	block := rest[:end]
 
 	var pms []string
 	seen := make(map[string]bool)

--- a/internal/supplychain/shell_test.go
+++ b/internal/supplychain/shell_test.go
@@ -661,6 +661,20 @@ func TestWrappedPMs(t *testing.T) {
 		}
 	})
 
+	t.Run("returns nil for a block missing its end marker", func(t *testing.T) {
+		// A start marker with no closing marker is a malformed/truncated block.
+		// Parsing it to EOF would sweep in user functions written after the
+		// (never-closed) block, so it must be treated as no injected block. Build
+		// such a file by stripping the end marker from a real wrapper, then append
+		// a user-defined function that must NOT be reported.
+		full := GenerateWrapper(shellBash, []string{"npm"})
+		truncated := strings.Replace(full, markerEnd, "", 1)
+		body := truncated + "\nyarn() { echo mine; }\n"
+		if got := WrappedPMs(writeRC(t, body)); got != nil {
+			t.Errorf("WrappedPMs = %v, want nil for a block with no end marker", got)
+		}
+	})
+
 	t.Run("returns nil for an unreadable file", func(t *testing.T) {
 		if got := WrappedPMs(filepath.Join(t.TempDir(), "does-not-exist")); got != nil {
 			t.Errorf("WrappedPMs = %v, want nil for a missing file", got)

--- a/internal/supplychain/shell_test.go
+++ b/internal/supplychain/shell_test.go
@@ -615,3 +615,55 @@ func TestResolveCliPath_FallsBackToAbsWhenNotOnPath(t *testing.T) {
 		t.Errorf("resolveCliPath() = %q, want an absolute path or the %q fallback", got, cliBinaryName)
 	}
 }
+
+func TestWrappedPMs(t *testing.T) {
+	writeRC := func(t *testing.T, body string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "rc")
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write rc: %v", err)
+		}
+		return path
+	}
+
+	t.Run("parses the PMs from a posix block in order", func(t *testing.T) {
+		rc := writeRC(t, GenerateWrapper(shellBash, []string{"npm", "pnpm", "pip3.12"}))
+		got := WrappedPMs(rc)
+		want := []string{"npm", "pnpm", "pip3.12"}
+		if !slices.Equal(got, want) {
+			t.Errorf("WrappedPMs = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("parses the PMs from a fish block", func(t *testing.T) {
+		rc := writeRC(t, GenerateWrapper(shellFish, []string{"npm", "uv", "uvx"}))
+		got := WrappedPMs(rc)
+		want := []string{"npm", "uv", "uvx"}
+		if !slices.Equal(got, want) {
+			t.Errorf("WrappedPMs = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("ignores user functions outside the injected block", func(t *testing.T) {
+		// A user's own npm function defined before the marker must not be reported
+		// as armis-wrapped — only declarations inside the marked block count.
+		body := "npm() { echo mine; }\n" + GenerateWrapper(shellBash, []string{"pnpm"})
+		got := WrappedPMs(writeRC(t, body))
+		want := []string{"pnpm"}
+		if !slices.Equal(got, want) {
+			t.Errorf("WrappedPMs = %v, want %v (must skip the pre-marker npm)", got, want)
+		}
+	})
+
+	t.Run("returns nil when no block is present", func(t *testing.T) {
+		if got := WrappedPMs(writeRC(t, "export PATH=/usr/bin\n")); got != nil {
+			t.Errorf("WrappedPMs = %v, want nil for a file with no injected block", got)
+		}
+	})
+
+	t.Run("returns nil for an unreadable file", func(t *testing.T) {
+		if got := WrappedPMs(filepath.Join(t.TempDir(), "does-not-exist")); got != nil {
+			t.Errorf("WrappedPMs = %v, want nil for a missing file", got)
+		}
+	})
+}


### PR DESCRIPTION
## Related Issue

* [PPSC-997](https://armis.atlassian.net/browse/PPSC-997)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)

## Problem

`supply-chain status` answered the wrong question: it only probed the current directory for lockfiles (so a monorepo root lockfile read as "(none detected)" from a subdir), it never showed *which* commands the installed shell wrappers actually guard, and a reader had to cross-reference the sections to answer the one thing that matters — "is protection on right now?"

## Solution

Status now leads with a one-line verdict (`Protected` / `Disabled` / `Not active`) computed by a single `computeVerdict` shared by both human and `--json` output so they can never disagree; ecosystem detection walks upward (`DetectEcosystemsUpward`) to mirror what the wrapper actually enforces at install time; and a new `WrappedPMs` parser scopes a regex to the injected marker block to surface the guarded commands (`wraps: npm, pnpm, pip …`, pip variants collapsed) without misreading a user's own `npm()` function. The `--json` payload gains a stable `verdict.state` enum (CI can gate with `jq -e '.verdict.state == "protected"'`) and a per-shell `wraps` array.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

`make test` (2609 passed, 2 skipped, 71.2% coverage), `make lint` (golangci-lint v2.12.2, 0 issues), `make build`, and a clean `scan_diff` against `main`. New table-driven tests cover `computeVerdict`, `collapsePipVariants`, `summarizePMs`, `DetectEcosystemsUpward` (incl. the upward-walk and pip-not-canonical cases), and `WrappedPMs` (posix/fish blocks, pre-marker user functions, unreadable files).

## Reviewer Notes

The upward walk deliberately does **not** apply to pip's non-canonical `requirements.txt` (no fixed name/location, enforcement never walks up for it) — verified by test so status never claims enforcement that won't happen. CHANGELOG entry intentionally deferred until the PR number exists, per the repo's `(#NNN)`-tagged convention.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated


[PPSC-997]: https://armis-security.atlassian.net/browse/PPSC-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ