### PR TITLE
[PPSC-1007] fix(ux): error message quality — problem + cause + fix

### DIFF
--- a/internal/agentdetect/agentdetect_test.go
+++ b/internal/agentdetect/agentdetect_test.go
@@ -185,6 +185,36 @@ func TestFormatPlain(t *testing.T) {
 	if !strings.Contains(output, "Copilot(MCP:false)") {
 		t.Error("expected 'Copilot(MCP:false)' in output")
 	}
+	// At least one agent has MCP:false, so the remediation hint must appear.
+	if !strings.Contains(output, "armis-cli install") {
+		t.Errorf("expected install hint when an agent lacks MCP, got:\n%s", output)
+	}
+}
+
+func TestFormatPlain_AllMCPInstalled_NoHint(t *testing.T) {
+	cli.InitColors(cli.ColorModeNever)
+	output.SyncColors()
+
+	result := &ScanResult{
+		Users: []UserResult{
+			{
+				User: "John",
+				Agents: []DetectedAgent{
+					{Name: "ClaudeCode", MCPInstalled: true, User: "John"},
+					{Name: "Cursor", MCPInstalled: true, User: "John"},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := FormatPlain(result, &buf); err != nil {
+		t.Fatalf("FormatPlain() error: %v", err)
+	}
+
+	if strings.Contains(buf.String(), "armis-cli install") {
+		t.Errorf("did not expect install hint when all agents have MCP, got:\n%s", buf.String())
+	}
 }
 
 func TestFormatPlain_NoAgentsForUser(t *testing.T) {

--- a/internal/agentdetect/format.go
+++ b/internal/agentdetect/format.go
@@ -60,9 +60,11 @@ func FormatPlain(result *ScanResult, w io.Writer) error {
 
 // anyMCPMissing reports whether at least one detected agent lacks the Armis MCP.
 func anyMCPMissing(result *ScanResult) bool {
-	for _, agent := range result.FlatResults() {
-		if !agent.MCPInstalled {
-			return true
+	for _, u := range result.Users {
+		for _, agent := range u.Agents {
+			if !agent.MCPInstalled {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/agentdetect/format.go
+++ b/internal/agentdetect/format.go
@@ -43,7 +43,29 @@ func FormatPlain(result *ScanResult, w io.Writer) error {
 			return err
 		}
 	}
+
+	// MCP:false renders in red above; tell the user how to fix it rather than
+	// leaving the red status with no next step. Shown once, after all users.
+	if anyMCPMissing(result) {
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+		hint := s.MutedText.Render("Run 'armis-cli install' to enable Armis AppSec MCP for detected agents.")
+		if _, err := fmt.Fprintln(w, hint); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// anyMCPMissing reports whether at least one detected agent lacks the Armis MCP.
+func anyMCPMissing(result *ScanResult) bool {
+	for _, agent := range result.FlatResults() {
+		if !agent.MCPInstalled {
+			return true
+		}
+	}
+	return false
 }
 
 // FormatJSON writes the flat JSON array of all detected agents.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -92,7 +92,7 @@ func NewAuthProvider(config AuthConfig) (*AuthProvider, error) {
 			return nil, fmt.Errorf("tenant ID required: use --tenant-id flag or ARMIS_TENANT_ID environment variable")
 		}
 	} else {
-		return nil, fmt.Errorf("authentication required: set ARMIS_CLIENT_ID and ARMIS_CLIENT_SECRET for JWT auth, or ARMIS_API_TOKEN for legacy auth")
+		return nil, fmt.Errorf("authentication required: set ARMIS_CLIENT_ID / ARMIS_CLIENT_SECRET (or use --client-id / --client-secret) for JWT auth, or ARMIS_API_TOKEN (--token) for legacy auth")
 	}
 
 	return p, nil

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -181,6 +181,15 @@ func init() {
 	// The help function is inherited by all subcommands added later
 	SetupHelp(rootCmd)
 
+	// Append a help hint to flag-parse errors. SilenceUsage suppresses the full
+	// usage dump, so without this an "unknown flag" error leaves the user with no
+	// next step. Cobra walks up to the parent's FlagErrorFunc when a subcommand
+	// has none, so registering it on rootCmd covers every subcommand. CommandPath()
+	// yields the full path (e.g. "armis-cli scan repo"), unlike Name() (leaf only).
+	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return fmt.Errorf("%w\n\nRun '%s --help' for usage", err, cmd.CommandPath())
+	})
+
 	// Legacy Basic authentication
 	rootCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "API token for Basic authentication (env: ARMIS_API_TOKEN)")
 	rootCmd.PersistentFlags().StringVar(&tenantID, "tenant-id", "", "Tenant identifier for Armis Cloud (env: ARMIS_TENANT_ID)")

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -709,6 +709,29 @@ func TestPrintUpdateNotification(t *testing.T) {
 	})
 }
 
+// TestFlagErrorFunc_AppendsHelpHint verifies the FlagErrorFunc registered on
+// rootCmd appends a "--help" hint using the full command path (not just the leaf
+// name) so users get an actionable next step despite SilenceUsage.
+func TestFlagErrorFunc_AppendsHelpHint(t *testing.T) {
+	fn := rootCmd.FlagErrorFunc()
+	if fn == nil {
+		t.Fatal("expected a FlagErrorFunc to be registered on rootCmd")
+	}
+
+	// scanRepoCmd is a nested subcommand; its full path is "armis-cli scan repo".
+	err := fn(scanRepoCmd, fmt.Errorf("unknown flag: --bogus-flag"))
+	if err == nil {
+		t.Fatal("expected FlagErrorFunc to return an error")
+	}
+	msg := err.Error()
+	if !testutil.ContainsSubstring(msg, "unknown flag: --bogus-flag") {
+		t.Errorf("expected original flag error preserved, got: %s", msg)
+	}
+	if !testutil.ContainsSubstring(msg, "armis-cli scan repo --help") {
+		t.Errorf("expected full-path help hint 'armis-cli scan repo --help', got: %s", msg)
+	}
+}
+
 // TestGetAuthProvider_NoCredentials tests auth provider creation with no credentials.
 func TestGetAuthProvider_NoCredentials(t *testing.T) {
 	// Save original values

--- a/internal/cmd/scan_image.go
+++ b/internal/cmd/scan_image.go
@@ -49,6 +49,14 @@ var scanImageCmd = &cobra.Command{
 			}
 		}
 
+		// Surface a missing container runtime before auth. Scanning by image name
+		// exports via Docker/Podman, so a dev with no runtime would otherwise hit
+		// the auth error first and never learn the real blocker. --tarball bypasses
+		// the daemon, so skip this check on that path.
+		if tarballPath == "" && !image.IsDockerAvailable() {
+			return image.ErrRuntimeNotFound
+		}
+
 		authProvider, err := getAuthProvider()
 		if err != nil {
 			return err

--- a/internal/scan/image/helpers_test.go
+++ b/internal/scan/image/helpers_test.go
@@ -3,6 +3,7 @@ package image
 import (
 	"io"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -263,8 +264,24 @@ func TestNewScanner(t *testing.T) {
 	}
 }
 
+func TestErrRuntimeNotFound_Message(t *testing.T) {
+	msg := ErrRuntimeNotFound.Error()
+	// Three-tier message: names the problem, points at install docs, and offers
+	// the --tarball escape hatch that bypasses the daemon.
+	for _, want := range []string{
+		"container runtime not found",
+		"docs.docker.com",
+		"podman.io",
+		"--tarball",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("ErrRuntimeNotFound message missing %q, got: %s", want, msg)
+		}
+	}
+}
+
 func TestIsDockerAvailable(t *testing.T) {
-	result := isDockerAvailable()
+	result := IsDockerAvailable()
 
 	if result {
 		t.Log("Docker is available on this system")
@@ -320,7 +337,7 @@ func TestValidateDockerCommand(t *testing.T) {
 }
 
 func TestImageExistsLocally(t *testing.T) {
-	if !isDockerAvailable() {
+	if !IsDockerAvailable() {
 		t.Skip("Docker/Podman not available, skipping imageExistsLocally tests")
 	}
 

--- a/internal/scan/image/image.go
+++ b/internal/scan/image/image.go
@@ -29,6 +29,11 @@ const (
 	podmanBinary = "podman"
 )
 
+// ErrRuntimeNotFound is returned when neither Docker nor Podman is available to
+// export an image. The message names the problem, the cause, and the fixes:
+// install a runtime, or bypass the daemon entirely with --tarball.
+var ErrRuntimeNotFound = errors.New("container runtime not found: install Docker (https://docs.docker.com/get-docker/) or Podman (https://podman.io); or use --tarball ./image.tar to scan a pre-exported image")
+
 // Scanner scans container images for security vulnerabilities.
 type Scanner struct {
 	client                *api.Client
@@ -92,8 +97,8 @@ func (s *Scanner) ScanImage(ctx context.Context, imageName string) (*model.ScanR
 	}
 	imageName = normalised
 
-	if !isDockerAvailable() {
-		return nil, fmt.Errorf("container runtime not found: install Docker or Podman")
+	if !IsDockerAvailable() {
+		return nil, ErrRuntimeNotFound
 	}
 
 	tmpFile, err := os.CreateTemp("", "armis-image-*.tar")
@@ -282,13 +287,17 @@ func (s *Scanner) exportImage(ctx context.Context, imageName, outputPath string)
 	return nil
 }
 
+// IsDockerAvailable reports whether a container runtime (Docker or Podman) is
+// reachable on the host. Callers use it to fail fast before auth/network work
+// when an image must be exported via the daemon.
 // armis:ignore cwe:426 reason:exec.Command uses hardcoded binary names ("docker", "podman"); no untrusted path
-func isDockerAvailable() bool {
+func IsDockerAvailable() bool {
 	cmd := exec.Command("docker", "version")
 	if err := cmd.Run(); err == nil {
 		return true
 	}
 
+	// armis:ignore cwe:426 cwe:427 reason:exec.Command uses hardcoded binary name ("podman"); no untrusted path
 	cmd = exec.Command("podman", "version")
 	if err := cmd.Run(); err == nil {
 		return true

--- a/internal/scan/image/image.go
+++ b/internal/scan/image/image.go
@@ -31,8 +31,8 @@ const (
 
 // ErrRuntimeNotFound is returned when neither Docker nor Podman is available to
 // export an image. The message names the problem, the cause, and the fixes:
-// install a runtime, or bypass the daemon entirely with --tarball.
-var ErrRuntimeNotFound = errors.New("container runtime not found: install Docker (https://docs.docker.com/get-docker/) or Podman (https://podman.io); or use --tarball ./image.tar to scan a pre-exported image")
+// install a runtime or start its daemon, or bypass the daemon entirely with --tarball.
+var ErrRuntimeNotFound = errors.New("container runtime not found or not running: install Docker (https://docs.docker.com/get-docker/) or Podman (https://podman.io) and ensure the daemon is running; or use --tarball ./image.tar to scan a pre-exported image")
 
 // Scanner scans container images for security vulnerabilities.
 type Scanner struct {
@@ -290,15 +290,14 @@ func (s *Scanner) exportImage(ctx context.Context, imageName, outputPath string)
 // IsDockerAvailable reports whether a container runtime (Docker or Podman) is
 // reachable on the host. Callers use it to fail fast before auth/network work
 // when an image must be exported via the daemon.
-// armis:ignore cwe:426 reason:exec.Command uses hardcoded binary names ("docker", "podman"); no untrusted path
+// armis:ignore cwe:426 cwe:427 reason:exec.Command uses hardcoded binary constants (dockerBinary/podmanBinary); no untrusted path
 func IsDockerAvailable() bool {
-	cmd := exec.Command("docker", "version")
+	cmd := exec.Command(dockerBinary, "version")
 	if err := cmd.Run(); err == nil {
 		return true
 	}
 
-	// armis:ignore cwe:426 cwe:427 reason:exec.Command uses hardcoded binary name ("podman"); no untrusted path
-	cmd = exec.Command("podman", "version")
+	cmd = exec.Command(podmanBinary, "version")
 	if err := cmd.Run(); err == nil {
 		return true
 	}


### PR DESCRIPTION
## Related Issue

* [PPSC-1007](https://armis-security.atlassian.net/browse/PPSC-1007)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

Several CLI error paths left users with incomplete information: the auth error omitted flag-path alternatives, unknown-flag errors had no help hint despite `SilenceUsage: true`, scanning an image with no container runtime surfaced the auth error before the real blocker, and `MCP:false` in agent-detect output showed red with no remediation step.

## Solution

Applied the Elm/Rust/Stripe three-tier model (problem + cause + fix) to each error:
- `auth.go`: auth error now names both env vars and flag equivalents (`--client-id`/`--client-secret`, `--token`)
- `root.go`: `SetFlagErrorFunc` appends `Run '<full-cmd> --help' for usage` to every flag-parse error across all subcommands
- `scan_image.go` + `image.go`: pre-auth runtime check returns `ErrRuntimeNotFound` with Docker/Podman install URLs and the `--tarball` escape hatch; `IsDockerAvailable()` exported for early call
- `agentdetect/format.go`: `FormatPlain` appends `armis-cli install` hint after the agent list when any agent has `MCPInstalled=false`

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally (2657 tests, 71.7% coverage)

### Manual Testing

Verified each error path produces actionable output with the new hint appended.

## Reviewer Notes

`IsDockerAvailable()` is now exported (capital I) — callers in `image.go` and `scan_image.go` updated accordingly. The `armis:ignore cwe:426 cwe:427` suppression on the `podman` sink in `IsDockerAvailable` is a FP: both binary names are hardcoded constants with no user-controlled input.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-1007]: https://armis-security.atlassian.net/browse/PPSC-1007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ