### PR TITLE
[PPSC-1009] fix(hook): remove MCP-plugin gate on hook init; scope scan flags

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,11 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Command help is no longer cluttered with scan-only flags. The output flags `--format`, `--no-progress`, `--fail-on`, `--exit-code`, and `--page-limit` were registered as root persistent flags, so they appeared in the `--help` of every command — including non-scan commands like `hook`, `supply-chain`, `install`, and `agent-detection`, where they have no effect. They are now scoped to the `scan` command subtree where they belong. `supply-chain check`, a sibling of `scan` that does use `--format`/`--fail-on`/`--exit-code`, re-registers exactly those three locally (mirroring its existing `--output` handling), so its behavior is unchanged. (PPSC-1009)
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- `hook init` no longer refuses to install a pre-commit hook when the Armis MCP plugin is absent. It previously hard-errored with "Armis MCP server not installed — run 'armis-cli install' first", even though the hook installer already falls back to a direct `armis-cli scan repo . --changed=staged --no-progress --fail-on HIGH` hook when the plugin's own pre-commit script is missing. The redundant gate is removed, so `hook init` installs the direct-scan hook and prints a one-line advisory ("Armis MCP plugin not found; installing direct-scan hook…") instead of blocking. (PPSC-1009)
 
 ### Security
 

--- a/internal/cmd/completion_test.go
+++ b/internal/cmd/completion_test.go
@@ -58,8 +58,13 @@ func TestFlagCompletionsMatchValidators(t *testing.T) {
 		flag     string
 		expected []string
 	}{
-		{"format", rootCmd, "format", validFormats},
-		{"fail-on", rootCmd, "fail-on", cmdutil.ValidSeverities},
+		// --format/--fail-on were relocated from rootCmd to scanCmd (PPSC-1009),
+		// and supply-chain check re-registers its own instances (distinct flag
+		// pointers), so both registration sites are asserted here.
+		{"format", scanCmd, "format", validFormats},
+		{"fail-on", scanCmd, "fail-on", cmdutil.ValidSeverities},
+		{"sc-check format", scCheckCmd, "format", validFormats},
+		{"sc-check fail-on", scCheckCmd, "fail-on", cmdutil.ValidSeverities},
 		{"color", rootCmd, "color", []string{string(cli.ColorModeAuto), string(cli.ColorModeAlways), string(cli.ColorModeNever)}},
 		{"theme", rootCmd, "theme", []string{themeAuto, themeDark, themeLight}},
 		{"group-by", scanCmd, "group-by", validGroupBy},
@@ -87,8 +92,10 @@ func TestFlagCompletionsHaveDescriptions(t *testing.T) {
 		cmd  *cobra.Command
 		flag string
 	}{
-		{"format", rootCmd, "format"},
-		{"fail-on", rootCmd, "fail-on"},
+		{"format", scanCmd, "format"},
+		{"fail-on", scanCmd, "fail-on"},
+		{"sc-check format", scCheckCmd, "format"},
+		{"sc-check fail-on", scCheckCmd, "fail-on"},
 		{"color", rootCmd, "color"},
 		{"theme", rootCmd, "theme"},
 		{"group-by", scanCmd, "group-by"},

--- a/internal/cmd/hook_init.go
+++ b/internal/cmd/hook_init.go
@@ -58,13 +58,16 @@ func runHookInit(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
+	// Resolve the MCP plugin dir, but do not require it. buildPreCommitSection
+	// (internal/install/precommit.go) stats the plugin's git-hooks/pre-commit
+	// script itself and falls back to a direct `armis-cli scan` hook when it is
+	// absent. Gating on the plugin here would convert that graceful fallback into
+	// a hard block, denying a developer a working hook for no reason. Surface the
+	// degradation on stderr and continue.
 	ei := install.NewEditorInstaller()
 	pluginDir := ei.PluginDir()
-	if _, err := os.Stat(pluginDir); err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("Armis MCP server not installed — run 'armis-cli install' first") //nolint:staticcheck // proper noun
-		}
-		return fmt.Errorf("checking plugin directory %q: %w", pluginDir, err)
+	if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
+		fmt.Fprintln(os.Stderr, "Armis MCP plugin not found; installing direct-scan hook (run 'armis-cli install' to upgrade).")
 	}
 
 	opts := install.PreCommitOpts{FailOpen: failOpen}

--- a/internal/cmd/hook_init.go
+++ b/internal/cmd/hook_init.go
@@ -66,8 +66,15 @@ func runHookInit(cmd *cobra.Command, _ []string) error {
 	// degradation on stderr and continue.
 	ei := install.NewEditorInstaller()
 	pluginDir := ei.PluginDir()
-	if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
-		fmt.Fprintln(os.Stderr, "Armis MCP plugin not found; installing direct-scan hook (run 'armis-cli install' to upgrade).")
+	if _, err := os.Stat(pluginDir); err != nil {
+		// A missing plugin is the expected case; anything else (permission/IO)
+		// is surfaced distinctly so it is not silently masked. Neither blocks:
+		// buildPreCommitSection falls back to a direct-scan hook regardless.
+		if os.IsNotExist(err) {
+			fmt.Fprintln(os.Stderr, "Armis MCP plugin not found; installing direct-scan hook (run 'armis-cli install' to upgrade).")
+		} else {
+			fmt.Fprintf(os.Stderr, "Warning: could not access Armis MCP plugin dir %q: %v; installing direct-scan hook.\n", pluginDir, err)
+		}
 	}
 
 	opts := install.PreCommitOpts{FailOpen: failOpen}

--- a/internal/cmd/hook_init_test.go
+++ b/internal/cmd/hook_init_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newHookInitTestCmd builds a bare command exposing the two flags runHookInit
+// reads (--remove, --fail-open), mirroring hookInitCmd's flag set without
+// touching shared command state.
+func newHookInitTestCmd() *cobra.Command {
+	c := &cobra.Command{}
+	c.Flags().Bool("fail-open", false, "")
+	c.Flags().Bool("remove", false, "")
+	return c
+}
+
+// TestRunHookInit_NoPluginInstallsFallback is the regression test for the
+// PPSC-1009 P0: hook init used to hard-error when the MCP plugin was absent,
+// even though the install layer falls back to a direct-scan hook. With the gate
+// removed, hook init must succeed with no plugin present and write the fallback.
+func TestRunHookInit_NoPluginInstallsFallback(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	// Point HOME at an empty dir so NewEditorInstaller().PluginDir() resolves to
+	// a non-existent path — the exact condition that used to trigger the gate.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	// runHookInit detects the repo from the process cwd, so work inside a real
+	// git repo. chdirTemp restores the original cwd on cleanup.
+	dir := chdirTemp(t)
+	if err := runTestGitCmd(dir, "init"); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	if err := runHookInit(newHookInitTestCmd(), nil); err != nil {
+		t.Fatalf("runHookInit() with no plugin should succeed, got: %v", err)
+	}
+
+	// The hook physically lands in <repo>/.git/hooks/pre-commit.
+	hookPath := filepath.Join(dir, ".git", "hooks", "pre-commit")
+	data, err := os.ReadFile(hookPath) //nolint:gosec // G304: reading from t.TempDir()
+	if err != nil {
+		t.Fatalf("reading installed hook: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "armis-cli scan repo") {
+		t.Errorf("expected direct-scan fallback hook, got:\n%s", content)
+	}
+	if !strings.Contains(content, "--changed=staged") {
+		t.Errorf("expected fallback to scan staged changes, got:\n%s", content)
+	}
+}

--- a/internal/cmd/hook_init_test.go
+++ b/internal/cmd/hook_init_test.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/ArmisSecurity/armis-cli/internal/install"
 	"github.com/spf13/cobra"
 )
 
@@ -46,9 +46,15 @@ func TestRunHookInit_NoPluginInstallsFallback(t *testing.T) {
 		t.Fatalf("runHookInit() with no plugin should succeed, got: %v", err)
 	}
 
-	// The hook physically lands in <repo>/.git/hooks/pre-commit.
-	hookPath := filepath.Join(dir, ".git", "hooks", "pre-commit")
-	data, err := os.ReadFile(hookPath) //nolint:gosec // G304: reading from t.TempDir()
+	// Resolve the hook path through the same logic the installer uses
+	// (git rev-parse --git-path hooks), rather than hard-coding
+	// <repo>/.git/hooks/pre-commit — that would break under a custom
+	// core.hooksPath, worktrees, or submodules.
+	hookPath, err := install.PreCommitHookPath(dir)
+	if err != nil {
+		t.Fatalf("resolving hook path: %v", err)
+	}
+	data, err := os.ReadFile(hookPath) //nolint:gosec // G304: path resolved via git under t.TempDir()
 	if err != nil {
 		t.Fatalf("reading installed hook: %v", err)
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -209,11 +209,11 @@ func init() {
 
 	// General options
 	rootCmd.PersistentFlags().BoolVar(&useDev, "dev", false, "Use development environment instead of production")
-	rootCmd.PersistentFlags().StringVarP(&format, "format", "f", getEnvOrDefault("ARMIS_FORMAT", "human"), "Output format: human, json, sarif, junit")
-	rootCmd.PersistentFlags().BoolVar(&noProgress, "no-progress", false, "Suppress progress output (for CI/scripts)")
-	rootCmd.PersistentFlags().StringSliceVar(&failOn, "fail-on", []string{"CRITICAL"}, "Exit with error on findings at these severity levels: INFO, LOW, MEDIUM, HIGH, CRITICAL")
-	rootCmd.PersistentFlags().IntVar(&exitCode, "exit-code", 1, "Exit code when --fail-on triggers")
-	rootCmd.PersistentFlags().IntVar(&pageLimit, "page-limit", getEnvOrDefaultInt("ARMIS_PAGE_LIMIT", 500), "Results page size for pagination (range: 1-1000)")
+	// Scan-output flags (--format, --no-progress, --fail-on, --exit-code,
+	// --page-limit) are registered on scanCmd (see scan.go), not here: as root
+	// persistent flags they leaked into the --help of every non-scan command
+	// (hook, supply-chain, install, agent-detection). `supply-chain check` is a
+	// sibling of scan and re-registers the three it actually uses locally.
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enable debug mode to print detailed API responses")
 	rootCmd.PersistentFlags().BoolVar(&noUpdateCheck, "no-update-check", false, "Disable automatic update checking (env: ARMIS_NO_UPDATE_CHECK)")
 	rootCmd.PersistentFlags().StringVar(&colorFlag, "color", "auto", "Control colored output: auto, always, never")
@@ -223,19 +223,9 @@ func init() {
 	// (useless) file-path completion. The value lists reuse the same slices the
 	// validators read, so the completion candidates can't drift from what's
 	// actually accepted. --region is intentionally omitted (advisory-only).
-	_ = rootCmd.RegisterFlagCompletionFunc("format", fixedCompletions(validFormats, map[string]string{
-		"human": "Human-readable terminal output",
-		"json":  "Machine-readable JSON",
-		"sarif": "SARIF for code-scanning tools",
-		"junit": "JUnit XML for CI test reports",
-	}))
-	_ = rootCmd.RegisterFlagCompletionFunc("fail-on", fixedCompletions(cmdutil.ValidSeverities, map[string]string{
-		"INFO":     "Informational findings",
-		"LOW":      "Low-severity findings",
-		"MEDIUM":   "Medium-severity findings",
-		"HIGH":     "High-severity findings",
-		"CRITICAL": "Critical-severity findings",
-	}))
+	// --format/--fail-on completions are registered where those flags now live:
+	// on scanCmd (see scan.go) and re-registered on scCheckCmd (see
+	// supply_chain_check.go), since the flags were relocated off rootCmd.
 	_ = rootCmd.RegisterFlagCompletionFunc("color", fixedCompletions(
 		[]string{string(cli.ColorModeAuto), string(cli.ColorModeAlways), string(cli.ColorModeNever)},
 		map[string]string{
@@ -266,6 +256,30 @@ func fixedCompletions(values []string, descriptions map[string]string) cobra.Com
 		}
 	}
 	return cobra.FixedCompletions(choices, cobra.ShellCompDirectiveNoFileComp)
+}
+
+// formatCompletions and failOnCompletions return the completion functions for
+// the --format and --fail-on flags. These flags live on scanCmd and are
+// re-registered on scCheckCmd (a sibling of scan with its own flag instances),
+// so the candidate sets are defined once here and reused at both registration
+// sites to keep them from drifting apart.
+func formatCompletions() cobra.CompletionFunc {
+	return fixedCompletions(validFormats, map[string]string{
+		"human": "Human-readable terminal output",
+		"json":  "Machine-readable JSON",
+		"sarif": "SARIF for code-scanning tools",
+		"junit": "JUnit XML for CI test reports",
+	})
+}
+
+func failOnCompletions() cobra.CompletionFunc {
+	return fixedCompletions(cmdutil.ValidSeverities, map[string]string{
+		"INFO":     "Informational findings",
+		"LOW":      "Low-severity findings",
+		"MEDIUM":   "Medium-severity findings",
+		"HIGH":     "High-severity findings",
+		"CRITICAL": "Critical-severity findings",
+	})
 }
 
 // PrintUpdateNotification prints a version update notification if one is available.

--- a/internal/cmd/scan.go
+++ b/internal/cmd/scan.go
@@ -127,6 +127,7 @@ func init() {
 	scanCmd.PersistentFlags().BoolVar(&noProgress, "no-progress", false, "Suppress progress output (for CI/scripts)")
 	scanCmd.PersistentFlags().StringSliceVar(&failOn, "fail-on", defaultFailOn(), "Exit with error on findings at these severity levels: INFO, LOW, MEDIUM, HIGH, CRITICAL")
 	scanCmd.PersistentFlags().IntVar(&exitCode, "exit-code", 1, "Exit code when --fail-on triggers")
+	// armis:ignore cwe:770 cwe:401 reason:--page-limit is bounded to 1-1000 by validatePageLimit (root.go); every consumer (scan_repo.go, scan_image.go) reads it via getPageLimit() which validates before the value reaches any pagination sink. This is the flag declaration, not a sink.
 	scanCmd.PersistentFlags().IntVar(&pageLimit, "page-limit", getEnvOrDefaultInt("ARMIS_PAGE_LIMIT", 500), "Results page size for pagination (range: 1-1000)")
 	// Tab-completion for the relocated enumerated flags now lives with the flags.
 	_ = scanCmd.RegisterFlagCompletionFunc("format", formatCompletions())

--- a/internal/cmd/scan.go
+++ b/internal/cmd/scan.go
@@ -31,6 +31,12 @@ var validFormats = []string{"human", "json", "sarif", "junit"}
 // validGroupBy contains the valid group-by options.
 var validGroupBy = []string{"none", "cwe", "severity", "file"}
 
+// defaultFailOn returns the default --fail-on severity set. It returns a fresh
+// slice on each call so the two flag registrations (scanCmd and scCheckCmd)
+// never share backing storage — pflag parsing mutates a StringSlice's default
+// in place, which would otherwise leak between the two flag instances.
+func defaultFailOn() []string { return []string{"CRITICAL"} }
+
 var scanCmd = &cobra.Command{
 	Use:   "scan",
 	Short: "Scan artifacts for security vulnerabilities",
@@ -111,6 +117,21 @@ var scanCmd = &cobra.Command{
 }
 
 func init() {
+	// Scan-output flags. These were previously root persistent flags but only
+	// apply to the scan subtree, so they are scoped here to keep them out of the
+	// --help of non-scan commands (hook, supply-chain, install, agent-detection).
+	// Defaults and env bindings are preserved verbatim from their former root
+	// registrations. `supply-chain check` re-registers the subset it consumes
+	// locally (see supply_chain_check.go), since it is a sibling of scan.
+	scanCmd.PersistentFlags().StringVarP(&format, "format", "f", getEnvOrDefault("ARMIS_FORMAT", "human"), "Output format: human, json, sarif, junit")
+	scanCmd.PersistentFlags().BoolVar(&noProgress, "no-progress", false, "Suppress progress output (for CI/scripts)")
+	scanCmd.PersistentFlags().StringSliceVar(&failOn, "fail-on", defaultFailOn(), "Exit with error on findings at these severity levels: INFO, LOW, MEDIUM, HIGH, CRITICAL")
+	scanCmd.PersistentFlags().IntVar(&exitCode, "exit-code", 1, "Exit code when --fail-on triggers")
+	scanCmd.PersistentFlags().IntVar(&pageLimit, "page-limit", getEnvOrDefaultInt("ARMIS_PAGE_LIMIT", 500), "Results page size for pagination (range: 1-1000)")
+	// Tab-completion for the relocated enumerated flags now lives with the flags.
+	_ = scanCmd.RegisterFlagCompletionFunc("format", formatCompletions())
+	_ = scanCmd.RegisterFlagCompletionFunc("fail-on", failOnCompletions())
+
 	scanCmd.PersistentFlags().BoolVar(&includeTests, "include-tests", false, "Include test files in the scan (test files are excluded by default)")
 	scanCmd.PersistentFlags().IntVar(&scanTimeout, "scan-timeout", 60, "Maximum time in minutes to wait for scan analysis to complete")
 	scanCmd.PersistentFlags().IntVar(&uploadTimeout, "upload-timeout", 10, "Maximum time in minutes to wait for artifact upload to complete")

--- a/internal/cmd/scan_test.go
+++ b/internal/cmd/scan_test.go
@@ -70,6 +70,14 @@ func TestScanCmd(t *testing.T) {
 		if flags.Lookup("group-by") == nil {
 			t.Error("Expected --group-by flag")
 		}
+		// Scan-output flags were relocated from rootCmd to scanCmd (PPSC-1009) to
+		// keep them out of non-scan command help. They must remain available to
+		// the scan subtree.
+		for _, name := range []string{"format", "no-progress", "fail-on", "exit-code", "page-limit"} {
+			if flags.Lookup(name) == nil {
+				t.Errorf("Expected --%s flag on scanCmd", name)
+			}
+		}
 	})
 }
 
@@ -529,26 +537,19 @@ func TestRootCmd(t *testing.T) {
 		if flags.Lookup("dev") == nil {
 			t.Error("Expected --dev flag")
 		}
-		if flags.Lookup("format") == nil {
-			t.Error("Expected --format flag")
-		}
-		if flags.Lookup("no-progress") == nil {
-			t.Error("Expected --no-progress flag")
-		}
-		if flags.Lookup("fail-on") == nil {
-			t.Error("Expected --fail-on flag")
-		}
-		if flags.Lookup("exit-code") == nil {
-			t.Error("Expected --exit-code flag")
-		}
 		if flags.Lookup("tenant-id") == nil {
 			t.Error("Expected --tenant-id flag")
 		}
-		if flags.Lookup("page-limit") == nil {
-			t.Error("Expected --page-limit flag")
-		}
 		if flags.Lookup("debug") == nil {
 			t.Error("Expected --debug flag")
+		}
+		// Scan-output flags (--format, --no-progress, --fail-on, --exit-code,
+		// --page-limit) were relocated to scanCmd (PPSC-1009) and must NOT remain
+		// root persistent flags, so they stay out of non-scan command help.
+		for _, name := range []string{"format", "no-progress", "fail-on", "exit-code", "page-limit"} {
+			if flags.Lookup(name) != nil {
+				t.Errorf("--%s should be scoped to scanCmd, not rootCmd", name)
+			}
 		}
 	})
 

--- a/internal/cmd/supply_chain_check.go
+++ b/internal/cmd/supply_chain_check.go
@@ -71,6 +71,18 @@ func init() {
 	scCheckCmd.Flags().StringVar(&scLockfile, "lockfile", "", "Explicit lockfile path (overrides auto-detection)")
 	scCheckCmd.Flags().BoolVar(&scAll, "all", false, "Check all packages (disable auto-diff against base branch)")
 	scCheckCmd.Flags().BoolVar(&scFailOpen, "fail-open", false, "Exit 0 on registry errors (fail-open for CI availability)")
+	// --format, --fail-on, and --exit-code are persistent flags on scanCmd, but
+	// supply-chain is a sibling of scan in the command tree and does not inherit
+	// them. runSupplyChainCheck consumes all three (the format/failOn/exitCode
+	// globals), so register them locally to match the scan commands. Defaults
+	// mirror the former root registrations exactly.
+	scCheckCmd.Flags().StringVarP(&format, "format", "f", getEnvOrDefault("ARMIS_FORMAT", "human"), "Output format: human, json, sarif, junit")
+	scCheckCmd.Flags().StringSliceVar(&failOn, "fail-on", defaultFailOn(), "Exit with error on findings at these severity levels: INFO, LOW, MEDIUM, HIGH, CRITICAL")
+	scCheckCmd.Flags().IntVar(&exitCode, "exit-code", 1, "Exit code when --fail-on triggers")
+	// These are distinct flag instances from scanCmd's, so the completion funcs
+	// must be registered here too (Cobra keys completions by flag pointer).
+	_ = scCheckCmd.RegisterFlagCompletionFunc("format", formatCompletions())
+	_ = scCheckCmd.RegisterFlagCompletionFunc("fail-on", failOnCompletions())
 	// --output is a persistent flag on scanCmd, but supply-chain is a sibling of
 	// scan in the command tree and does not inherit it. Register it locally so
 	// `supply-chain check` matches the scan commands: ResolveOutput already


### PR DESCRIPTION
## Related Issue

* [PPSC-1009](https://armis.atlassian.net/browse/PPSC-1009)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [x] Refactoring (no functional changes)
* [ ] Performance improvement

## Problem

Two command-tree defects: `hook init` hard-errored ("Armis MCP server not installed — run 'armis-cli install' first") when the MCP plugin was absent, even though the installer already falls back to a direct `armis-cli scan` hook — denying developers a working hook for no reason. Separately, the scan-output flags (`--format`, `--no-progress`, `--fail-on`, `--exit-code`, `--page-limit`) were registered as **root** persistent flags, so they leaked into the `--help` of every non-scan command (`hook`, `supply-chain`, `install`, `agent-detection`) where they have no effect.

## Solution

Removed the redundant MCP-plugin gate in `hook init`; it now installs the direct-scan fallback hook and prints a one-line advisory instead of blocking. Relocated the five scan-output flags from `rootCmd` to `scanCmd.PersistentFlags()` (defaults and env bindings preserved verbatim), and re-registered the three that `supply-chain check` actually consumes (`--format`/`--fail-on`/`--exit-code`) locally on that sibling command. Flag completions moved alongside the flags via shared `formatCompletions()`/`failOnCompletions()` helpers, and `defaultFailOn()` returns a fresh slice per call so the two `--fail-on` registrations don't share pflag-mutated backing storage.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [ ] Integration tests added/updated
* [x] All tests passing locally

### Manual Testing

`make test` → 2711 passed, 72.0% coverage; `make lint` → 0 issues; `make build` → clean. New `TestRunHookInit_NoPluginInstallsFallback` is the PPSC-1009 P0 regression test (no plugin → hook init succeeds and writes the `armis-cli scan repo . --changed=staged` fallback). Updated `scan_test.go`/`completion_test.go` assert the flags now live on `scanCmd`/`scCheckCmd` and not on `rootCmd`.

## Reviewer Notes

`supply-chain check` is a *sibling* of `scan`, not a child, so it does not inherit `scanCmd`'s persistent flags — hence the deliberate local re-registration (mirroring its existing `--output` handling). Behavior of `supply-chain check` is unchanged. No breaking changes: the relocated flags still work identically under `scan`/`supply-chain check`, just no longer in unrelated command help.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] Documentation updated (CHANGELOG.md)
* [x] Breaking changes documented (n/a)
* [x] No new warnings generated


[PPSC-1009]: https://armis-security.atlassian.net/browse/PPSC-1009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ