### PR TITLE
[PPSC-1012] feat(completion): tab-complete enumerated flag values

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Enterprise-grade CLI for static application security scanning with Armis Cloud. 
 
 - [Features](#features)
 - [Installation](#installation)
+- [Shell Completion](#shell-completion)
 - [Quick Start](#quick-start)
 - [Verification](#verification)
 - [Usage](#usage)
@@ -222,6 +223,60 @@ If you see "command not found" after installation:
    ```powershell
    & "$env:LOCALAPPDATA\armis-cli\armis-cli.exe" --help
    ```
+
+### Shell Completion
+
+`armis-cli` ships tab-completion for commands, subcommands, and flag values (e.g.
+`--format <TAB>` offers `human/json/sarif/junit`). Generate the script for your
+shell with `armis-cli completion <shell>`; run `armis-cli completion <shell> --help`
+for the full instructions.
+
+**Bash** (requires the `bash-completion` package):
+
+```bash
+# Current shell session
+source <(armis-cli completion bash)
+
+# Every new session (Linux)
+armis-cli completion bash > /etc/bash_completion.d/armis-cli
+
+# Every new session (macOS)
+armis-cli completion bash > $(brew --prefix)/etc/bash_completion.d/armis-cli
+```
+
+**Zsh** (enable completion once with `echo "autoload -U compinit; compinit" >> ~/.zshrc`):
+
+```zsh
+# Current shell session
+source <(armis-cli completion zsh)
+
+# Every new session (Linux)
+armis-cli completion zsh > "${fpath[1]}/_armis-cli"
+
+# Every new session (macOS)
+armis-cli completion zsh > $(brew --prefix)/share/zsh/site-functions/_armis-cli
+```
+
+**Fish:**
+
+```fish
+# Current shell session
+armis-cli completion fish | source
+
+# Every new session
+armis-cli completion fish > ~/.config/fish/completions/armis-cli.fish
+```
+
+**PowerShell:**
+
+```powershell
+# Current shell session
+armis-cli completion powershell | Out-String | Invoke-Expression
+
+# Every new session: add the output of the above command to your PowerShell profile
+```
+
+Start a new shell for the persistent setup to take effect.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Shell completion now suggests values for enumerated flags: `--format`, `--fail-on`, `--color`, `--theme`, and `--group-by` offer their accepted values (with descriptions in zsh/fish) instead of falling back to file-path completion. The candidate lists reuse the same slices the flag validators read, so completions cannot drift from what is actually accepted. The README documents the per-shell setup for `armis-cli completion <shell>` (bash/zsh/fish/PowerShell). (PPSC-1012)
+
 ### Changed
 
 - Update notification now links to the release notes for the available version, so breaking changes can be reviewed before upgrading

--- a/internal/cmd/completion_test.go
+++ b/internal/cmd/completion_test.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ArmisSecurity/armis-cli/internal/cmd/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// stripDesc returns the candidate value with any "\tdescription" hint removed.
+// Cobra encodes a completion as "value\tDescription"; only the value before the
+// tab is what the shell inserts.
+func stripDesc(completion string) string {
+	if i := strings.IndexByte(completion, '\t'); i >= 0 {
+		return completion[:i]
+	}
+	return completion
+}
+
+// runFlagCompletion looks up the completion func registered on cmd for flagName,
+// invokes it, and returns the bare candidate values and the directive.
+func runFlagCompletion(t *testing.T, cmd *cobra.Command, flagName string) ([]string, cobra.ShellCompDirective) {
+	t.Helper()
+	fn, ok := cmd.GetFlagCompletionFunc(flagName)
+	if !ok || fn == nil {
+		t.Fatalf("no completion func registered for --%s", flagName)
+	}
+	raw, directive := fn(cmd, nil, "")
+	values := make([]string, 0, len(raw))
+	for _, c := range raw {
+		values = append(values, stripDesc(c))
+	}
+	return values, directive
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestFlagCompletionsMatchValidators is the core guarantee: every registered
+// completion offers exactly the values its validator accepts, in order, and
+// suppresses file completion. If a validator's value list changes, this test
+// fails unless the completion is updated to match.
+func TestFlagCompletionsMatchValidators(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      *cobra.Command
+		flag     string
+		expected []string
+	}{
+		{"format", rootCmd, "format", validFormats},
+		{"fail-on", rootCmd, "fail-on", cmdutil.ValidSeverities},
+		{"color", rootCmd, "color", []string{"auto", "always", "never"}},
+		{"theme", rootCmd, "theme", []string{themeAuto, themeDark, themeLight}},
+		{"group-by", scanCmd, "group-by", validGroupBy},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, directive := runFlagCompletion(t, tt.cmd, tt.flag)
+			if !equalSlices(values, tt.expected) {
+				t.Errorf("--%s completions = %v, want %v", tt.flag, values, tt.expected)
+			}
+			if directive != cobra.ShellCompDirectiveNoFileComp {
+				t.Errorf("--%s directive = %d, want ShellCompDirectiveNoFileComp (%d)",
+					tt.flag, directive, cobra.ShellCompDirectiveNoFileComp)
+			}
+		})
+	}
+}
+
+// TestFlagCompletionsHaveDescriptions verifies the candidates carry the "\thint"
+// suffix that zsh/fish render, matching the established supply-chain pattern.
+func TestFlagCompletionsHaveDescriptions(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+		flag string
+	}{
+		{"format", rootCmd, "format"},
+		{"fail-on", rootCmd, "fail-on"},
+		{"color", rootCmd, "color"},
+		{"theme", rootCmd, "theme"},
+		{"group-by", scanCmd, "group-by"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn, ok := tt.cmd.GetFlagCompletionFunc(tt.flag)
+			if !ok || fn == nil {
+				t.Fatalf("no completion func registered for --%s", tt.flag)
+			}
+			raw, _ := fn(tt.cmd, nil, "")
+			if len(raw) == 0 {
+				t.Fatalf("--%s produced no completions", tt.flag)
+			}
+			for _, c := range raw {
+				if !strings.Contains(c, "\t") {
+					t.Errorf("--%s completion %q is missing a \\tdescription hint", tt.flag, c)
+				}
+			}
+		})
+	}
+}
+
+// TestFixedCompletions exercises the helper directly, including the fallback for
+// values that have no description entry.
+func TestFixedCompletions(t *testing.T) {
+	t.Run("attaches descriptions in order", func(t *testing.T) {
+		fn := fixedCompletions([]string{"a", "b"}, map[string]string{
+			"a": "first",
+			"b": "second",
+		})
+		got, directive := fn(nil, nil, "")
+		want := []cobra.Completion{"a\tfirst", "b\tsecond"}
+		if !equalSlices(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("directive = %d, want %d", directive, cobra.ShellCompDirectiveNoFileComp)
+		}
+	})
+
+	t.Run("falls back to bare value when no description", func(t *testing.T) {
+		fn := fixedCompletions([]string{"a", "b"}, map[string]string{"a": "first"})
+		got, _ := fn(nil, nil, "")
+		if got[1] != "b" {
+			t.Errorf("undescribed value = %q, want bare %q", got[1], "b")
+		}
+		if strings.Contains(got[1], "\t") {
+			t.Errorf("undescribed value %q should not carry a tab", got[1])
+		}
+	})
+}

--- a/internal/cmd/completion_test.go
+++ b/internal/cmd/completion_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ArmisSecurity/armis-cli/internal/cli"
 	"github.com/ArmisSecurity/armis-cli/internal/cmd/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -59,7 +60,7 @@ func TestFlagCompletionsMatchValidators(t *testing.T) {
 	}{
 		{"format", rootCmd, "format", validFormats},
 		{"fail-on", rootCmd, "fail-on", cmdutil.ValidSeverities},
-		{"color", rootCmd, "color", []string{"auto", "always", "never"}},
+		{"color", rootCmd, "color", []string{string(cli.ColorModeAuto), string(cli.ColorModeAlways), string(cli.ColorModeNever)}},
 		{"theme", rootCmd, "theme", []string{themeAuto, themeDark, themeLight}},
 		{"group-by", scanCmd, "group-by", validGroupBy},
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ArmisSecurity/armis-cli/internal/auth"
 	"github.com/ArmisSecurity/armis-cli/internal/cli"
+	"github.com/ArmisSecurity/armis-cli/internal/cmd/cmdutil"
 	"github.com/ArmisSecurity/armis-cli/internal/output"
 	"github.com/ArmisSecurity/armis-cli/internal/progress"
 	"github.com/ArmisSecurity/armis-cli/internal/update"
@@ -217,6 +218,52 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&noUpdateCheck, "no-update-check", false, "Disable automatic update checking (env: ARMIS_NO_UPDATE_CHECK)")
 	rootCmd.PersistentFlags().StringVar(&colorFlag, "color", "auto", "Control colored output: auto, always, never")
 	rootCmd.PersistentFlags().StringVar(&themeFlag, "theme", getEnvOrDefault("ARMIS_THEME", themeAuto), "Terminal background theme: auto, dark, light (env: ARMIS_THEME)")
+
+	// Tab-completion for enumerated flags. Without these, Cobra falls back to
+	// (useless) file-path completion. The value lists reuse the same slices the
+	// validators read, so the completion candidates can't drift from what's
+	// actually accepted. --region is intentionally omitted (advisory-only).
+	_ = rootCmd.RegisterFlagCompletionFunc("format", fixedCompletions(validFormats, map[string]string{
+		"human": "Human-readable terminal output (default)",
+		"json":  "Machine-readable JSON",
+		"sarif": "SARIF for code-scanning tools",
+		"junit": "JUnit XML for CI test reports",
+	}))
+	_ = rootCmd.RegisterFlagCompletionFunc("fail-on", fixedCompletions(cmdutil.ValidSeverities, map[string]string{
+		"INFO":     "Informational findings",
+		"LOW":      "Low-severity findings",
+		"MEDIUM":   "Medium-severity findings",
+		"HIGH":     "High-severity findings",
+		"CRITICAL": "Critical-severity findings",
+	}))
+	_ = rootCmd.RegisterFlagCompletionFunc("color", fixedCompletions([]string{"auto", "always", "never"}, map[string]string{
+		"auto":   "Enable colors when writing to a terminal (default)",
+		"always": "Always emit ANSI colors",
+		"never":  "Never emit ANSI colors",
+	}))
+	_ = rootCmd.RegisterFlagCompletionFunc("theme", fixedCompletions([]string{themeAuto, themeDark, themeLight}, map[string]string{
+		themeAuto:  "Auto-detect terminal background (default)",
+		themeDark:  "Optimize colors for a dark background",
+		themeLight: "Optimize colors for a light background",
+	}))
+}
+
+// fixedCompletions builds a Cobra completion function that offers a fixed set
+// of values in the given order, attaching a "\tDescription" hint (rendered by
+// zsh/fish) when one is present. It always returns ShellCompDirectiveNoFileComp
+// so the shell does not fall back to file-path completion. Passing the
+// validator's own slice as values keeps the completion set and the accepted set
+// in lockstep.
+func fixedCompletions(values []string, descriptions map[string]string) cobra.CompletionFunc {
+	choices := make([]cobra.Completion, 0, len(values))
+	for _, v := range values {
+		if desc, ok := descriptions[v]; ok {
+			choices = append(choices, cobra.CompletionWithDesc(v, desc))
+		} else {
+			choices = append(choices, v)
+		}
+	}
+	return cobra.FixedCompletions(choices, cobra.ShellCompDirectiveNoFileComp)
 }
 
 // PrintUpdateNotification prints a version update notification if one is available.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -236,11 +236,13 @@ func init() {
 		"HIGH":     "High-severity findings",
 		"CRITICAL": "Critical-severity findings",
 	}))
-	_ = rootCmd.RegisterFlagCompletionFunc("color", fixedCompletions([]string{"auto", "always", "never"}, map[string]string{
-		"auto":   "Enable colors when writing to a terminal (default)",
-		"always": "Always emit ANSI colors",
-		"never":  "Never emit ANSI colors",
-	}))
+	_ = rootCmd.RegisterFlagCompletionFunc("color", fixedCompletions(
+		[]string{string(cli.ColorModeAuto), string(cli.ColorModeAlways), string(cli.ColorModeNever)},
+		map[string]string{
+			string(cli.ColorModeAuto):   "Enable colors when writing to a terminal (default)",
+			string(cli.ColorModeAlways): "Always emit ANSI colors",
+			string(cli.ColorModeNever):  "Never emit ANSI colors",
+		}))
 	_ = rootCmd.RegisterFlagCompletionFunc("theme", fixedCompletions([]string{themeAuto, themeDark, themeLight}, map[string]string{
 		themeAuto:  "Auto-detect terminal background (default)",
 		themeDark:  "Optimize colors for a dark background",

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -224,7 +224,7 @@ func init() {
 	// validators read, so the completion candidates can't drift from what's
 	// actually accepted. --region is intentionally omitted (advisory-only).
 	_ = rootCmd.RegisterFlagCompletionFunc("format", fixedCompletions(validFormats, map[string]string{
-		"human": "Human-readable terminal output (default)",
+		"human": "Human-readable terminal output",
 		"json":  "Machine-readable JSON",
 		"sarif": "SARIF for code-scanning tools",
 		"junit": "JUnit XML for CI test reports",
@@ -244,7 +244,7 @@ func init() {
 			string(cli.ColorModeNever):  "Never emit ANSI colors",
 		}))
 	_ = rootCmd.RegisterFlagCompletionFunc("theme", fixedCompletions([]string{themeAuto, themeDark, themeLight}, map[string]string{
-		themeAuto:  "Auto-detect terminal background (default)",
+		themeAuto:  "Auto-detect terminal background",
 		themeDark:  "Optimize colors for a dark background",
 		themeLight: "Optimize colors for a light background",
 	}))

--- a/internal/cmd/scan.go
+++ b/internal/cmd/scan.go
@@ -116,6 +116,12 @@ func init() {
 	scanCmd.PersistentFlags().IntVar(&uploadTimeout, "upload-timeout", 10, "Maximum time in minutes to wait for artifact upload to complete")
 	scanCmd.PersistentFlags().BoolVar(&includeNonExploitable, "include-non-exploitable", false, "Show low/medium exploitability findings (hidden by default; high and ungraded findings always shown)")
 	scanCmd.PersistentFlags().StringVar(&groupBy, "group-by", "none", "Group findings by: none, cwe, severity, file")
+	_ = scanCmd.RegisterFlagCompletionFunc("group-by", fixedCompletions(validGroupBy, map[string]string{
+		"none":     "No grouping (default)",
+		"cwe":      "Group findings by CWE identifier",
+		"severity": "Group findings by severity level",
+		"file":     "Group findings by file path",
+	}))
 	scanCmd.PersistentFlags().BoolVar(&generateSBOM, "sbom", false, "Generate Software Bill of Materials (SBOM) in CycloneDX format")
 	scanCmd.PersistentFlags().BoolVar(&generateVEX, "vex", false, "Generate Vulnerability Exploitability eXchange (VEX) document")
 	scanCmd.PersistentFlags().StringVar(&sbomOutput, "sbom-output", "", "Output file path for SBOM (default: .armis/<artifact>-sbom.json)")


### PR DESCRIPTION
## Related Issue

* [PPSC-1012](https://armis.atlassian.net/browse/PPSC-1012)

## Type of Change

* [x] New feature (non-breaking change which adds functionality)
* [x] Documentation update

## Problem

Tab-completion for enumerated flags fell back to (useless) file-path completion, so users had to remember the accepted values for `--format`, `--fail-on`, `--color`, `--theme`, and `--group-by`, and the feature itself was undiscoverable.

## Solution

Register Cobra completion funcs that offer each flag's accepted values (with zsh/fish descriptions) and suppress file completion; the candidate lists reuse the same slices the validators read so they can never drift, and `--color` reuses the existing `cli.ColorMode*` constants. The README gains a Shell Completion section with per-shell setup (bash/zsh/fish/PowerShell), backed by `completion_test.go` asserting completions match the validators.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

`make build` then `source <(armis-cli completion zsh)` and confirmed `--format <TAB>` offers `human/json/sarif/junit` and `--group-by <TAB>` offers `none/cwe/severity/file`.

## Reviewer Notes

`--region` is intentionally omitted from completion (advisory-only). Pre-PR verify surfaced a `goconst` lint failure the feature introduced (a third `"always"` literal); fixed by reusing `cli.ColorMode*` constants. CHANGELOG `[Unreleased]` entry added.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] Documentation updated (if needed)
* [x] No new warnings generated

[PPSC-1012]: https://armis-security.atlassian.net/browse/PPSC-1012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ