### PR TITLE
docs: update CHANGELOG for v1.15.0 (PPSC-1023)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,18 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- First-run onboarding now reaches a working command faster. The README leads with a "Try it without credentials" Quick Start that runs `supply-chain check` against public registries with no Armis account, and the Quick Start section now precedes the release-verification material (the SLSA/cosign/SBOM steps are collapsed into an expandable block) so an install-to-scan reader is no longer interrupted by 96 lines of signature verification. The credential-setup steps now link to where the VIPR client credentials live, and the auth `401` error message points to the same place ("get credentials from the VIPR external API screen in the Armis Platform") instead of saying only "invalid credentials". The README "General Flags" table and environment-variable table now document the previously-missing `--color`, `--theme`, `--no-update-check`, and `--dev` flags and the `ARMIS_THEME` / `ARMIS_NO_UPDATE_CHECK` variables. (#236)
-- `auth`: the Armis cloud region is now auto-detected from your credentials, so non-US customers no longer need to pass `--region` on every scan. The token exchange already discovers the region server-side and returns it in the JWT (with a response-body fallback for older tokens); the CLI now reads that region and routes the region-pinned data plane (upload, status polling, results) to the matching host automatically. Explicit configuration still wins — `ARMIS_API_URL`, `--dev`, and `--region`/`ARMIS_REGION` are honored ahead of the discovered region, and legacy Basic auth or tokens without a region claim fall back to the primary host. (PPSC-1018)
-
 ### Deprecated
 
 ### Removed
 
 ### Fixed
 
-- `scan`: the `--include-non-exploitable` filter now correctly hides low/medium exploitability findings. The backend's exploitability label schema changed from a boolean (`Exploitable: true/false`) to a graded one (`Exploitability Level: low/medium/high`), which left the old filter matching nothing — the flag was effectively a no-op. Findings graded low or medium are now hidden by default, while high-exploitability and ungraded findings (SCA, container CVEs, false positives) are always shown. Pass `--include-non-exploitable` to restore the previous behavior of showing every finding (PPSC-1015)
-
 ### Security
+
+---
+
+## [1.15.0] - 2026-06-23
+
+### Changed
+
+- First-run onboarding now reaches a working command faster. The README leads with a "Try it without credentials" Quick Start that runs `supply-chain check` against public registries with no Armis account, and the Quick Start section now precedes the release-verification material (the SLSA/cosign/SBOM steps are collapsed into an expandable block) so an install-to-scan reader is no longer interrupted by 96 lines of signature verification. The credential-setup steps now link to where the VIPR client credentials live, and the auth `401` error message points to the same place ("get credentials from the VIPR external API screen in the Armis Platform") instead of saying only "invalid credentials". The README "General Flags" table and environment-variable table now document the previously-missing `--color`, `--theme`, `--no-update-check`, and `--dev` flags and the `ARMIS_THEME` / `ARMIS_NO_UPDATE_CHECK` variables. (#236)
+- `auth`: the Armis cloud region is now auto-detected from your credentials, so non-US customers no longer need to pass `--region` on every scan. The token exchange already discovers the region server-side and returns it in the JWT (with a response-body fallback for older tokens); the CLI now reads that region and routes the region-pinned data plane (upload, status polling, results) to the matching host automatically. Explicit configuration still wins — `ARMIS_API_URL`, `--dev`, and `--region`/`ARMIS_REGION` are honored ahead of the discovered region, and legacy Basic auth or tokens without a region claim fall back to the primary host. (PPSC-1018)
+
+### Fixed
+
+- `scan`: the `--include-non-exploitable` filter now correctly hides low/medium exploitability findings. The backend's exploitability label schema changed from a boolean (`Exploitable: true/false`) to a graded one (`Exploitability Level: low/medium/high`), which left the old filter matching nothing — the flag was effectively a no-op. Findings graded low or medium are now hidden by default, while high-exploitability and ungraded findings (SCA, container CVEs, false positives) are always shown. Pass `--include-non-exploitable` to restore the previous behavior of showing every finding (PPSC-1015)
 
 ---
 
@@ -507,7 +515,8 @@ Manual entries for significant releases:
 
 -->
 
-[Unreleased]: https://github.com/ArmisSecurity/armis-cli/compare/v1.14.0...HEAD
+[Unreleased]: https://github.com/ArmisSecurity/armis-cli/compare/v1.15.0...HEAD
+[1.15.0]: https://github.com/ArmisSecurity/armis-cli/compare/v1.14.0...v1.15.0
 [1.14.0]: https://github.com/ArmisSecurity/armis-cli/compare/v1.13.0...v1.14.0
 [1.13.0]: https://github.com/ArmisSecurity/armis-cli/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/ArmisSecurity/armis-cli/compare/v1.11.1...v1.12.0


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v1.15.0 release
- Release ticket: https://armis-security.atlassian.net/browse/PPSC-1023

## Changes since v1.14.0
- `auth`: auto-detect region from credentials (#237)
- `docs`: credential-free Quick Start (#236)
- `scan`: repair dead exploitability filter for graded labels (#233)

## Checklist
- [x] CHANGELOG updated
- [x] Version bump validated (semver: MINOR)
