### PR TITLE
[PPSC-1011] docs: update README and docs for --changed flag, armisignore, and missing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ armis-cli agent-detection
 # Use --fail-open to warn instead of block, or --remove to uninstall.
 armis-cli hook init
 
-# Generate a shell completion script (bash, zsh, fish, powershell).
+# Generate a shell completion script (bash, zsh, fish, PowerShell).
 armis-cli completion zsh > "${fpath[1]}/_armis-cli"
 ```
 

--- a/README.md
+++ b/README.md
@@ -439,6 +439,32 @@ armis-cli scan repo ./my-app --format json --fail-on HIGH,CRITICAL
 armis-cli scan repo ./my-app --sbom --vex
 ```
 
+#### Scan Only Changed Files
+
+Speed up PR and pre-commit feedback by scanning only the files that changed,
+instead of the whole repository. The `--changed` flag has three modes:
+
+```bash
+# All uncommitted changes (staged + unstaged + untracked) vs HEAD
+armis-cli scan repo . --changed
+
+# Staged changes only (what `git commit` would include)
+armis-cli scan repo . --changed=staged
+
+# Changes relative to a branch, tag, or commit (great for PRs)
+armis-cli scan repo . --changed=main
+armis-cli scan repo . --changed=origin/main
+armis-cli scan repo . --changed=HEAD~3
+```
+
+Notes:
+
+- Requires a git repository. If no files changed, the scan exits early with nothing to do.
+- `staged` and `uncommitted` are reserved keywords and cannot be used as ref names.
+- `--changed` is mutually exclusive with `--include-files` (use one or the other).
+
+See [PR Scanning with Changed Files](docs/CI-INTEGRATION.md#pr-scanning-with-changed-files) for CI usage.
+
 ### Scan Container Image
 
 Scans a container image (local or remote) or a tarball.
@@ -474,6 +500,23 @@ armis-cli scan image nginx:latest --pull=always
 # Never pull, require local image (for air-gapped environments)
 armis-cli scan image nginx:latest --pull=never
 ```
+
+### Other Commands
+
+```bash
+# Detect AI coding agents (Claude Code, Cursor, Copilot, ...) and whether
+# the Armis AppSec MCP is enabled. Run with sudo to scan all user profiles.
+armis-cli agent-detection
+
+# Install a git pre-commit hook that blocks commits unless scanning passed.
+# Use --fail-open to warn instead of block, or --remove to uninstall.
+armis-cli hook init
+
+# Generate a shell completion script (bash, zsh, fish, powershell).
+armis-cli completion zsh > "${fpath[1]}/_armis-cli"
+```
+
+Run `armis-cli <command> --help` for the full flag reference of any command.
 
 ---
 

--- a/docs/CI-INTEGRATION.md
+++ b/docs/CI-INTEGRATION.md
@@ -361,6 +361,12 @@ jobs:
 - Only runs if files actually changed
 - Excludes test files that may contain intentional security test patterns
 
+> **Tip — native `--changed` flag:** Outside GitHub Actions (local pre-commit
+> hooks, GitLab, Jenkins, etc.), the CLI can detect changed files itself with no
+> extra tooling. Use `armis-cli scan repo . --changed=origin/main` to scan only
+> what differs from the base branch, or `--changed` for uncommitted work. See
+> [Scan Only Changed Files](../README.md#scan-only-changed-files) for all three modes.
+
 ---
 
 ### Scheduled Repository Scans

--- a/docs/CI-SETUP.md
+++ b/docs/CI-SETUP.md
@@ -77,7 +77,7 @@ Or manually:
 ```bash
 export ARMIS_CLIENT_ID="your-client-id"
 export ARMIS_CLIENT_SECRET="your-client-secret"
-./bin/armis scan repo . --fail-on CRITICAL,HIGH
+armis-cli scan repo . --fail-on CRITICAL,HIGH
 ```
 
 ## Viewing Results
@@ -109,7 +109,7 @@ Edit `.github/workflows/cli-self-scan.yml`:
 ```yaml
 - name: Run security scan (SARIF)
   run: |
-    ./bin/armis scan repo . \
+    armis-cli scan repo . \
       --format sarif \
       --fail-on CRITICAL,HIGH,MEDIUM \  # Add MEDIUM here
       --output armis-results.sarif
@@ -117,17 +117,18 @@ Edit `.github/workflows/cli-self-scan.yml`:
 
 ### Adding Exclusions
 
-If you need to exclude certain paths:
+To exclude certain paths from scans, create a `.armisignore` file in your
+repository root (gitignore-compatible syntax). Matching files are excluded
+before the upload archive is created:
 
-```yaml
-- name: Run security scan (SARIF)
-  run: |
-    ./bin/armis scan repo . \
-      --format sarif \
-      --fail-on CRITICAL,HIGH \
-      --exclude "test/*,vendor/*" \
-      --output armis-results.sarif
+```text
+test/*
+vendor/*
 ```
+
+See the [.armisignore section in FEATURES.md](FEATURES.md#-armisignore-support)
+for the full pattern syntax. No scan-command flag is needed — the file is
+picked up automatically.
 
 ### Running on Specific Branches Only
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -93,19 +93,21 @@ Both documents are generated in [CycloneDX](https://cyclonedx.org/) format, an O
 ### Basic Usage
 
 ```bash
+# ARMIS_CLIENT_ID and ARMIS_CLIENT_SECRET set via env (JWT auto-extracts the tenant ID)
+
 # Generate SBOM for a repository scan
-armis-cli scan repo . --tenant-id my-tenant --sbom
+armis-cli scan repo . --sbom
 
 # Generate both SBOM and VEX
-armis-cli scan repo . --tenant-id my-tenant --sbom --vex
+armis-cli scan repo . --sbom --vex
 
 # Specify custom output paths
-armis-cli scan repo . --tenant-id my-tenant \
+armis-cli scan repo . \
   --sbom --sbom-output ./reports/sbom.json \
   --vex --vex-output ./reports/vex.json
 
 # Generate SBOM for container image scan
-armis-cli scan image nginx:latest --tenant-id my-tenant --sbom --vex
+armis-cli scan image nginx:latest --sbom --vex
 ```
 
 ### Flags


### PR DESCRIPTION
## Related Issue

* [PPSC-1011](https://armis.atlassian.net/browse/PPSC-1011)

## Type of Change

* [x] Documentation update

## Problem

The README and supporting docs were missing coverage for the `--changed` flag (introduced in a prior PR), the `agent-detection`/`hook init`/`completion` commands, and had stale examples using the old `./bin/armis` binary name and `--exclude` flag (replaced by `.armisignore`). The FEATURES.md SBOM examples still required `--tenant-id` even though JWT auth auto-extracts it.

## Solution

- Document `--changed` with all three modes in README, with cross-link to CI-INTEGRATION
- Add "Other Commands" section covering `agent-detection`, `hook init`, and `completion`
- Add a tip in CI-INTEGRATION pointing to native `--changed` for non-GitHub-Actions CI (GitLab, Jenkins, local hooks)
- Replace `./bin/armis` with `armis-cli` and `--exclude` yaml block with `.armisignore` explanation in CI-SETUP
- Drop `--tenant-id` from SBOM/VEX examples in FEATURES (JWT auto-extracts it from the `customer_id` claim)

## Testing

### Automated Tests

* [x] All tests passing locally (2660 passed, 71.7% coverage)

### Manual Testing

Docs-only change; verified all cross-links point to correct anchors.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] Documentation updated (if needed)
* [x] No new warnings generated

[PPSC-1011]: https://armis-security.atlassian.net/browse/PPSC-1011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ