### PR TITLE
[PPSC-1081] feat(agent-detection): CLI ergonomics fixes

### DIFF
--- a/internal/agentdetect/agent.go
+++ b/internal/agentdetect/agent.go
@@ -23,6 +23,16 @@ const (
 
 // AgentDetector detects the presence of a coding agent for a given user home directory.
 // resolvedHome is the symlink-resolved, canonical path for homeDir (resolved once by Scanner).
+//
+// DetectVersion returns the installed version, or "" when no reliable on-disk
+// source exists. Versions are read from files only (e.g. a VS Code/JetBrains
+// extension's package.json). We deliberately never shell out to the agent's
+// binary: the scanner can run as root over every user's home directory, where
+// executing another user's binary would be unsafe and would not report that
+// user's version anyway. Agents detected via dotfiles or app bundles (Claude
+// Code, Cursor, Gemini CLI, Zed, Continue, Aider, Devin, OpenHands, Junie,
+// Antigravity) carry no consistent version file, so their DetectVersion is an
+// intentional "" stub rather than an oversight.
 type AgentDetector interface {
 	Name() AgentName
 	Detect(resolvedHome, homeDir string, platform Platform) bool
@@ -49,4 +59,39 @@ func Registry() []AgentDetector {
 		&continueDetector{},
 		&geminiCLIDetector{},
 	}
+}
+
+// displayNames maps internal agent identifiers to human-readable names for help text.
+var displayNames = map[AgentName]string{
+	AgentClaudeCode:        "Claude Code",
+	AgentWindsurf:          "Windsurf",
+	AgentGoogleAntigravity: "Google Antigravity",
+	AgentGitHubCopilot:     "GitHub Copilot",
+	AgentCursor:            "Cursor",
+	AgentCline:             "Cline",
+	AgentRooCode:           "Roo Code",
+	AgentAider:             "Aider",
+	AgentDevin:             "Devin",
+	AgentOpenHands:         "OpenHands",
+	AgentAmazonQ:           "Amazon Q",
+	AgentJunie:             "Junie",
+	AgentZed:               "Zed",
+	AgentContinue:          "Continue",
+	AgentGeminiCLI:         "Gemini CLI",
+}
+
+// RegisteredAgentDisplayNames returns the human-readable names of all registered
+// detectors, in registry order. Used to keep help text in sync with Registry so
+// the agent list never drifts when a detector is added.
+func RegisteredAgentDisplayNames() []string {
+	detectors := Registry()
+	names := make([]string, 0, len(detectors))
+	for _, d := range detectors {
+		if display, ok := displayNames[d.Name()]; ok {
+			names = append(names, display)
+		} else {
+			names = append(names, string(d.Name()))
+		}
+	}
+	return names
 }

--- a/internal/agentdetect/agent.go
+++ b/internal/agentdetect/agent.go
@@ -31,8 +31,8 @@ const (
 // executing another user's binary would be unsafe and would not report that
 // user's version anyway. Agents detected via dotfiles or app bundles (Claude
 // Code, Cursor, Gemini CLI, Zed, Continue, Aider, Devin, OpenHands, Junie,
-// Antigravity) carry no consistent version file, so their DetectVersion is an
-// intentional "" stub rather than an oversight.
+// Google Antigravity) carry no consistent version file, so their DetectVersion
+// is an intentional "" stub rather than an oversight.
 type AgentDetector interface {
 	Name() AgentName
 	Detect(resolvedHome, homeDir string, platform Platform) bool

--- a/internal/agentdetect/agentdetect_test.go
+++ b/internal/agentdetect/agentdetect_test.go
@@ -272,3 +272,36 @@ func TestFormatJSON_Empty(t *testing.T) {
 		t.Errorf("expected empty array, got %d agents", len(agents))
 	}
 }
+
+func TestRegisteredAgentDisplayNames(t *testing.T) {
+	t.Parallel()
+
+	names := RegisteredAgentDisplayNames()
+
+	// Must stay in sync with the detector registry so help text never drifts.
+	if got, want := len(names), len(Registry()); got != want {
+		t.Errorf("len(display names) = %d, want %d (one per registered detector)", got, want)
+	}
+
+	// Every name must be human-readable: non-empty and mapped (not a raw identifier).
+	for i, name := range names {
+		if name == "" {
+			t.Errorf("display name at index %d is empty", i)
+		}
+	}
+
+	// Spot-check that identifiers are mapped to friendly names, not passed through raw.
+	joined := strings.Join(names, ", ")
+	for _, want := range []string{"Claude Code", "GitHub Copilot", "Gemini CLI", "Roo Code", "Amazon Q"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("display names missing %q; got: %s", want, joined)
+		}
+	}
+
+	// Every registered detector must have a display-name mapping.
+	for _, d := range Registry() {
+		if _, ok := displayNames[d.Name()]; !ok {
+			t.Errorf("detector %q has no entry in displayNames map", d.Name())
+		}
+	}
+}

--- a/internal/cmd/agent_detection.go
+++ b/internal/cmd/agent_detection.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/ArmisSecurity/armis-cli/internal/agentdetect"
 	"github.com/spf13/cobra"
@@ -14,14 +15,23 @@ const (
 
 var agentDetectFormat string
 
-var agentDetectionCmd = &cobra.Command{
-	Use:   "agent-detection",
-	Short: "Detect AI coding agents installed on this system",
-	Long: `Detect AI coding agents (Claude Code, Cursor, Copilot, Windsurf, Google Antigravity)
-across user profiles and check if Armis AppSec MCP is enabled.
+// agentDetectionLong builds the long help text, sourcing the agent list from the
+// detector registry so it stays in sync as detectors are added or removed.
+func agentDetectionLong() string {
+	names := agentdetect.RegisteredAgentDisplayNames()
+	return fmt.Sprintf(`Detect AI coding agents across user profiles and check if Armis AppSec MCP is enabled.
+
+Detects %d agents: %s.
 
 When run as root (macOS/Linux) or SYSTEM (Windows), scans all local user profiles.
 When run as a standard user, scans only the current user's home directory.`,
+		len(names), strings.Join(names, ", "))
+}
+
+var agentDetectionCmd = &cobra.Command{
+	Use:   "agent-detection",
+	Short: "Detect AI coding agents installed on this system",
+	Long:  agentDetectionLong(),
 	Example: `  # Detect agents for current user
   armis-cli agent-detection
 
@@ -30,6 +40,7 @@ When run as a standard user, scans only the current user's home directory.`,
 
   # Detect agents across all users (requires root/admin)
   sudo armis-cli agent-detection`,
+	Args: cobra.NoArgs,
 	RunE: runAgentDetection,
 }
 

--- a/internal/cmd/agent_detection_collect.go
+++ b/internal/cmd/agent_detection_collect.go
@@ -23,6 +23,7 @@ When run as a standard user, scans only the current user's home directory.`,
 
   # Report agents across all users (requires root/admin)
   sudo armis-cli agent-detection collect`,
+	Args: cobra.NoArgs,
 	RunE: runAgentDetectionCollect,
 }
 
@@ -31,6 +32,13 @@ func init() {
 }
 
 func runAgentDetectionCollect(cmd *cobra.Command, _ []string) error {
+	// collect reports to the cloud inventory and has no formatted stdout output,
+	// so the inherited global --format flag is meaningless here. Reject it
+	// explicitly rather than silently ignoring it.
+	if cmd.Flags().Changed("format") {
+		return fmt.Errorf("collect does not support --format; it reports to Armis Cloud and prints status to stderr")
+	}
+
 	ctx, cancel := NewSignalContext()
 	defer cancel()
 

--- a/internal/cmd/agent_detection_collect_test.go
+++ b/internal/cmd/agent_detection_collect_test.go
@@ -1,11 +1,36 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/ArmisSecurity/armis-cli/internal/agentdetect"
 	"github.com/ArmisSecurity/armis-cli/internal/api"
+	"github.com/spf13/cobra"
 )
+
+func TestAgentDetectionCmd_RejectsArgs(t *testing.T) {
+	// Both the parent command and the collect subcommand must reject unknown
+	// positional args rather than silently running detection (and exiting 0).
+	for _, cmd := range []*cobra.Command{agentDetectionCmd, agentDetectionCollectCmd} {
+		if cmd.Args == nil {
+			t.Errorf("%q has no Args validator; unknown positional args would be silently ignored", cmd.Name())
+			continue
+		}
+		if err := cmd.Args(cmd, []string{"bogus"}); err == nil {
+			t.Errorf("%q accepted an unexpected positional arg; want error", cmd.Name())
+		}
+	}
+}
+
+func TestAgentDetectionLong_ListsAllAgents(t *testing.T) {
+	long := agentDetectionLong()
+	for _, name := range agentdetect.RegisteredAgentDisplayNames() {
+		if !strings.Contains(long, name) {
+			t.Errorf("agent-detection long help missing %q; help text drifted from registry", name)
+		}
+	}
+}
 
 func TestBuildInventoryPayload(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Related Issue

* [PPSC-1081](https://armis-security.atlassian.net/browse/PPSC-1081) (subtask of [PPSC-1004](https://armis-security.atlassian.net/browse/PPSC-1004) — Armis CLI DX improvements)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Refactoring (no functional changes)
* [ ] Performance improvement

## Problem

A `/devex-review` of the `agent-detection` command surfaced four ergonomics gaps: unknown positional args (e.g. `agent-detection bogus`) silently ran detection and exited 0 (hiding typos); `--help` named only 5 of the 15 detected agents; `collect` inherited the global `--format` flag but silently ignored it; and the empty version returned for 10 of 15 agents looked like an oversight rather than a deliberate constraint.

## Solution

Added `cobra.NoArgs` to both commands so unknown args error clearly; generated the `--help` agent list from the detector registry so it lists all 15 and can never drift; rejected an explicitly-passed `--format` on `collect` with an explanatory error (using `Flags().Changed`, so `ARMIS_FORMAT` is unaffected); and documented on the `AgentDetector` interface why version detection is file-only and intentionally empty for non-extension agents (the root-scoped scanner cannot safely shell out to another user's binary).

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [ ] Integration tests added/updated
* [x] All tests passing locally

### Manual Testing

Built the binary and exercised every path: `agent-detection bogus` and `collect bogus` now exit 1 with `unknown command`; `--help` lists all 15 agents; `collect -f json` errors while `ARMIS_FORMAT=json ... collect` passes through to auth; normal detection (plain + JSON) and the empty-result case still work. `gofmt`, `golangci-lint`, and `go test ./...` all clean.

## Reviewer Notes

Pure CLI-ergonomics changes — no behavior change to actual detection or the cloud-inventory payload. README/CHANGELOG entries were intentionally deferred and are not in this PR. The branch is currently behind `main`; will rebase if needed during review.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [ ] Documentation updated (if needed)
* [ ] Breaking changes documented (if applicable)
* [x] No new warnings generated

[PPSC-1081]: https://armis-security.atlassian.net/browse/PPSC-1081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PPSC-1004]: https://armis-security.atlassian.net/browse/PPSC-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ