### PR TITLE
[PPSC-1080] fix(install): use pip --prefer-binary so cryptography avoids source build behind TLS-inspecting proxies

### DIFF
--- a/internal/install/plugin.go
+++ b/internal/install/plugin.go
@@ -273,9 +273,19 @@ func (pi *PluginInstaller) createVenv(pluginDir string) error {
 		pip = filepath.Join(venvDir, "Scripts", "pip.exe")
 	}
 	reqsFile := filepath.Join(pluginDir, "requirements.txt")
+	// --prefer-binary makes pip favor the newest dependency version that ships a
+	// usable wheel over a newer source-only release, instead of pip's default of
+	// "newest version wins, build from source if needed". This matters for the
+	// transitive cryptography dep (mcp[cli] -> pyjwt[crypto] -> cryptography):
+	// when its latest release lacks a matching wheel, a source build pulls in a
+	// Rust toolchain via a rustup-init download — which fails behind corporate
+	// TLS-inspecting proxies (e.g. Zscaler) with CERTIFICATE_VERIFY_FAILED. A
+	// prior wheeled version exists, so this avoids the build entirely without
+	// pinning anything. pip falls back to a source build only if no version has
+	// a compatible wheel, so machines that already worked are unaffected.
 	// armis:ignore cwe:78 reason:pip binary from our own venv directory; args are hardcoded literals
 	// armis:ignore cwe:94 reason:pip binary from our own venv; reqsFile is hardcoded "requirements.txt"
-	pipCmd := exec.Command(pip, "install", "-q", "-r", reqsFile) //nolint:gosec // pip path derived from our own venv
+	pipCmd := exec.Command(pip, "install", "-q", "--prefer-binary", "-r", reqsFile) //nolint:gosec // pip path derived from our own venv
 	pipCmd.Stdout = os.Stderr
 	pipCmd.Stderr = os.Stderr
 	if err := pipCmd.Run(); err != nil {


### PR DESCRIPTION
## Summary

`armis-cli install` fails behind a TLS-inspecting corporate proxy (Zscaler) while setting up the MCP server's Python venv. The error misleadingly ends with `╰─> cryptography` and `CERTIFICATE_VERIFY_FAILED`, looking like a pip↔PyPI TLS problem — but it isn't.

## Root cause

The SSL failure is a *secondary* effect of pip building `cryptography` **from source**:

1. `requirements.txt` pins `mcp[cli]==1.25.0`, which pulls in `cryptography` **transitively**: `mcp[cli]` → `pyjwt[crypto]` → `cryptography`.
2. pip's default policy is "newest version wins, then build from source if no wheel." The latest `cryptography` (49.0.0) ships **no compatible wheel**, so pip downloads the sdist and tries to build it.
3. Building from source needs Rust. `maturin`/`puccinialin` downloads `rustup-init` from `static.rust-lang.org` via its own `httpx` client (which doesn't trust the OS CA store) — and *that* request dies on Zscaler's self-signed cert.

A prior wheeled version (`cryptography 48.0.1`, `cp311-abi3-...universal2`, covers Intel + Apple Silicon, Python ≥3.11) exists; pip only skips it because of "newest version wins."

## Fix

Add `--prefer-binary` to the pip invocation in `createVenv` (`internal/install/plugin.go`):

```go
pipCmd := exec.Command(pip, "install", "-q", "--prefer-binary", "-r", reqsFile)
```

`--prefer-binary` makes pip favor the newest version that ships a usable wheel over a newer source-only release. The Rust build — and the rustup download that failed — never happens. Graceful / non-flag-day: pins nothing, and pip still falls back to a source build only if *no* version has a wheel, so machines that already worked are unaffected.

## Verification

Reproduced dependency resolution in a clean venv:

| pip invocation | resolves `cryptography` to | outcome |
|---|---|---|
| `pip install` (before) | `49.0.0.tar.gz` (source) | ❌ Rust build → rustup download → SSL fail |
| `pip install --prefer-binary` (after) | `48.0.1-...universal2.whl` | ✅ no build, no Rust, no rustup call |

`go build`, `go test ./internal/install/...`, and `golangci-lint` all pass.

## Notes / follow-ups

- Distinct from #247 / PPSC-1064 (Go HTTP clients ignoring WinINET/PAC). This is a *Python subprocess* doing its own egress, which `ProxyAwareTransport()` cannot help. A belt-and-suspenders follow-up could inject the resolved proxy / a CA bundle (`HTTPS_PROXY`, `PIP_CERT`/`REQUESTS_CA_BUNDLE`) into `pipCmd.Env`.
- A durable fix could also live in the separate `ArmisSecurity/armis-appsec-mcp` repo by pinning `cryptography`/`pyjwt` to a wheeled version in `requirements.txt`.

## Acceptance test

On a machine behind a TLS-inspecting proxy where the latest `cryptography` is source-only, `armis-cli install` completes the Python venv setup without attempting a Rust/cryptography source build.

Jira: PPSC-1080