### PR TITLE
[PPSC-1008] fix(install): harden install/uninstall lifecycle

### DIFF
--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -16,6 +16,8 @@ var installCmd = &cobra.Command{
 	Short: "Install the Armis security scanner MCP server",
 	Long: `Download and install the Armis AppSec MCP server for your coding tools.
 
+Requires Python 3.11+ on your PATH (the MCP server runs on it).
+
 With no arguments, installs the plugin and registers it in all detected editors.
 Specify one or more editor names to target specific tools.
 
@@ -128,6 +130,10 @@ func showInstalledVersions() error {
 }
 
 func installAll(force bool) error {
+	if err := install.CheckPython(); err != nil {
+		return err
+	}
+
 	ei := install.NewEditorInstaller()
 
 	fmt.Fprintln(os.Stderr, "Downloading Armis AppSec MCP server...")
@@ -235,9 +241,10 @@ func installTargets(targets []string, force bool) error {
 		case "copilot":
 			editorIDs = append(editorIDs, install.EditorCopilotCLI)
 		case "jetbrains":
-			fmt.Fprintln(os.Stderr, "JetBrains: MCP servers are configured per-project.")
-			fmt.Fprintln(os.Stderr, "After installing, copy .jb-mcp.json to your project root.")
-			fmt.Fprintln(os.Stderr, "Run: armis-cli install --jetbrains-project /path/to/project")
+			fmt.Fprintln(os.Stderr, "JetBrains: MCP servers are configured per-project (no automatic setup).")
+			fmt.Fprintln(os.Stderr, "  1. Install the MCP server first: armis-cli install <editor>")
+			fmt.Fprintln(os.Stderr, "  2. Create a .jb-mcp.json in your project root pointing at the installed")
+			fmt.Fprintln(os.Stderr, "     server, then enable it in your IDE's AI Assistant MCP settings.")
 			fmt.Fprintln(os.Stderr, "")
 		case "devin":
 			fmt.Fprintln(os.Stderr, "Devin: MCP servers are configured via the Devin web UI.")
@@ -260,6 +267,16 @@ func installTargets(targets []string, force bool) error {
 	}
 
 	needsSharedPlugin := len(editorIDs) > 0 || hasCodex
+
+	// Both the shared-plugin and Claude paths build a Python venv, so verify the
+	// interpreter is present before downloading anything (advisory-only targets
+	// like "jetbrains" skip the download and so skip this check).
+	if needsSharedPlugin || hasClaude {
+		if err := install.CheckPython(); err != nil {
+			return err
+		}
+	}
+
 	var ei *install.EditorInstaller
 
 	if needsSharedPlugin {

--- a/internal/cmd/install_interactive.go
+++ b/internal/cmd/install_interactive.go
@@ -15,6 +15,13 @@ import (
 )
 
 func runInteractiveInstall(force bool) error {
+	// Fail fast before prompting for credentials/editors: every meaningful path
+	// through the wizard ends in a Python venv build, so a missing interpreter
+	// should stop us before the user invests any setup effort.
+	if err := install.CheckPython(); err != nil {
+		return err
+	}
+
 	theme := cmdutil.GetInstallTheme()
 	accessible := !cli.ColorsEnabled()
 

--- a/internal/cmd/install_test.go
+++ b/internal/cmd/install_test.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ArmisSecurity/armis-cli/internal/install"
@@ -35,6 +37,39 @@ func TestInstallTargetsAdvisoryEditors(t *testing.T) {
 				t.Errorf("installTargets(%q) unexpected error: %v", name, err)
 			}
 		})
+	}
+}
+
+// TestInstallTargetsJetBrainsNoGhostFlag verifies fix #2: the JetBrains advisory
+// must not reference the nonexistent --jetbrains-project flag (which errors with
+// "unknown flag"), and should give accurate manual setup guidance instead.
+func TestInstallTargetsJetBrainsNoGhostFlag(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStderr := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = oldStderr })
+
+	installErr := installTargets([]string{"jetbrains"}, false)
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	_ = r.Close()
+
+	if installErr != nil {
+		t.Errorf("installTargets(jetbrains) unexpected error: %v", installErr)
+	}
+	output := string(out)
+	if strings.Contains(output, "--jetbrains-project") {
+		t.Errorf("JetBrains guidance must not mention the ghost flag --jetbrains-project, got:\n%s", output)
+	}
+	if !strings.Contains(output, ".jb-mcp.json") {
+		t.Errorf("JetBrains guidance should mention the .jb-mcp.json config file, got:\n%s", output)
 	}
 }
 

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -23,7 +23,9 @@ With no arguments, removes the plugin from all editors and deletes plugin files.
 Specify editor names to remove from specific tools only (plugin files are kept).
 
 Use --keep-credentials to preserve the .env file for easy reinstall.
-Use --force to skip the confirmation prompt.`,
+Use --force to skip the confirmation prompt.
+
+For a list of valid editor names, run: armis-cli install --help`,
 	Example: `  # Remove from all editors and delete plugin
   armis-cli uninstall
 
@@ -160,6 +162,24 @@ func uninstallAll(u *install.Uninstaller, keepCreds, force bool) error {
 		}
 	}
 
+	// Remove the git pre-commit hook from the current repo BEFORE deleting plugin
+	// files. The hook execs <pluginDir>/git-hooks/pre-commit; once RemovePluginFiles
+	// deletes that path, an orphaned hook would break every future commit with
+	// "no such file". RemovePreCommit is a no-op outside a git repo or when no
+	// Armis section is present, so it is safe to call unconditionally.
+	preCommitRemoved := false
+	if repoRoot := install.DetectGitRoot(); repoRoot != "" {
+		if err := install.RemovePreCommit(repoRoot); err != nil {
+			if styled {
+				fmt.Fprintf(os.Stderr, "  %s Pre-commit hook: %v\n", warnMark.Render("⚠"), err)
+			} else {
+				fmt.Fprintf(os.Stderr, "  ⚠ Pre-commit hook: %v\n", err)
+			}
+		} else {
+			preCommitRemoved = true
+		}
+	}
+
 	if err := u.RemovePluginFiles(keepCreds); err != nil {
 		if styled {
 			fmt.Fprintf(os.Stderr, "  %s Plugin files: %v\n", warnMark.Render("⚠"), err)
@@ -185,6 +205,14 @@ func uninstallAll(u *install.Uninstaller, keepCreds, force bool) error {
 		fmt.Fprintf(os.Stderr, "  %s Armis AppSec MCP server uninstalled.\n", successMark.Render("✓"))
 	} else {
 		fmt.Fprintln(os.Stderr, "Armis AppSec MCP server uninstalled.")
+	}
+	if preCommitRemoved {
+		msg := "Pre-commit hook removed from this repository. Run `armis-cli hook init --remove` in other repos."
+		if styled {
+			fmt.Fprintf(os.Stderr, "  %s\n", dimStyle.Render(msg))
+		} else {
+			fmt.Fprintln(os.Stderr, msg)
+		}
 	}
 	fmt.Fprintln(os.Stderr, "")
 	return nil

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -169,13 +169,18 @@ func uninstallAll(u *install.Uninstaller, keepCreds, force bool) error {
 	// Armis section is present, so it is safe to call unconditionally.
 	preCommitRemoved := false
 	if repoRoot := install.DetectGitRoot(); repoRoot != "" {
+		// Record whether a hook was actually present first: RemovePreCommit
+		// returns nil for the no-op cases too (no hook file, no Armis section),
+		// so a nil result alone would wrongly claim a removal. Only report one
+		// when a hook was installed before the call and is gone after it.
+		hadHook := install.IsPreCommitInstalled(repoRoot)
 		if err := install.RemovePreCommit(repoRoot); err != nil {
 			if styled {
 				fmt.Fprintf(os.Stderr, "  %s Pre-commit hook: %v\n", warnMark.Render("⚠"), err)
 			} else {
 				fmt.Fprintf(os.Stderr, "  ⚠ Pre-commit hook: %v\n", err)
 			}
-		} else {
+		} else if hadHook {
 			preCommitRemoved = true
 		}
 	}

--- a/internal/cmd/uninstall_test.go
+++ b/internal/cmd/uninstall_test.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ArmisSecurity/armis-cli/internal/install"
@@ -152,4 +154,74 @@ func TestUninstallAllForce(t *testing.T) {
 			t.Errorf("uninstallAll(keepCreds=true, force=true) unexpected error: %v", err)
 		}
 	})
+}
+
+// TestUninstallAllRemovesPreCommitHook verifies fix #9: uninstall must remove the
+// Armis pre-commit hook from the current repo before deleting plugin files, so
+// future commits don't break on a dangling hook script path.
+func TestUninstallAllRemovesPreCommitHook(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available on PATH")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	// Stage a plugin dir with a shipped pre-commit script so InstallPreCommit
+	// writes the "exec <pluginDir>/git-hooks/pre-commit" form that uninstall must
+	// later clean up.
+	pluginDir := filepath.Join(home, ".armis", "plugins", "armis-appsec-mcp")
+	gitHooksDir := filepath.Join(pluginDir, "git-hooks")
+	if err := os.MkdirAll(gitHooksDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitHooksDir, "pre-commit"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // executable hook for test
+		t.Fatal(err)
+	}
+
+	// Create a real git repo and chdir into it so install.DetectGitRoot resolves it.
+	repo := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...) // #nosec G204 -- test helper, controlled args
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "-b", "main")
+	t.Chdir(repo)
+
+	repoRoot := install.DetectGitRoot()
+	if repoRoot == "" {
+		t.Fatal("DetectGitRoot returned empty after git init")
+	}
+	if err := install.InstallPreCommit(repoRoot, pluginDir, install.PreCommitOpts{}); err != nil {
+		t.Fatalf("InstallPreCommit: %v", err)
+	}
+	if !install.IsPreCommitInstalled(repoRoot) {
+		t.Fatal("pre-commit hook not installed by setup")
+	}
+
+	u := install.NewUninstaller()
+	if err := uninstallAll(u, false, true); err != nil {
+		t.Fatalf("uninstallAll: %v", err)
+	}
+
+	if install.IsPreCommitInstalled(repoRoot) {
+		t.Error("pre-commit hook still present after uninstall — orphaned hook would break future commits")
+	}
+	// The plugin dir (and its git-hooks script) must be gone; the hook would now dangle.
+	if _, err := os.Stat(pluginDir); !os.IsNotExist(err) {
+		t.Errorf("plugin dir should be removed, stat err = %v", err)
+	}
+}
+
+// TestUninstallTargetsHelpMentionsInstall verifies fix #31: the uninstall command's
+// long help points users to `install --help` for the list of valid editor names.
+func TestUninstallTargetsHelpMentionsInstall(t *testing.T) {
+	if !strings.Contains(uninstallCmd.Long, "armis-cli install --help") {
+		t.Errorf("uninstall Long help should point to `armis-cli install --help`, got:\n%s", uninstallCmd.Long)
+	}
 }

--- a/internal/install/plugin.go
+++ b/internal/install/plugin.go
@@ -255,7 +255,7 @@ func (pi *PluginInstaller) downloadAndExtract(tarballURL, destDir string) error 
 func (pi *PluginInstaller) createVenv(pluginDir string) error {
 	python := findPython()
 	if python == "" {
-		return fmt.Errorf("Python 3.11+ is required but not found in PATH (tried %s)", strings.Join(pythonCandidates, ", ")) //nolint:staticcheck // proper noun
+		return pythonNotFoundError()
 	}
 
 	venvDir := filepath.Join(pluginDir, ".venv")
@@ -320,6 +320,38 @@ func writeJSON(path string, data interface{}) error {
 		return err
 	}
 	return os.WriteFile(filepath.Clean(path), append(b, '\n'), 0o600)
+}
+
+// CheckPython verifies that a Python 3.11+ interpreter is available on PATH.
+// It is a fast, side-effect-free preflight used by the install commands to fail
+// early — before any multi-MB plugin download — when the MCP server's runtime
+// dependency is missing. Returns nil if a suitable interpreter is found, or an
+// actionable error with per-OS install hints otherwise.
+func CheckPython() error {
+	if findPython() == "" {
+		return pythonNotFoundError()
+	}
+	return nil
+}
+
+// pythonNotFoundError builds the shared "Python not found" error with the list
+// of interpreter names tried and an OS-specific install hint. Centralized so the
+// preflight (CheckPython) and the venv setup (createVenv) emit identical guidance.
+func pythonNotFoundError() error {
+	var hint string
+	switch runtime.GOOS {
+	case osDarwin:
+		hint = "install it with: brew install python@3.11"
+	case osLinux:
+		hint = "install it with your package manager, e.g.: sudo apt install python3.11"
+	case osWindows:
+		hint = "install it from https://www.python.org/downloads/ (enable \"Add to PATH\")"
+	default:
+		hint = "install it from https://www.python.org/downloads/"
+	}
+	// armis:ignore reason:"Python" is a proper noun; leading capital is intentional
+	return fmt.Errorf("Python 3.11+ is required for the MCP server but was not found in PATH (tried %s)\n%s", //nolint:staticcheck // proper noun
+		strings.Join(pythonCandidates, ", "), hint)
 }
 
 func findPython() string {

--- a/internal/install/plugin.go
+++ b/internal/install/plugin.go
@@ -349,13 +349,17 @@ func pythonNotFoundError() error {
 	default:
 		hint = "install it from https://www.python.org/downloads/"
 	}
+	// "no suitable ... found" covers both cases findPython rejects: no interpreter
+	// on PATH at all, and one that exists but is older than 3.11 (the version probe
+	// fails). "not found in PATH" alone would mislead users who do have Python.
 	// armis:ignore reason:"Python" is a proper noun; leading capital is intentional
-	return fmt.Errorf("Python 3.11+ is required for the MCP server but was not found in PATH (tried %s)\n%s", //nolint:staticcheck // proper noun
+	return fmt.Errorf("no suitable Python 3.11+ interpreter found on PATH (tried %s)\n%s", //nolint:staticcheck // proper noun
 		strings.Join(pythonCandidates, ", "), hint)
 }
 
 func findPython() string {
 	for _, name := range pythonCandidates {
+		// armis:ignore cwe:426 cwe:427 reason:name is from the hardcoded pythonCandidates allowlist (not user input); resolved path is validated via EvalSymlinks + IsAbs below
 		resolved, err := exec.LookPath(name)
 		if err != nil {
 			continue

--- a/internal/install/plugin_test.go
+++ b/internal/install/plugin_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -50,6 +51,42 @@ func TestFetchLatestRelease_NoRelease(t *testing.T) {
 	_, err := pi.fetchLatestRelease()
 	if err == nil {
 		t.Fatal("expected error for 404 response")
+	}
+}
+
+func TestCheckPython_NotFound(t *testing.T) {
+	// Stripping PATH makes exec.LookPath fail for every candidate, so findPython
+	// returns "" deterministically regardless of what is installed on the host.
+	t.Setenv("PATH", "")
+
+	err := CheckPython()
+	if err == nil {
+		t.Fatal("expected error when no Python interpreter is on PATH")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "Python 3.11+") {
+		t.Errorf("error should mention the required version, got: %q", msg)
+	}
+	// The message must list the interpreter names tried so users know what to install.
+	for _, name := range pythonCandidates {
+		if !strings.Contains(msg, name) {
+			t.Errorf("error should list candidate %q, got: %q", name, msg)
+		}
+	}
+	// And it must include an actionable, OS-specific install hint (second line).
+	if !strings.Contains(msg, "\n") {
+		t.Errorf("error should include an install hint on a second line, got: %q", msg)
+	}
+}
+
+func TestCheckPython_Found(t *testing.T) {
+	// Only assert success when a suitable interpreter actually exists; on a host
+	// without Python 3.11+ this is not an error condition for the test.
+	if findPython() == "" {
+		t.Skip("no Python 3.11+ interpreter available on this host")
+	}
+	if err := CheckPython(); err != nil {
+		t.Errorf("CheckPython() = %v, want nil when a 3.11+ interpreter is present", err)
 	}
 }
 

--- a/internal/install/plugin_test.go
+++ b/internal/install/plugin_test.go
@@ -80,13 +80,36 @@ func TestCheckPython_NotFound(t *testing.T) {
 }
 
 func TestCheckPython_Found(t *testing.T) {
-	// Only assert success when a suitable interpreter actually exists; on a host
-	// without Python 3.11+ this is not an error condition for the test.
-	if findPython() == "" {
-		t.Skip("no Python 3.11+ interpreter available on this host")
+	// Make the success path deterministic by planting a stub interpreter on PATH
+	// that reports a >= 3.11 version, instead of depending on the host's Python.
+	// The stub is a shell script, which exec.LookPath only runs as a bare command
+	// on Unix; on Windows it would need a .exe/.bat shim, so fall back there to
+	// asserting against a real host interpreter (skipping if none is present).
+	if runtime.GOOS == osWindows {
+		if findPython() == "" {
+			t.Skip("no Python 3.11+ interpreter available on this Windows host")
+		}
+		if err := CheckPython(); err != nil {
+			t.Errorf("CheckPython() = %v, want nil when a 3.11+ interpreter is present", err)
+		}
+		return
 	}
+
+	dir := t.TempDir()
+	// findPython runs `<interp> -c "import sys; print(sys.version_info >= (3, 11))"`
+	// and accepts the interpreter only when it prints exactly "True". The stub
+	// prints True regardless of args, which is all the version probe needs.
+	stub := filepath.Join(dir, "python3.11")
+	script := "#!/bin/sh\necho True\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil { //nolint:gosec // test stub must be executable
+		t.Fatal(err)
+	}
+	// Restrict PATH to the stub dir so findPython resolves our stub, not a real
+	// host Python that might be a different version.
+	t.Setenv("PATH", dir)
+
 	if err := CheckPython(); err != nil {
-		t.Errorf("CheckPython() = %v, want nil when a 3.11+ interpreter is present", err)
+		t.Errorf("CheckPython() = %v, want nil when a 3.11+ interpreter is on PATH", err)
 	}
 }
 


### PR DESCRIPTION
## Related Issue

* [PPSC-1008](https://armis.atlassian.net/browse/PPSC-1008)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

Three rough edges in the MCP-server install/uninstall lifecycle: a missing Python interpreter only surfaced *after* a multi-MB plugin download, the JetBrains advisory pointed at a `--jetbrains-project` flag that does not exist (errors with "unknown flag"), uninstall deleted plugin files while leaving the git pre-commit hook pointing at the now-missing `<pluginDir>/git-hooks/pre-commit` (breaking every future commit), and `uninstall --help` gave no way to discover valid editor names.

## Solution

Added a fast, side-effect-free `CheckPython` preflight that runs before any download (with a centralized, per-OS install hint shared with venv setup); replaced the JetBrains ghost-flag guidance with accurate manual `.jb-mcp.json` setup steps; made uninstall remove the pre-commit hook *before* deleting plugin files (no-op outside a git repo, so safe to call unconditionally); and pointed `uninstall --help` at `install --help` for the editor-name list.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

New tests cover each fix: `TestCheckPython_NotFound`/`_Found`, `TestInstallTargetsJetBrainsNoGhostFlag`, `TestUninstallAllRemovesPreCommitHook`, and `TestUninstallTargetsHelpMentionsInstall`. Full suite green (2711 passed, coverage 71.8%); lint clean; security scan of the branch diff clean.

## Reviewer Notes

No behavior change for the happy path — these are guardrails around failure and teardown. The pre-commit removal runs only when a git repo is detected and an Armis hook section is present. Branch is one commit behind `main` (PPSC-1009) with zero file overlap, so it rebases/merges cleanly.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [ ] Documentation updated (if needed) — see note: no CHANGELOG entry yet
* [x] No new warnings generated


[PPSC-1008]: https://armis-security.atlassian.net/browse/PPSC-1008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ