### PR TITLE
[PPSC-1014] fix(devex): green make test, lint cache docs, Go badge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,8 @@ Tests use table-driven patterns. Mock HTTP responses with `internal/testutil/htt
 
 Uses golangci-lint v2 config (`.golangci.yml`) with: errcheck, govet, ineffassign, staticcheck, unused, gosec, goconst, misspell.
 
+If `make lint` reports issues from `../*/` paths (sibling git worktrees), the goconst cache has bled across worktrees sharing this module path. Run `golangci-lint cache clean` then re-run, or use the `make lint-clean` target which does both.
+
 ## Conventions
 
 - Error wrapping: always use `fmt.Errorf("context: %w", err)`

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install clean test lint lint-clean scan help tools coverage
+.PHONY: build install clean test lint lint-clean scan help tools coverage release
 
 BINARY_NAME=armis-cli
 BUILD_DIR=bin

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install clean test lint scan help tools coverage
+.PHONY: build install clean test lint lint-clean scan help tools coverage
 
 BINARY_NAME=armis-cli
 BUILD_DIR=bin
@@ -16,6 +16,7 @@ help:
 	@echo "  test       - Run tests with coverage"
 	@echo "  coverage   - Show coverage report"
 	@echo "  lint       - Run linters"
+	@echo "  lint-clean - Clear the golangci-lint cache, then run linters"
 	@echo "  scan       - Run security scan on this repository"
 	@echo "  release    - Build for multiple platforms"
 	@echo "  tools      - Install dev tools (gotestsum)"
@@ -66,6 +67,15 @@ tools:
 lint:
 	@echo "Running linters..."
 	@which golangci-lint > /dev/null || (echo "golangci-lint not installed" && exit 1)
+	golangci-lint run
+
+# Sibling git worktrees that share this module path can pollute golangci-lint's
+# goconst cache, surfacing phantom violations from ../<other-worktree>/ paths.
+# Clearing the cache first removes them (see CLAUDE.md "Linting").
+lint-clean:
+	@echo "Clearing golangci-lint cache and running linters..."
+	@which golangci-lint > /dev/null || (echo "golangci-lint not installed" && exit 1)
+	golangci-lint cache clean
 	golangci-lint run
 
 scan:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # Armis CLI
 
 [![Build Status](https://github.com/ArmisSecurity/armis-cli/actions/workflows/release.yml/badge.svg)](https://github.com/ArmisSecurity/armis-cli/actions)
-[![Go Version](https://img.shields.io/badge/go-1.23+-blue)](https://golang.org/dl/)
+[![Go Version](https://img.shields.io/badge/go-1.25+-blue)](https://golang.org/dl/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 [![Coverage](https://img.shields.io/badge/coverage-check%20CI-blue)](https://github.com/ArmisSecurity/armis-cli/actions/workflows/ci.yml)

--- a/internal/cmd/scan_test.go
+++ b/internal/cmd/scan_test.go
@@ -74,6 +74,14 @@ func TestScanCmd(t *testing.T) {
 }
 
 func TestScanRepoCmd(t *testing.T) {
+	// The "fails without base URL" subtest falls through to a real scan attempt,
+	// which starts the upload spinner. Its ANSI/carriage-return frames corrupt
+	// gotestsum's go-test-json PASS-line parser, producing false "failures" under
+	// `make test` even though `go test` passes. Suppress progress for all subtests.
+	originalNoProgress := noProgress
+	noProgress = true
+	t.Cleanup(func() { noProgress = originalNoProgress })
+
 	t.Run("repo command exists", func(t *testing.T) {
 		if scanRepoCmd == nil {
 			t.Fatal("scanRepoCmd should not be nil")

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -302,9 +302,15 @@ func uninstallTargets(u *install.Uninstaller, targets []string) error {
 	return nil
 }
 
+// confirmOut is where confirm() writes its prompt. It defaults to stderr (all
+// interactive output goes to stderr), but is a package var so tests can redirect
+// it to io.Discard — the unterminated prompt otherwise corrupts gotestsum's
+// go-test-json parser and produces false failures under `make test`.
+var confirmOut io.Writer = os.Stderr
+
 // armis:ignore cwe:253 reason:Scan() returns false on EOF/error which is correct default-deny behavior (returns false = no confirmation)
 func confirm(prompt string) bool {
-	fmt.Fprintf(os.Stderr, "%s [y/N] ", prompt)
+	_, _ = fmt.Fprintf(confirmOut, "%s [y/N] ", prompt)
 	scanner := bufio.NewScanner(io.LimitReader(os.Stdin, 256))
 	if !scanner.Scan() {
 		return false

--- a/internal/cmd/uninstall_test.go
+++ b/internal/cmd/uninstall_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +10,12 @@ import (
 )
 
 func TestConfirm(t *testing.T) {
+	// Discard the prompt so its unterminated "Continue? [y/N] " line does not
+	// bleed into gotestsum's go-test-json parser and cause false failures.
+	originalConfirmOut := confirmOut
+	confirmOut = io.Discard
+	t.Cleanup(func() { confirmOut = originalConfirmOut })
+
 	tests := []struct {
 		name  string
 		input string


### PR DESCRIPTION
## Related Issue

* [PPSC-1014](https://armis-security.atlassian.net/browse/PPSC-1014) — S10: Contributor environment (subtask of PPSC-1004, Armis CLI DX improvements)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] Documentation update

## Problem

A contributor's first `make test` on a clean checkout reported **8 failures**, even though `go test ./...` was green — so the codebase looked broken at T0. The failures were gotestsum misclassifications: the progress spinner's ANSI/carriage-return frames (in `TestScanRepoCmd`) and `confirm()`'s unterminated `[y/N]` prompt (in `TestConfirm`) corrupted go-test-json's line-anchored PASS-marker parser. Two smaller papercuts compounded it: `make lint` emits phantom goconst violations from sibling git worktrees with no documented fix, and the README Go-version badge (`1.23+`) contradicted `go.mod` (`1.25.0`).

## Solution

`#10` (P1): `TestScanRepoCmd` now saves/sets/restores `noProgress = true` to suppress the spinner, and `confirm()` writes its prompt to a swappable package-level `confirmOut io.Writer` (defaulting to `os.Stderr`) so `TestConfirm` can redirect it to `io.Discard` — no runtime behavior change. `#35` (P2): documented the `golangci-lint cache clean` worktree fix in CLAUDE.md and added a `make lint-clean` target. `#37` (P2): bumped the README badge to `go-1.25+`.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

Reproduced the baseline (`gotestsum -- -v ./internal/cmd/...` → 8 failures), confirmed each root cause in isolation (6 from `TestScanRepoCmd`, 2 from `TestConfirm`), then verified the fix: full `make test` → **0 failures** (2683 tests, 71.7% coverage), `go test ./...` still green, `make build` clean, and `make lint-clean` resolves the phantom worktree findings → 0 issues.

## Reviewer Notes

The `confirm()` change is deliberately a swappable package var (not an `io.Writer` parameter) to leave the single production call site untouched. The `_, _ = fmt.Fprintf(...)` discard follows the repo's existing convention for writes to a generic `io.Writer` (cf. `internal/progress/progress.go:181`). No CHANGELOG entry was added — these are contributor-DX/test-harness changes with no user-facing CLI behavior change.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] Documentation updated (if needed)
* [x] No new warnings generated

[PPSC-1014]: https://armis-security.atlassian.net/browse/PPSC-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ