### PR TITLE
[PPSC-1013] feat(ux): signpost the upgrade path

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update notification now links to the release notes for the available version, so breaking changes can be reviewed before upgrading
+
 ### Deprecated
+
+- Legacy Basic auth `--token` / `-t` (env: `ARMIS_API_TOKEN`) now emits a runtime deprecation warning; use JWT auth (`--client-id` / `--client-secret`, env: `ARMIS_CLIENT_ID` / `ARMIS_CLIENT_SECRET`) instead. The flag still functions
 
 ### Removed
 
@@ -56,13 +60,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `supply-chain`: `uvx` (uv's on-demand tool runner) is now wrapped alongside `uv`, the PyPI analogue of how `npx` is paired with `npm`. `uvx <tool>` fetches a tool from PyPI and runs it — exactly the supply-chain vector the proxy guards — so wherever `uv` is enforced, `uvx` is too. It shares uv's resolver and config, so it routes through the same transparent PyPI proxy (`UV_INDEX_URL`) and inherits uv's `ecosystems`-scope decision. Enforcement applies to tools `uvx` fetches from the registry; a tool already in the uv tool cache runs without a registry round-trip and is not re-checked. Re-run `armis-cli supply-chain init` to wrap `uvx` on machines where it is installed. (#219)
+  > **Action required:** Re-run `armis-cli supply-chain init` to wrap `uvx` on machines where it is installed.
 - `supply-chain check` now warns when the audited lockfile references a loopback registry (`127.0.0.1`, `localhost`, `[::1]`). The wrap's residue sweep can only remove the proxy origin of the run that just finished — a wrapper killed mid-install leaves a stale port behind, and versions before the sweep existed left residue routinely — so this gives CI a way to catch a corrupted lockfile before it breaks builds that resolve outside the wrapper. The warning is advisory: a deliberate local registry (e.g. Verdaccio) also matches. (#226)
 
 ### Fixed
 
 - `supply-chain`: wrapped `uv` commands that write `uv.lock` (`uv sync`, `uv lock`, `uv add`, `uv run`, …) no longer corrupt the lockfile. uv records the configured index URL as each package's `source.registry` in `uv.lock`, and an index differing from the recorded one triggers a full re-lock — so routing these commands through the transparent proxy stamped the ephemeral `http://127.0.0.1:<port>/simple/` proxy address into every package entry, breaking any subsequent sync outside the wrapper (Docker builds, CI, teammates). Lockfile-writing `uv` invocations now use the same pre-install lockfile audit as poetry/pipenv/pdm: `uv.lock` is checked for too-young packages and the build is blocked before it runs, while uv itself resolves against the real index so the lockfile stays pristine. `uv pip …` and `uv tool …` (which never touch `uv.lock`) and `uvx` keep the transparent proxy. A lockfile already corrupted by an earlier version can be repaired by re-running `uv lock` outside the wrapper (or with `ARMIS_SUPPLY_CHAIN=off`). (#226)
+  > **Action required:** A `uv.lock` corrupted by an earlier version is repaired by re-running `uv lock` outside the wrapper (or with `ARMIS_SUPPLY_CHAIN=off`).
 - `supply-chain`: a wrapped `bun update` no longer leaves the ephemeral proxy address in `bun.lock`. bun records the full tarball URL it fetched from when re-resolving, so the proxy's `http://127.0.0.1:<port>/…` origin was persisted into the lockfile (verified on bun 1.3; `bun add`/`bun install` are unaffected — they record registry-relative entries). After every proxied run the wrapper now sweeps the project's lockfiles and rewrites any occurrence of the proxy origin back to the real upstream registry; the rewrite is atomic and produces exactly the URLs an unwrapped run would have recorded (the proxy forwards tarball paths to the upstream 1:1). The sweep also covers `package-lock.json`, `yarn.lock`, and `pnpm-lock.yaml` defensively — current npm/yarn/pnpm record upstream URLs (verified on npm 10, yarn 1.22, pnpm 10), but older releases recorded the configured registry. A legacy binary `bun.lockb` cannot be rewritten in place; if proxy residue is detected there, a warning explains how to repair (`ARMIS_SUPPLY_CHAIN=off bun install --save-text-lockfile`). (#226)
+  > **Action required:** A legacy binary `bun.lockb` with proxy residue is repaired with `ARMIS_SUPPLY_CHAIN=off bun install --save-text-lockfile`.
 - `supply-chain`: a wrapped `uv tool install` no longer breaks subsequent `uv tool upgrade` runs. uv records the index it was invoked with as `index-url` in the tool's `uv-receipt.toml`, so upgrades would target the dead ephemeral proxy address; the post-run sweep now restores `https://pypi.org/simple/` in tool receipts. Receipts already poisoned by an earlier version can be repaired by re-running `uv tool install <tool> --force` through the wrapper, or editing the receipt's `index-url` by hand. (#226)
+  > **Action required:** A poisoned `uv-receipt.toml` is repaired by re-running `uv tool install <tool> --force` through the wrapper, or editing the receipt's `index-url` by hand.
 - `supply-chain`: a wrapped `uv pip compile --emit-index-url -o FILE` no longer writes the ephemeral proxy URL as the `--index-url` of the generated requirements file; the post-run sweep restores `https://pypi.org/simple/` in the output file. Output redirected to stdout by the shell happens outside the wrapper and cannot be intercepted — the new `supply-chain check` loopback warning covers that case. (#226)
 - `supply-chain`: wrapped Yarn Berry (2+) installs no longer fail with `YN0081: Unsafe http requests must be explicitly whitelisted`. Berry honors the wrap's registry override but refuses plain-http registries — and the filtering proxy is necessarily plain http on loopback — so every wrapped Berry install errored out with no mention of the wrapper. The wrap now sets `YARN_UNSAFE_HTTP_WHITELIST=127.0.0.1` alongside the registry override (Yarn classic ignores the variable). Verified on Berry 4.16: wrapped installs are filtered by the age policy and Berry's registry-agnostic `yarn.lock` stays clean. (#226)
 - `supply-chain`: the residue sweep also covers `npm-shrinkwrap.json` (package-lock.json's publishable twin), and rewrites symlinked lockfiles through to their target instead of replacing the link with a regular file. (#226)
@@ -94,6 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `supply-chain init`: the injected shell wrappers no longer break after an `armis-cli` upgrade. The wrapper now references `armis-cli` by bare name (resolved from `PATH` on every call) when it is on `PATH`, falling back to the stable symlink path otherwise — previously it embedded the fully symlink-resolved binary path, which on Homebrew was the version-pinned Cellar directory (e.g. `…/Cellar/armis-cli/1.11.0/…`). After `brew upgrade armis-cli` deleted that directory, every wrapped package manager (npm, pnpm, bun, pip, uv, poetry, npx) failed to run in new shells. The wrappers are also now fail-closed: if `armis-cli` cannot be found at invocation time, the wrapper prints a loud warning to stderr that enforcement has lapsed and runs the real package manager un-wrapped, so installs never silently break. The fish guard now uses fish-native `command -q` (POSIX `command -v` errored under fish and silently disabled enforcement), and the guard adds an executable-path check so an absolute fallback path is detected reliably across shells. Wrappers injected before this fix must be refreshed by re-running `armis-cli supply-chain init` once. (#216)
+  > **Action required:** Re-run `armis-cli supply-chain init` once to refresh shell wrappers injected before v1.11.1.
 
 ---
 
@@ -289,6 +298,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SARIF rule IDs normalized to stable CWE/CVE identifiers, removing unstable fingerprints for consistent GitHub Code Scanning deduplication (#154)
 - Install script now surfaces credential write failures instead of silently swallowing errors (#151)
 - Release pipeline fixed by upgrading cosign-installer to v4 (v3 bootstrap binary was delisted) (#149)
+
+---
+
+## [1.6.1] - 2026-04-28
+
+### Fixed
+
+- Upgraded go-git to v5.18.0 to remediate CVE-2026-41506 (#148)
+- SARIF rule IDs stabilized to prevent recurring false-positive GitHub Code Scanning alerts (#147)
+
+---
+
+## [1.6.0] - 2026-04-22
+
+### Added
+
+- `install claude` command for registering the Armis MCP plugin with Claude (#143)
+
+---
+
+## [1.5.0] - 2026-04-13
+
+### Added
+
+- Graceful degradation when result fetching fails: partial results are surfaced instead of aborting the scan (#141)
+
+### Fixed
+
+- Security hardening from the PPSC-602 code-scanning sweep: `.armisignore` size limit with go-git CVE remediation (#136), upper bounds on scan and upload timeouts to bound resource use (CWE-770, #122), install aborts when checksum-verification tools are unavailable (CWE-494, #124), integer-overflow guard in file-size calculation (CWE-190, #105), and reduced debug-info exposure in auth (CWE-215, #109) (#135)
 
 ---
 
@@ -536,6 +574,9 @@ Manual entries for significant releases:
 [1.8.1]: https://github.com/ArmisSecurity/armis-cli/compare/v1.8.0...v1.8.1
 [1.8.0]: https://github.com/ArmisSecurity/armis-cli/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/ArmisSecurity/armis-cli/compare/v1.6.1...v1.7.0
+[1.6.1]: https://github.com/ArmisSecurity/armis-cli/compare/v1.6.0...v1.6.1
+[1.6.0]: https://github.com/ArmisSecurity/armis-cli/compare/v1.5.0...v1.6.0
+[1.5.0]: https://github.com/ArmisSecurity/armis-cli/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/ArmisSecurity/armis-cli/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/ArmisSecurity/armis-cli/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/ArmisSecurity/armis-cli/compare/v1.2.0...v1.2.1

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -192,6 +192,13 @@ func init() {
 
 	// Legacy Basic authentication
 	rootCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "API token for Basic authentication (env: ARMIS_API_TOKEN)")
+	// Signal that Basic auth is the legacy path: MarkDeprecated prints a stderr
+	// warning whenever --token is used and hides it from --help; the shorthand
+	// (-t) needs its own call. Both error only on an unknown flag name, so the
+	// returns are intentionally discarded. The flag still functions — auth is
+	// unchanged; this is signposting toward JWT (--client-id / --client-secret).
+	_ = rootCmd.PersistentFlags().MarkDeprecated("token", "use --client-id / --client-secret (JWT) instead; see ARMIS_CLIENT_ID + ARMIS_CLIENT_SECRET")
+	_ = rootCmd.PersistentFlags().MarkShorthandDeprecated("token", "use --client-id / --client-secret (JWT) instead")
 	rootCmd.PersistentFlags().StringVar(&tenantID, "tenant-id", "", "Tenant identifier for Armis Cloud (env: ARMIS_TENANT_ID)")
 
 	// JWT authentication

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -315,6 +315,10 @@ func FormatNotification(current, latest, icon string) string {
 	if updateCmd != "" {
 		msg += fmt.Sprintf("   %s\n", styles.MutedText.Render(updateCmd))
 	}
+	// Link the release notes so the user can review breaking changes before
+	// upgrading. latest is already v-trimmed above, so prefix a literal "v".
+	releaseURL := "https://github.com/ArmisSecurity/armis-cli/releases/tag/v" + latest
+	msg += fmt.Sprintf("   %s\n", styles.MutedText.Render(releaseURL))
 	return msg
 }
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -115,11 +115,20 @@ func TestFormatNotification(t *testing.T) {
 	if !strings.Contains(result, testIcon) {
 		t.Errorf("notification should contain icon, got: %s", result)
 	}
+	// Check that it links the release notes for the latest version
+	if !strings.Contains(result, "releases/tag/v1.1.0") {
+		t.Errorf("notification should link release notes for latest version, got: %s", result)
+	}
 
 	// Check with v prefix
 	result = FormatNotification("v1.0.0", "v1.1.0", testIcon)
 	if !strings.Contains(result, "v1.1.0") {
 		t.Errorf("notification should normalize version, got: %s", result)
+	}
+	// The release-notes URL must carry exactly one "v" prefix even when the
+	// caller passes a v-prefixed version (guards against "tag/vv1.1.0").
+	if !strings.Contains(result, "releases/tag/v1.1.0") || strings.Contains(result, "tag/vv") {
+		t.Errorf("notification should normalize release-notes URL, got: %s", result)
 	}
 }
 


### PR DESCRIPTION
## Related Issue

* [PPSC-1013](https://armis.atlassian.net/browse/PPSC-1013)

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] Documentation update
* [ ] Refactoring (no functional changes)
* [ ] Performance improvement

## Problem

When a new version is available, users have no easy way to review what changed (or whether it's breaking) before upgrading. Separately, the legacy Basic auth `--token` flag gives no signal that JWT is the recommended path, and several CHANGELOG entries that require a manual user step bury that action inside long paragraphs.

## Solution

Three small signposts toward the upgrade path: (1) the update notification now prints a link to the release notes for the available version; (2) the legacy `--token` / `-t` flag is marked deprecated via Cobra (`MarkDeprecated` + `MarkShorthandDeprecated`), which prints a stderr warning and hides it from `--help` while leaving auth fully functional; and (3) CHANGELOG entries that require user action now carry an `> **Action required:**` callout, plus the missing 1.5.0/1.6.0/1.6.1 release sections and compare links are backfilled.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [ ] Integration tests added/updated
* [x] All tests passing locally

### Manual Testing

`TestFormatNotification` was extended to assert the release-notes URL is present and carries exactly one `v` prefix (guards against `tag/vv1.1.0`). Pre-commit hooks (go fmt, go vet, golangci-lint, markdownlint) pass.

## Reviewer Notes

`--token` continues to function exactly as before — this only adds a deprecation warning and hides it from help output, so it's non-breaking. The discarded returns on the `MarkDeprecated` calls are intentional: those functions only error on an unknown flag name (a startup-time programmer error).

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] Documentation updated (if needed)
* [x] Breaking changes documented (if applicable)
* [x] No new warnings generated


[PPSC-1013]: https://armis-security.atlassian.net/browse/PPSC-1013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ