### PR TITLE
[PPSC-1006] fix(scan): validate flags before auth and network

### DIFF
--- a/internal/cmd/scan.go
+++ b/internal/cmd/scan.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ArmisSecurity/armis-cli/internal/cli"
+	"github.com/ArmisSecurity/armis-cli/internal/cmd/cmdutil"
 	"github.com/ArmisSecurity/armis-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -83,6 +85,25 @@ var scanCmd = &cobra.Command{
 		const maxUploadTimeout = 120 // 2 hours
 		if uploadTimeout > maxUploadTimeout {
 			return fmt.Errorf("invalid --upload-timeout value %d: must not exceed %d minutes", uploadTimeout, maxUploadTimeout)
+		}
+
+		// Validate --fail-on early so a typo (e.g. HIGHT) surfaces as a flag error
+		// instead of silently defaulting once auth succeeds. ValidateFailOn also
+		// normalizes the slice to uppercase in place, so the GetFailOn calls in the
+		// subcommands' RunE become idempotent re-validation.
+		if err := cmdutil.ValidateFailOn(failOn); err != nil {
+			return err
+		}
+
+		// Warn early if SBOM/VEX output paths are given without their generation
+		// flags. These are persistent flags shared by `scan repo` and `scan image`,
+		// so surfacing the misuse here (before auth) keeps both commands consistent
+		// and stops the warning from hiding behind an auth error in CI.
+		if sbomOutput != "" && !generateSBOM {
+			cli.PrintWarning("--sbom-output is ignored without --sbom flag")
+		}
+		if vexOutput != "" && !generateVEX {
+			cli.PrintWarning("--vex-output is ignored without --vex flag")
 		}
 
 		return nil

--- a/internal/cmd/scan_image.go
+++ b/internal/cmd/scan_image.go
@@ -33,11 +33,17 @@ var scanImageCmd = &cobra.Command{
 		// flag error rather than hiding behind an auth failure. This mirrors the
 		// allowlist in determinePullBehavior, which only runs after auth + the docker
 		// check; "" is excluded here because the flag default is "missing".
-		switch pullPolicy {
-		case "always", "missing", "never":
-			// valid
-		default:
-			return fmt.Errorf("invalid --pull value %q: must be one of [always missing never]", pullPolicy)
+		//
+		// Only validate on the image-name path: --pull is documented as "Ignored
+		// when --tarball is used" (tarball scans never pull), so rejecting a bad
+		// --pull alongside --tarball would contradict the flag's contract.
+		if tarballPath == "" {
+			switch pullPolicy {
+			case "always", "missing", "never":
+				// valid
+			default:
+				return fmt.Errorf("invalid --pull value %q: must be one of [always missing never]", pullPolicy)
+			}
 		}
 
 		if tarballPath == "" && len(args) == 0 {

--- a/internal/cmd/scan_image.go
+++ b/internal/cmd/scan_image.go
@@ -29,6 +29,17 @@ var scanImageCmd = &cobra.Command{
   $ armis-cli scan image alpine:3.18 --sbom --vex --fail-on HIGH,CRITICAL`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Validate --pull before auth so a bad value (e.g. "badvalue") surfaces as a
+		// flag error rather than hiding behind an auth failure. This mirrors the
+		// allowlist in determinePullBehavior, which only runs after auth + the docker
+		// check; "" is excluded here because the flag default is "missing".
+		switch pullPolicy {
+		case "always", "missing", "never":
+			// valid
+		default:
+			return fmt.Errorf("invalid --pull value %q: must be one of [always missing never]", pullPolicy)
+		}
+
 		if tarballPath == "" && len(args) == 0 {
 			return fmt.Errorf("missing target: specify an image name or use --tarball")
 		}
@@ -78,13 +89,8 @@ var scanImageCmd = &cobra.Command{
 		scanner := image.NewScanner(client, noProgress, tid, limit, includeTests, scanTimeoutDuration, includeNonExploitable).
 			WithPullPolicy(pullPolicy)
 
-		// Warn if output paths are specified without the corresponding generation flags
-		if sbomOutput != "" && !generateSBOM {
-			cli.PrintWarning("--sbom-output is ignored without --sbom flag")
-		}
-		if vexOutput != "" && !generateVEX {
-			cli.PrintWarning("--vex-output is ignored without --vex flag")
-		}
+		// --sbom-output/--vex-output misuse is warned about in scan.PersistentPreRunE
+		// (before auth), so no warning is emitted here.
 
 		// Configure SBOM/VEX options if any flags are set
 		if generateSBOM || generateVEX {

--- a/internal/cmd/scan_image_test.go
+++ b/internal/cmd/scan_image_test.go
@@ -171,4 +171,25 @@ func TestScanImageRunE_PullPolicyValidation(t *testing.T) {
 			}
 		})
 	}
+
+	// --pull is documented as "Ignored when --tarball is used", so a bad --pull
+	// must NOT be rejected on the tarball path. With --tarball set to a missing
+	// file, RunE skips the pull check and reaches the tarball-existence guard;
+	// seeing that error (not the pull error) proves --pull was ignored.
+	t.Run("invalid pull ignored when tarball is set", func(t *testing.T) {
+		pullPolicy = "badvalue"
+		tarballPath = "/nonexistent/does-not-exist.tar"
+		t.Cleanup(func() { tarballPath = "" })
+
+		err := scanImageCmd.RunE(scanImageCmd, []string{})
+		if err == nil {
+			t.Fatal("expected tarball-does-not-exist error")
+		}
+		if testutil.ContainsSubstring(err.Error(), "invalid --pull value") {
+			t.Errorf("--pull must be ignored with --tarball, but it was rejected: %v", err)
+		}
+		if !testutil.ContainsSubstring(err.Error(), "tarball does not exist") {
+			t.Errorf("expected tarball-does-not-exist error, got: %v", err)
+		}
+	})
 }

--- a/internal/cmd/scan_image_test.go
+++ b/internal/cmd/scan_image_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"os"
 	"testing"
+
+	"github.com/ArmisSecurity/armis-cli/internal/testutil"
 )
 
 func TestScanImageRunE_MissingTarget(t *testing.T) {
@@ -105,4 +107,68 @@ func TestScanImageRunE_TarballScan(t *testing.T) {
 	// Note: This test requires a running mock server and a valid tarball
 	// For now, we just verify that the command validates inputs correctly
 	t.Skip("Full tarball scan test requires mock server integration")
+}
+
+// TestScanImageRunE_PullPolicyValidation verifies --pull is validated at the top
+// of RunE, before auth/network (PPSC-1006 #16). An invalid value must error with
+// the pull message; valid values must pass that check (here surfacing the
+// downstream "missing target" error, which proves the pull check let them
+// through). No ARMIS_API_URL is set, so reaching auth would fail differently.
+func TestScanImageRunE_PullPolicyValidation(t *testing.T) {
+	originalPullPolicy := pullPolicy
+	originalTarballPath := tarballPath
+	originalColorFlag := colorFlag
+	originalThemeFlag := themeFlag
+	originalNoUpdateCheck := noUpdateCheck
+
+	t.Cleanup(func() {
+		pullPolicy = originalPullPolicy
+		tarballPath = originalTarballPath
+		colorFlag = originalColorFlag
+		themeFlag = originalThemeFlag
+		noUpdateCheck = originalNoUpdateCheck
+	})
+
+	tarballPath = ""
+	colorFlag = testColorNever
+	themeFlag = themeAuto
+	noUpdateCheck = true
+
+	t.Run("invalid pull errors before missing-target", func(t *testing.T) {
+		pullPolicy = "badvalue"
+		err := scanImageCmd.RunE(scanImageCmd, []string{})
+		if err == nil {
+			t.Fatal("expected error for invalid --pull value")
+		}
+		if !testutil.ContainsSubstring(err.Error(), "invalid --pull value") {
+			t.Errorf("error should mention 'invalid --pull value', got: %v", err)
+		}
+	})
+
+	t.Run("empty pull rejected", func(t *testing.T) {
+		pullPolicy = ""
+		err := scanImageCmd.RunE(scanImageCmd, []string{})
+		if err == nil || !testutil.ContainsSubstring(err.Error(), "invalid --pull value") {
+			t.Errorf("expected invalid --pull error for empty value, got: %v", err)
+		}
+	})
+
+	for _, valid := range []string{"always", "missing", "never"} {
+		t.Run("valid pull "+valid+" passes the check", func(t *testing.T) {
+			pullPolicy = valid
+			// No image and no tarball: the pull check passes, so RunE proceeds to
+			// the missing-target guard. Seeing that error (not the pull error)
+			// confirms the valid value was accepted.
+			err := scanImageCmd.RunE(scanImageCmd, []string{})
+			if err == nil {
+				t.Fatalf("expected missing-target error for valid --pull %q", valid)
+			}
+			if testutil.ContainsSubstring(err.Error(), "invalid --pull value") {
+				t.Errorf("valid --pull %q wrongly rejected: %v", valid, err)
+			}
+			if !testutil.ContainsSubstring(err.Error(), "missing target") {
+				t.Errorf("expected missing-target error for valid --pull %q, got: %v", valid, err)
+			}
+		})
+	}
 }

--- a/internal/cmd/scan_repo.go
+++ b/internal/cmd/scan_repo.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/ArmisSecurity/armis-cli/internal/api"
-	"github.com/ArmisSecurity/armis-cli/internal/cli"
 	"github.com/ArmisSecurity/armis-cli/internal/cmd/cmdutil"
 	"github.com/ArmisSecurity/armis-cli/internal/output"
 	"github.com/ArmisSecurity/armis-cli/internal/scan"
@@ -33,9 +32,15 @@ var scanRepoCmd = &cobra.Command{
   $ armis-cli scan repo . --changed
   $ armis-cli scan repo . --changed=staged
   $ armis-cli scan repo . --changed=main`,
-	Args: cobra.ExactArgs(1),
+	// MaximumNArgs(1) (not ExactArgs(1)) makes the `[path]` in Use honest: the path
+	// is optional and defaults to the current directory, matching every example and
+	// `scan image`'s arg handling.
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		repoPath := args[0]
+		repoPath := "."
+		if len(args) > 0 {
+			repoPath = args[0]
+		}
 
 		// Validate path exists and is a directory before making network calls
 		// armis:ignore cwe:22 reason:os.Stat is read-only existence check; path is from direct CLI arg, not untrusted input
@@ -78,13 +83,8 @@ var scanRepoCmd = &cobra.Command{
 		scanTimeoutDuration := time.Duration(scanTimeout) * time.Minute
 		scanner := repo.NewScanner(client, noProgress, tid, limit, includeTests, scanTimeoutDuration, includeNonExploitable)
 
-		// Warn if output paths are specified without the corresponding generation flags
-		if sbomOutput != "" && !generateSBOM {
-			cli.PrintWarning("--sbom-output is ignored without --sbom flag")
-		}
-		if vexOutput != "" && !generateVEX {
-			cli.PrintWarning("--vex-output is ignored without --vex flag")
-		}
+		// --sbom-output/--vex-output misuse is warned about in scan.PersistentPreRunE
+		// (before auth), so no warning is emitted here.
 
 		// Configure SBOM/VEX options if any flags are set
 		if generateSBOM || generateVEX {

--- a/internal/cmd/scan_repo_test.go
+++ b/internal/cmd/scan_repo_test.go
@@ -76,6 +76,62 @@ func TestScanRepoRunE_SuccessfulScan(t *testing.T) {
 	}
 }
 
+// TestScanRepoRunE_DefaultsToCurrentDir verifies that `scan repo` with no path
+// argument defaults to "." instead of erroring with "accepts 1 arg(s)"
+// (PPSC-1006 #18). The command chdirs into a temp repo so "." resolves there.
+func TestScanRepoRunE_DefaultsToCurrentDir(t *testing.T) {
+	findings := []model.NormalizedFinding{
+		testhelpers.CreateNormalizedFinding("repo-finding-1", "HIGH", "sql_injection", []string{"CVE-2024-1111"}, []string{"CWE-89"}),
+	}
+	serverURL := testutil.GetMockServerURL(t, findings)
+
+	dir := chdirTemp(t)
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n\nfunc main() {}"), 0600); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	originalToken := token
+	originalTenantID := tenantID
+	originalClientID := clientID
+	originalClientSecret := clientSecret
+	originalFormat := format
+	originalColorFlag := colorFlag
+	originalThemeFlag := themeFlag
+	originalNoUpdateCheck := noUpdateCheck
+	originalNoProgress := noProgress
+
+	t.Cleanup(func() {
+		token = originalToken
+		tenantID = originalTenantID
+		clientID = originalClientID
+		clientSecret = originalClientSecret
+		format = originalFormat
+		colorFlag = originalColorFlag
+		themeFlag = originalThemeFlag
+		noUpdateCheck = originalNoUpdateCheck
+		noProgress = originalNoProgress
+		_ = os.Unsetenv("ARMIS_API_URL")
+	})
+
+	_ = os.Setenv("ARMIS_API_URL", serverURL)
+	t.Setenv("ARMIS_CLIENT_ID", "")
+	t.Setenv("ARMIS_CLIENT_SECRET", "")
+	token = testToken
+	tenantID = testTenantID
+	clientID = ""
+	clientSecret = ""
+	format = agentFormatJSON
+	colorFlag = testColorNever
+	themeFlag = themeAuto
+	noUpdateCheck = true
+	noProgress = true
+
+	// No path argument: RunE must default repoPath to "." (the temp dir).
+	if err := scanRepoCmd.RunE(scanRepoCmd, []string{}); err != nil {
+		t.Fatalf("expected scan of '.' to succeed with no path arg, got error: %v", err)
+	}
+}
+
 func TestScanRepoRunE_IncludeFilesValidation(t *testing.T) {
 	// Save and restore global state
 	originalToken := token

--- a/internal/cmd/scan_test.go
+++ b/internal/cmd/scan_test.go
@@ -83,10 +83,12 @@ func TestScanRepoCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("repo command requires exactly one arg", func(t *testing.T) {
+	t.Run("repo command accepts zero or one arg", func(t *testing.T) {
+		// PPSC-1006 #18: the path is optional and defaults to "." in RunE, so
+		// MaximumNArgs(1) accepts zero args; only two or more are rejected.
 		err := scanRepoCmd.Args(scanRepoCmd, []string{})
-		if err == nil {
-			t.Error("Expected error when no args provided")
+		if err != nil {
+			t.Errorf("Expected no error when no args provided (path defaults to '.'), got %v", err)
 		}
 
 		err = scanRepoCmd.Args(scanRepoCmd, []string{"path1", "path2"})
@@ -426,6 +428,76 @@ func TestScanPersistentPreRunE(t *testing.T) {
 		}
 		if err != nil && !testutil.ContainsSubstring(err.Error(), "invalid --color value") {
 			t.Errorf("expected error from root PreRunE, got: %v", err)
+		}
+	})
+
+	// --fail-on is validated in PersistentPreRunE (PPSC-1006 #17) so a typo surfaces
+	// as a flag error before auth, not as a silent default after auth succeeds.
+	t.Run("fail-on", func(t *testing.T) {
+		originalFailOn := failOn
+		t.Cleanup(func() { failOn = originalFailOn })
+
+		format = testFormatHuman
+		groupBy = testGroupByNone
+		colorFlag = testColorAuto
+
+		t.Run("valid uppercase passes", func(t *testing.T) {
+			failOn = []string{"HIGH", "CRITICAL"}
+			if err := scanCmd.PersistentPreRunE(scanCmd, []string{}); err != nil {
+				t.Errorf("expected no error for valid --fail-on, got: %v", err)
+			}
+		})
+
+		t.Run("lowercase accepted and normalized in place", func(t *testing.T) {
+			failOn = []string{"medium"}
+			if err := scanCmd.PersistentPreRunE(scanCmd, []string{}); err != nil {
+				t.Errorf("expected lowercase --fail-on to be accepted, got: %v", err)
+			}
+			if failOn[0] != "MEDIUM" {
+				t.Errorf("expected --fail-on normalized to MEDIUM, got: %q", failOn[0])
+			}
+		})
+
+		t.Run("typo returns error", func(t *testing.T) {
+			failOn = []string{"HIGHT"}
+			err := scanCmd.PersistentPreRunE(scanCmd, []string{})
+			if err == nil {
+				t.Error("expected error for invalid --fail-on 'HIGHT'")
+			}
+			if err != nil && !testutil.ContainsSubstring(err.Error(), "invalid severity level") {
+				t.Errorf("error should mention 'invalid severity level', got: %v", err)
+			}
+		})
+	})
+
+	// --sbom-output/--vex-output without their generation flags is a non-fatal
+	// warning, now emitted before auth (PPSC-1006 #25). The pre-run must still
+	// succeed (no error) on this path.
+	t.Run("sbom/vex output without generation flag warns but does not error", func(t *testing.T) {
+		originalFailOn := failOn
+		originalSBOMOutput := sbomOutput
+		originalVEXOutput := vexOutput
+		originalGenerateSBOM := generateSBOM
+		originalGenerateVEX := generateVEX
+		t.Cleanup(func() {
+			failOn = originalFailOn
+			sbomOutput = originalSBOMOutput
+			vexOutput = originalVEXOutput
+			generateSBOM = originalGenerateSBOM
+			generateVEX = originalGenerateVEX
+		})
+
+		format = testFormatHuman
+		groupBy = testGroupByNone
+		colorFlag = testColorAuto
+		failOn = []string{"CRITICAL"}
+		sbomOutput = "sbom.json"
+		vexOutput = "vex.json"
+		generateSBOM = false
+		generateVEX = false
+
+		if err := scanCmd.PersistentPreRunE(scanCmd, []string{}); err != nil {
+			t.Errorf("expected no error on misuse-warning path, got: %v", err)
 		}
 	})
 }

--- a/internal/cmd/supply_chain_check.go
+++ b/internal/cmd/supply_chain_check.go
@@ -88,6 +88,17 @@ func runSupplyChainCheck(cmd *cobra.Command, args []string) error {
 		dir = args[0]
 	}
 
+	// Validate --fail-on up front, before lockfile detection and the registry
+	// scan. supply-chain is a sibling of `scan` in the command tree, so it does
+	// not inherit scan.PersistentPreRunE's validation; without this, a typo'd
+	// --fail-on would run the full check and print results before erroring.
+	// cmdutil.GetFailOn also case-normalizes to uppercase so ShouldFail (which
+	// matches exactly) trips on a lowercase "medium".
+	failOnSeverities, err := cmdutil.GetFailOn(failOn)
+	if err != nil {
+		return err
+	}
+
 	policy, err := resolvePolicy(cmd, dir)
 	if err != nil {
 		return err
@@ -207,14 +218,9 @@ func runSupplyChainCheck(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("formatting output: %w", err)
 	}
 
-	// Use cmdutil.GetFailOn (not the raw failOn global) so --fail-on is validated
-	// and case-normalized to uppercase. ShouldFail matches severities exactly, so a
-	// lowercase "medium" would otherwise never match a "MEDIUM" finding and the
-	// CI gate would silently pass. The scan commands already route through here.
-	failOnSeverities, err := cmdutil.GetFailOn(failOn)
-	if err != nil {
-		return err
-	}
+	// failOnSeverities was validated and uppercase-normalized at the top of this
+	// function (before the scan ran), so a lowercase "medium" correctly trips
+	// ShouldFail's exact match here.
 	return output.CheckExit(scanResult, failOnSeverities, exitCode)
 }
 

--- a/internal/cmd/supply_chain_check_test.go
+++ b/internal/cmd/supply_chain_check_test.go
@@ -320,6 +320,32 @@ func TestRunSupplyChainCheck_OutputFlagWritesFile(t *testing.T) {
 	}
 }
 
+// TestRunSupplyChainCheck_FailOnValidatedFirst verifies --fail-on is validated at
+// the very top of runSupplyChainCheck, before lockfile detection and the scan
+// (PPSC-1006 #11). With a bogus --fail-on AND no lockfile present, the error must
+// be the fail-on validation error, not "no lockfile detected" — proving the
+// validation runs first and no scan output is produced.
+func TestRunSupplyChainCheck_FailOnValidatedFirst(t *testing.T) {
+	chdirTemp(t) // empty dir: no lockfile, no network
+
+	origAll, origFailOn := scAll, failOn
+	t.Cleanup(func() { scAll, failOn = origAll, origFailOn })
+	scAll = true
+	failOn = []string{"bogus"}
+
+	cmd := newWrapTestCmd()
+	err := runSupplyChainCheck(cmd, []string{"."})
+	if err == nil {
+		t.Fatal("expected error for invalid --fail-on")
+	}
+	if !strings.Contains(err.Error(), "invalid severity level") {
+		t.Errorf("expected fail-on validation error to fire before lockfile detection, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "no lockfile detected") {
+		t.Errorf("--fail-on must be validated before lockfile detection, got: %v", err)
+	}
+}
+
 // TestSupplyChainCheckOutputFlagRegistered guards the exact regression this PR
 // fixes: the real scCheckCmd (built by init()) must expose -o/--output bound to
 // the outputFile var that runSupplyChainCheck reads. Unlike the functional test


### PR DESCRIPTION
## Related Issue

* [PPSC-1006](https://armis.atlassian.net/browse/PPSC-1006)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Refactoring (no functional changes)
* [ ] Performance improvement

## Problem

Flag errors surfaced too late: a typo in `--fail-on` (e.g. `HIGHT`) or `--pull` was only caught *after* authentication and network calls, so users saw an auth failure instead of a clear flag error — or, worse, `--fail-on` silently defaulted once auth succeeded, letting a CI gate pass when it should have failed. `scan repo` also rejected a missing path argument despite every example and the `[path]` usage implying it was optional, and `supply-chain check` (a sibling of `scan`, so it doesn't inherit `scan.PersistentPreRunE`) ran the full registry scan and printed results before validating `--fail-on`.

## Solution

Move all flag validation ahead of auth and the network: `scan.PersistentPreRunE` now validates/normalizes `--fail-on` and warns on `--sbom-output`/`--vex-output` given without their generation flags; `scan image` validates `--pull` against its allowlist at the top of `RunE`; `scan repo` uses `MaximumNArgs(1)` and defaults the path to `.`; and `supply-chain check` validates `--fail-on` up front (with the same `cmdutil.GetFailOn` uppercase normalization so `ShouldFail`'s exact match trips on a lowercase `medium`).

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [ ] Integration tests added/updated
* [x] All tests passing locally

### Manual Testing

`/pre-pr-verify`: gofmt clean, golangci-lint 0 issues, `make build` OK, `make test` 2670 passed (71.7% coverage). New table-driven tests cover `--pull` validation ordering, `scan repo` zero-arg defaulting, `--fail-on` typo/normalization in `PersistentPreRunE`, and `supply-chain check` validating `--fail-on` before lockfile detection.

## Reviewer Notes

This branch rebased cleanly on top of the just-merged PPSC-1018 (region auto-detect); both touch the pre-auth path but in non-overlapping ranges, and `resolveDataPlaneURL` + the new flag validation coexist (verified by build + tests). No CHANGELOG entry added — this repo populates `docs/CHANGELOG.md` at release time.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [ ] Documentation updated (if needed)
* [ ] Breaking changes documented (if applicable)
* [x] No new warnings generated


[PPSC-1006]: https://armis-security.atlassian.net/browse/PPSC-1006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ