### PR TITLE
[PPSC-1010] fix(supply-chain): polish check gate, uninit, and npmrc handling

### DIFF
--- a/internal/cmd/supply_chain_check.go
+++ b/internal/cmd/supply_chain_check.go
@@ -33,6 +33,7 @@ var (
 	scAll          bool
 	scFailOpen     bool
 	scReport       string
+	scFailOn       []string
 )
 
 var scCheckCmd = &cobra.Command{
@@ -72,14 +73,30 @@ func init() {
 	scCheckCmd.Flags().StringVar(&scLockfile, "lockfile", "", "Explicit lockfile path (overrides auto-detection)")
 	scCheckCmd.Flags().BoolVar(&scAll, "all", false, "Check all packages (disable auto-diff against base branch)")
 	scCheckCmd.Flags().BoolVar(&scFailOpen, "fail-open", false, "Exit 0 on registry errors (fail-open for CI availability)")
-	// --format, --fail-on, and --exit-code are persistent flags on scanCmd, but
-	// supply-chain is a sibling of scan in the command tree and does not inherit
-	// them. runSupplyChainCheck consumes all three (the format/failOn/exitCode
-	// globals), so register them locally to match the scan commands. Defaults
-	// mirror the former root registrations exactly.
+	// --format and --exit-code are persistent flags on scanCmd, but supply-chain
+	// is a sibling of scan in the command tree and does not inherit them.
+	// runSupplyChainCheck consumes both (the format/exitCode globals), so register
+	// them locally to match the scan commands. Defaults mirror the former root
+	// registrations exactly. --fail-on is also registered locally below, but bound
+	// to its own scFailOn var with a "medium" default (see that registration).
 	scCheckCmd.Flags().StringVarP(&format, "format", "f", getEnvOrDefault("ARMIS_FORMAT", "human"), "Output format: human, json, sarif, junit")
-	scCheckCmd.Flags().StringSliceVar(&failOn, "fail-on", defaultFailOn(), "Exit with error on findings at these severity levels: INFO, LOW, MEDIUM, HIGH, CRITICAL")
 	scCheckCmd.Flags().IntVar(&exitCode, "exit-code", 1, "Exit code when --fail-on triggers")
+	// Locally shadow the root's persistent --fail-on with a default that can
+	// actually gate. supply-chain violations are graded MEDIUM or HIGH by
+	// ClassifySeverity (they never reach CRITICAL), so the root default of
+	// [CRITICAL] (root.go) would let a copy-pasted `supply-chain check` pass CI
+	// no matter how many violations it found — a silently broken gate. Default to
+	// "medium" here so any real violation fails by default, while leaving the flag
+	// fully overridable (e.g. --fail-on high to gate only on packages published
+	// in the last 24h). Same sibling-of-scan rationale as --output below:
+	// supply-chain does not inherit scan's flag defaults, and a locally-registered
+	// flag cleanly shadows the root's persistent one (cobra's mergePersistentFlags
+	// skips the parent flag when a same-named local flag exists). Bound to its own
+	// scFailOn var — not the failOn global — so the two registrations don't both
+	// write the global at init() time, where the resting default would silently
+	// depend on init() ordering. runSupplyChainCheck reads scFailOn explicitly.
+	// Registered before the completion func below, which keys off the flag pointer.
+	scCheckCmd.Flags().StringSliceVar(&scFailOn, "fail-on", []string{"medium"}, "Exit with error on findings at these severity levels: INFO, LOW, MEDIUM, HIGH, CRITICAL")
 	// These are distinct flag instances from scanCmd's, so the completion funcs
 	// must be registered here too (Cobra keys completions by flag pointer).
 	_ = scCheckCmd.RegisterFlagCompletionFunc("format", formatCompletions())
@@ -112,8 +129,11 @@ func runSupplyChainCheck(cmd *cobra.Command, args []string) error {
 	// not inherit scan.PersistentPreRunE's validation; without this, a typo'd
 	// --fail-on would run the full check and print results before erroring.
 	// cmdutil.GetFailOn also case-normalizes to uppercase so ShouldFail (which
-	// matches exactly) trips on a lowercase "medium".
-	failOnSeverities, err := cmdutil.GetFailOn(failOn)
+	// matches exactly) trips on a lowercase "medium". Read scFailOn (the
+	// check-local flag, default "medium"), not the failOn global — scFailOn
+	// shadows root's persistent --fail-on, whose [CRITICAL] default would never
+	// gate a MEDIUM/HIGH supply-chain violation; see its registration.
+	failOnSeverities, err := cmdutil.GetFailOn(scFailOn)
 	if err != nil {
 		return err
 	}
@@ -179,10 +199,26 @@ func runSupplyChainCheck(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if autoDetectedBase {
+		// armis:ignore cwe:73 cwe:22 reason:this branch only runs when autoDetectedBase is set, which detectBaseLockfile sets solely for the os.CreateTemp temp file it just created; a user-supplied --base-lockfile leaves autoDetectedBase false and is never removed, so the deleted path is always CLI-owned with no external control
 		defer os.Remove(baseLockfile) //nolint:errcheck,gosec
 	}
 
+	// Without --all and without a usable base lockfile, only-new diffing is
+	// impossible, so check silently audits every package — a different, stricter
+	// mode than the default. detectBaseLockfile already announces the auto-detected
+	// case (and an explicit --base-lockfile is the user's own choice), so surface
+	// only the remaining silent path: no git base was found and the user did not
+	// ask for --all. Say so plainly so the broader scope isn't mistaken for the
+	// only-new default.
+	if !scAll && baseLockfile == "" {
+		s := output.GetStyles()
+		fmt.Fprintf(os.Stderr, "%s %s\n",
+			s.MutedText.Render("[armis]"),
+			s.MutedText.Render("supply-chain: no git base detected, checking all packages (use --all to suppress this notice)"))
+	}
+
 	ctx := cmd.Context()
+	// armis:ignore cwe:73 cwe:22 reason:lockfilePath and baseLockfile derive from the user-controlled --lockfile/--base-lockfile CLI flags (or auto-detected paths) naming files on the user's own machine; reading them is the purpose of `supply-chain check`, same no-trust-boundary pattern as --output suppressed at the flag registration above
 	result, err := check.RunCheck(ctx, policy, lockfilePath, baseLockfile)
 	if err != nil {
 		if policy.FailOpen {
@@ -267,8 +303,8 @@ func runSupplyChainCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	// failOnSeverities was validated and uppercase-normalized at the top of this
-	// function (before the scan ran), so a lowercase "medium" correctly trips
-	// ShouldFail's exact match here.
+	// function (before the scan ran) from the check-local scFailOn flag, so a
+	// lowercase "medium" correctly trips ShouldFail's exact match here.
 	return output.CheckExit(scanResult, failOnSeverities, exitCode)
 }
 

--- a/internal/cmd/supply_chain_check_test.go
+++ b/internal/cmd/supply_chain_check_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ArmisSecurity/armis-cli/internal/cmd/cmdutil"
+	"github.com/ArmisSecurity/armis-cli/internal/model"
+	"github.com/ArmisSecurity/armis-cli/internal/output"
 	"github.com/ArmisSecurity/armis-cli/internal/supplychain"
 	"github.com/spf13/cobra"
 )
@@ -272,18 +275,20 @@ func TestRunSupplyChainCheck_OutputFlagWritesFile(t *testing.T) {
 	outPath := filepath.Join(dir, "report.sarif")
 
 	// Save/restore every package-level var the check command reads so this test
-	// can't leak state into others sharing the cmd package.
+	// can't leak state into others sharing the cmd package. The gate var is
+	// scFailOn (the check-local shadow runSupplyChainCheck reads), not the root
+	// failOn global.
 	origLockfile, origAll, origMinAge, origFormat, origOutput, origFailOn :=
-		scLockfile, scAll, scMinAge, format, outputFile, failOn
+		scLockfile, scAll, scMinAge, format, outputFile, scFailOn
 	t.Cleanup(func() {
-		scLockfile, scAll, scMinAge, format, outputFile, failOn =
+		scLockfile, scAll, scMinAge, format, outputFile, scFailOn =
 			origLockfile, origAll, origMinAge, origFormat, origOutput, origFailOn
 	})
 	scLockfile = "package-lock.json"
 	scAll = true // skip base-lockfile git detection
 	scMinAge = "72h"
 	format = "human" // left at default; extension should override to SARIF
-	failOn = []string{"CRITICAL"}
+	scFailOn = []string{"CRITICAL"}
 
 	cmd := newWrapTestCmd() // command with a live context
 	cmd.Flags().StringVar(&scMinAge, "min-age", "72h", "")
@@ -328,10 +333,13 @@ func TestRunSupplyChainCheck_OutputFlagWritesFile(t *testing.T) {
 func TestRunSupplyChainCheck_FailOnValidatedFirst(t *testing.T) {
 	chdirTemp(t) // empty dir: no lockfile, no network
 
-	origAll, origFailOn := scAll, failOn
-	t.Cleanup(func() { scAll, failOn = origAll, origFailOn })
+	// Set the bogus value on scFailOn (the check-local shadow runSupplyChainCheck
+	// reads), not the root failOn global, so the validation under test actually
+	// sees it.
+	origAll, origFailOn := scAll, scFailOn
+	t.Cleanup(func() { scAll, scFailOn = origAll, origFailOn })
 	scAll = true
-	failOn = []string{"bogus"}
+	scFailOn = []string{"bogus"}
 
 	cmd := newWrapTestCmd()
 	err := runSupplyChainCheck(cmd, []string{"."})
@@ -372,5 +380,94 @@ func TestSupplyChainCheckOutputFlagRegistered(t *testing.T) {
 	}
 	if outputFile != "out.sarif" {
 		t.Errorf("--output not bound to outputFile: outputFile = %q, want %q", outputFile, "out.sarif")
+	}
+}
+
+// TestRunSupplyChainCheck_NoGitBaseNotice guards #21: when there is no git base
+// and the user did not pass --all, check silently audits all packages. It must
+// announce that it switched to the broader scope. Runs in a non-git temp dir so
+// detectBaseLockfile returns "" and the notice path is taken.
+func TestRunSupplyChainCheck_NoGitBaseNotice(t *testing.T) {
+	forceNoColor(t)
+	dir := chdirTemp(t)
+	if err := os.WriteFile(filepath.Join(dir, "package-lock.json"),
+		[]byte(`{"lockfileVersion":3,"packages":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	origLockfile, origAll, origMinAge, origFormat, origFailOn :=
+		scLockfile, scAll, scMinAge, format, scFailOn
+	t.Cleanup(func() {
+		scLockfile, scAll, scMinAge, format, scFailOn =
+			origLockfile, origAll, origMinAge, origFormat, origFailOn
+	})
+	scLockfile = "package-lock.json"
+	scAll = false // exercise the auto-detect path; temp dir is not a git repo
+	scMinAge = "72h"
+	format = "human"
+	scFailOn = []string{"medium"}
+
+	cmd := newWrapTestCmd()
+	cmd.Flags().StringVar(&scMinAge, "min-age", "72h", "")
+	cmd.Flags().StringSliceVar(&scExclude, "exclude", nil, "")
+	cmd.Flags().BoolVar(&scFailOpen, "fail-open", false, "")
+
+	out := captureStderr(t, func() {
+		if err := runSupplyChainCheck(cmd, []string{"."}); err != nil {
+			t.Fatalf("runSupplyChainCheck: %v", err)
+		}
+	})
+	if !strings.Contains(out, "no git base detected") {
+		t.Errorf("expected a no-git-base notice in stderr, got:\n%s", out)
+	}
+}
+
+// TestSupplyChainCheckFailOnDefaultsToMedium guards #12: the real scCheckCmd
+// must register a local --fail-on whose default is "medium", shadowing root's
+// [CRITICAL] persistent default. supply-chain violations are graded MEDIUM/HIGH
+// and never CRITICAL, so the root default would make a copy-pasted CI gate
+// permanently green; the local default must be able to gate.
+func TestSupplyChainCheckFailOnDefaultsToMedium(t *testing.T) {
+	f := scCheckCmd.Flags().Lookup("fail-on")
+	if f == nil {
+		t.Fatal("supply-chain check must register a local --fail-on flag")
+	}
+	if got := f.DefValue; !strings.Contains(strings.ToLower(got), "medium") {
+		t.Errorf("--fail-on default = %q, want it to contain \"medium\"", got)
+	}
+	if strings.Contains(strings.ToUpper(f.DefValue), "CRITICAL") {
+		t.Errorf("--fail-on default = %q, must not be the ungateable CRITICAL", f.DefValue)
+	}
+}
+
+// TestSupplyChainCheckDefaultGatesMediumViolation proves the end-to-end gate the
+// #12 fix restores: with the check-local default, a MEDIUM violation must cause a
+// non-zero exit (a returned ErrFindingsExceeded), where the old [CRITICAL]
+// default would have silently passed. It drives the exact pipeline
+// runSupplyChainCheck uses: cmdutil.GetFailOn(scFailOn) → output.CheckExit.
+func TestSupplyChainCheckDefaultGatesMediumViolation(t *testing.T) {
+	orig := scFailOn
+	t.Cleanup(func() { scFailOn = orig })
+	scFailOn = []string{"medium"} // the registered default
+
+	failOnSeverities, err := cmdutil.GetFailOn(scFailOn)
+	if err != nil {
+		t.Fatalf("GetFailOn: %v", err)
+	}
+
+	result := &model.ScanResult{
+		Findings: []model.Finding{{Severity: model.SeverityMedium}},
+	}
+	if err := output.CheckExit(result, failOnSeverities, 1); err == nil {
+		t.Error("expected a MEDIUM violation to gate (non-nil error) with the default --fail-on, got nil")
+	}
+
+	// Sanity check on the old behavior: CRITICAL would NOT have gated this.
+	criticalSeverities, err := cmdutil.GetFailOn([]string{"critical"})
+	if err != nil {
+		t.Fatalf("GetFailOn(critical): %v", err)
+	}
+	if err := output.CheckExit(result, criticalSeverities, 1); err != nil {
+		t.Errorf("CRITICAL fail-on should not gate a MEDIUM finding, but it returned: %v", err)
 	}
 }

--- a/internal/cmd/supply_chain_init.go
+++ b/internal/cmd/supply_chain_init.go
@@ -43,7 +43,10 @@ Four modes are available:
            dynamically by 'supply-chain wrap'; use with the rc or env modes)
   config — Generate .armis-supply-chain.yaml policy file for this project
 
-Run 'armis-cli supply-chain uninit' to reverse changes made by this command.`,
+Run 'armis-cli supply-chain uninit' to reverse the shell RC and .npmrc changes
+made by this command. The --mode config policy file (.armis-supply-chain.yaml) is
+meant to be committed and shared with your team, so uninit leaves it in place;
+remove it manually if you no longer want it.`,
 	Example: `  # Interactive setup (default)
   armis-cli supply-chain init
 
@@ -57,7 +60,10 @@ Run 'armis-cli supply-chain uninit' to reverse changes made by this command.`,
   armis-cli supply-chain init --mode env
 
   # Add the supply-chain marker comment to .npmrc
-  armis-cli supply-chain init --mode npmrc`,
+  armis-cli supply-chain init --mode npmrc
+
+  # Generate a committable .armis-supply-chain.yaml for this project
+  armis-cli supply-chain init --mode config`,
 	Args: cobra.NoArgs,
 	RunE: runSupplyChainInit,
 }
@@ -384,8 +390,8 @@ func runInitEnv(pms []string) error {
 
 func runInitNpmrc() error {
 	s := output.GetStyles()
-	npmrcPath := ".npmrc"
-	line := "# armis-cli supply-chain: registry override applied at install time via 'supply-chain wrap'\n"
+	npmrcPath := supplychain.NpmrcFileName
+	line := supplychain.NpmrcMarkerComment + "\n"
 
 	if scInitDryRun {
 		fmt.Fprintf(os.Stderr, "%s\n", s.MutedText.Render(fmt.Sprintf("Would add comment to %s noting that supply-chain wrap handles registry override.", npmrcPath)))
@@ -401,7 +407,7 @@ func runInitNpmrc() error {
 		// empty file, which would make the "already configured" check unreliable.
 		return fmt.Errorf("reading %s: %w", npmrcPath, err)
 	}
-	if strings.Contains(string(content), "armis-cli supply-chain") {
+	if supplychain.HasNpmrcMarker(content) {
 		fmt.Fprintf(os.Stderr, "%s already contains armis-cli supply-chain configuration.\n", s.Bold.Render(npmrcPath))
 		return nil
 	}

--- a/internal/cmd/supply_chain_init_test.go
+++ b/internal/cmd/supply_chain_init_test.go
@@ -494,6 +494,27 @@ func TestDetectOrgScopes_SkipsYarn(t *testing.T) {
 	}
 }
 
+// TestScInitExampleIncludesModeConfig guards #33: the init Examples block must
+// show the --mode config path (the recommended way to generate a committable
+// policy file), which was previously omitted.
+func TestScInitExampleIncludesModeConfig(t *testing.T) {
+	if !strings.Contains(scInitCmd.Example, "--mode config") {
+		t.Errorf("init Example block must include --mode config:\n%s", scInitCmd.Example)
+	}
+}
+
+// TestScInitReverseClaimScoped guards #14 (part 3): init's Long must no longer
+// promise uninit reverses *all* changes (it cannot remove the committable config
+// file); the claim must be scoped to the shell RC and .npmrc artifacts.
+func TestScInitReverseClaimScoped(t *testing.T) {
+	if strings.Contains(scInitCmd.Long, "reverse changes made by this command") {
+		t.Errorf("init Long still makes the unscoped reverse-changes claim:\n%s", scInitCmd.Long)
+	}
+	if !strings.Contains(scInitCmd.Long, "shell RC and .npmrc") {
+		t.Errorf("init Long should scope the reverse claim to shell RC and .npmrc:\n%s", scInitCmd.Long)
+	}
+}
+
 // chdirTemp switches into a fresh temp dir for the duration of the test and
 // restores the original cwd on cleanup. runInitNpmrc operates on ".npmrc" in
 // the working directory, so each case needs an isolated dir.

--- a/internal/cmd/supply_chain_status.go
+++ b/internal/cmd/supply_chain_status.go
@@ -340,8 +340,11 @@ func runSupplyChainStatusJSON(dir string) error {
 
 	result := statusJSON{
 		Policy: statusPolicyJSON{
-			Source:     configSource,
-			MinAge:     policy.MinReleaseAge.String(),
+			Source: configSource,
+			// Use the same human-readable formatter as the text output (Min age
+			// line, :188) so JSON consumers see "3 days", not Go's internal
+			// Duration.String() form "72h0m0s".
+			MinAge:     formatDurationShort(policy.MinReleaseAge),
 			Exclusions: policy.Exclusions,
 			FailOpen:   cfg != nil && cfg.FailOpen,
 		},

--- a/internal/cmd/supply_chain_status_test.go
+++ b/internal/cmd/supply_chain_status_test.go
@@ -77,6 +77,7 @@ func captureStdout(t *testing.T, fn func()) string {
 	go func() {
 		var buf bytes.Buffer
 		_, _ = io.Copy(&buf, r)
+		_ = r.Close()
 		done <- buf.String()
 	}()
 

--- a/internal/cmd/supply_chain_status_test.go
+++ b/internal/cmd/supply_chain_status_test.go
@@ -80,6 +80,13 @@ func captureStdout(t *testing.T, fn func()) string {
 		done <- buf.String()
 	}()
 
+	// t.Cleanup runs even when fn calls t.Fatalf (which calls runtime.Goexit),
+	// guaranteeing the pipe is closed and os.Stdout is restored.
+	t.Cleanup(func() {
+		_ = w.Close()
+		os.Stdout = orig
+	})
+
 	fn()
 	_ = w.Close()
 	os.Stdout = orig

--- a/internal/cmd/supply_chain_status_test.go
+++ b/internal/cmd/supply_chain_status_test.go
@@ -1,10 +1,90 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
 	"slices"
 	"strings"
 	"testing"
 )
+
+// TestRunSupplyChainStatusJSON_MinAgeHumanReadable guards #22: the JSON policy
+// min_age must use the human-readable formatter ("3 days"), not Go's internal
+// Duration.String() ("72h0m0s"). With no config present, status falls back to
+// DefaultPolicy (72h), so the field must render as "3 days".
+func TestRunSupplyChainStatusJSON_MinAgeHumanReadable(t *testing.T) {
+	dir := chdirTemp(t) // empty dir → no config → DefaultPolicy (72h)
+
+	out := captureStdout(t, func() {
+		if err := runSupplyChainStatusJSON(dir); err != nil {
+			t.Fatalf("runSupplyChainStatusJSON: %v", err)
+		}
+	})
+
+	var parsed struct {
+		Policy struct {
+			MinAge string `json:"min_age"`
+		} `json:"policy"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("unmarshal status JSON: %v\n%s", err, out)
+	}
+	if parsed.Policy.MinAge != "3 days" {
+		t.Errorf("min_age = %q, want %q (not the raw Duration.String())", parsed.Policy.MinAge, "3 days")
+	}
+}
+
+// TestRunSupplyChainStatusJSON_MinAgeNonDefault drives a non-default config
+// through the JSON path so a branch other than "days" is exercised end-to-end,
+// and pins the singular form ("1 hour", not "1 hours") in the serialized output.
+func TestRunSupplyChainStatusJSON_MinAgeNonDefault(t *testing.T) {
+	dir := chdirTemp(t)
+	writeConfig(t, dir, "version: 1\nmin-age: 1h\n")
+
+	out := captureStdout(t, func() {
+		if err := runSupplyChainStatusJSON(dir); err != nil {
+			t.Fatalf("runSupplyChainStatusJSON: %v", err)
+		}
+	})
+
+	var parsed struct {
+		Policy struct {
+			MinAge string `json:"min_age"`
+		} `json:"policy"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("unmarshal status JSON: %v\n%s", err, out)
+	}
+	if parsed.Policy.MinAge != "1 hour" {
+		t.Errorf("min_age = %q, want %q (singular, human-readable)", parsed.Policy.MinAge, "1 hour")
+	}
+}
+
+// captureStdout swaps os.Stdout for a pipe, runs fn, and returns what fn wrote.
+// A goroutine drains the pipe so output larger than the buffer cannot deadlock.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+	_ = w.Close()
+	os.Stdout = orig
+	return <-done
+}
 
 func TestCollapsePipVariants(t *testing.T) {
 	tests := []struct {

--- a/internal/cmd/supply_chain_test.go
+++ b/internal/cmd/supply_chain_test.go
@@ -45,16 +45,22 @@ func TestSupplyChainUnknownSubcommand(t *testing.T) {
 // cmdutil.GetFailOn, which uppercases and validates it. A lowercase "medium"
 // must therefore trip the gate on a MEDIUM finding (ShouldFail matches
 // severities exactly), and an invalid value must be rejected rather than
-// silently ignored. It feeds the failOn global (the bound flag value) through
-// the same call the command makes, end-to-end into output.ShouldFail.
+// silently ignored. It feeds scFailOn (the check-local flag value that
+// runSupplyChainCheck actually reads) through the same call the command makes,
+// end-to-end into output.ShouldFail. Using scFailOn here — not the root failOn
+// global — keeps the test exercising the variable the command depends on.
 func TestSupplyChainCheckFailOnCaseInsensitive(t *testing.T) {
 	medium := &model.ScanResult{
 		Findings: []model.Finding{{Severity: model.SeverityMedium}},
 	}
 
+	// Restore the check-local default so this test can't leak state into others.
+	orig := scFailOn
+	t.Cleanup(func() { scFailOn = orig })
+
 	t.Run("lowercase fail-on still fails the gate", func(t *testing.T) {
-		failOn = []string{"medium"}
-		normalized, err := cmdutil.GetFailOn(failOn)
+		scFailOn = []string{"medium"}
+		normalized, err := cmdutil.GetFailOn(scFailOn)
 		if err != nil {
 			t.Fatalf("GetFailOn rejected a valid lowercase severity: %v", err)
 		}
@@ -64,12 +70,9 @@ func TestSupplyChainCheckFailOnCaseInsensitive(t *testing.T) {
 	})
 
 	t.Run("invalid fail-on is rejected", func(t *testing.T) {
-		failOn = []string{"banana"}
-		if _, err := cmdutil.GetFailOn(failOn); err == nil {
+		scFailOn = []string{"banana"}
+		if _, err := cmdutil.GetFailOn(scFailOn); err == nil {
 			t.Error("GetFailOn should reject an invalid severity, not silently ignore it")
 		}
 	})
-
-	// Reset the shared package global so this test can't leak state into others.
-	failOn = []string{"CRITICAL"}
 }

--- a/internal/cmd/supply_chain_uninit.go
+++ b/internal/cmd/supply_chain_uninit.go
@@ -9,20 +9,37 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	scUninitDryRun bool
+	scUninitYes    bool
+)
+
 var scUninitCmd = &cobra.Command{
 	Use:   "uninit",
-	Short: "Remove local package age enforcement",
-	Long: `Remove shell functions injected by 'armis-cli supply-chain init'.
+	Short: "Remove shell wrapper functions injected by supply-chain init",
+	Long: `Remove the changes made by 'armis-cli supply-chain init'.
 
 This scans your shell RC files (bashrc, zshrc, fish config) for armis-cli supply-chain
-blocks and removes them. Your package manager will return to its normal behavior.`,
+blocks and removes them, and strips the marker comment from a project .npmrc in the
+current directory if present. Your package manager will return to its normal behavior.
+
+The --mode config policy file (.armis-supply-chain.yaml) is meant to be committed, so it
+is left in place; remove it manually if you no longer want it.`,
 	Example: `  # Remove all injected shell functions
-  armis-cli supply-chain uninit`,
+  armis-cli supply-chain uninit
+
+  # Preview what would be removed without making changes
+  armis-cli supply-chain uninit --dry-run
+
+  # Non-interactive (CI friendly)
+  armis-cli supply-chain uninit --yes`,
 	Args: cobra.NoArgs,
 	RunE: runSupplyChainUninit,
 }
 
 func init() {
+	scUninitCmd.Flags().BoolVar(&scUninitDryRun, "dry-run", false, "Show what would be removed without making changes")
+	scUninitCmd.Flags().BoolVar(&scUninitYes, "yes", false, "Skip confirmation prompt")
 	supplyChainCmd.AddCommand(scUninitCmd)
 }
 
@@ -30,24 +47,73 @@ func runSupplyChainUninit(_ *cobra.Command, _ []string) error {
 	s := output.GetStyles()
 
 	shells := supplychain.DetectShells()
-	if len(shells) == 0 {
-		fmt.Fprintf(os.Stderr, "%s\n", s.MutedText.Render("No supported shells detected."))
+
+	// Gather every artifact uninit would remove before touching anything: the
+	// shell RC files that actually carry an injection block, and the project
+	// .npmrc if it carries the marker comment. Computing the target set up front
+	// powers the --dry-run preview and lets uninit report "nothing to do" without
+	// writing. .npmrc is handled independently of shells: a user who only ran
+	// `init --mode npmrc` has a marker to clean even with no wrappers installed.
+	var rcTargets []string
+	for _, sh := range shells {
+		if supplychain.HasInjection(sh.RCFile) {
+			rcTargets = append(rcTargets, sh.RCFile)
+		}
+	}
+	npmrcTarget := supplychain.NpmrcFileHasMarker(supplychain.NpmrcFileName)
+
+	if len(rcTargets) == 0 && !npmrcTarget {
+		fmt.Fprintf(os.Stderr, "%s\n", s.MutedText.Render("No armis-cli supply-chain changes found in shell RC files or .npmrc."))
 		return nil
 	}
 
-	modified, err := supplychain.RemoveFunctions(shells)
+	// Preview the targets. Shown for --dry-run and also ahead of the interactive
+	// confirm so the user sees exactly which files will change before consenting.
+	fmt.Fprintf(os.Stderr, "%s\n", s.SectionTitle.Render("Will remove armis-cli supply-chain changes from:"))
+	for _, f := range rcTargets {
+		fmt.Fprintf(os.Stderr, "  %s\n", s.Bold.Render(f))
+	}
+	if npmrcTarget {
+		fmt.Fprintf(os.Stderr, "  %s %s\n", s.Bold.Render(supplychain.NpmrcFileName), s.MutedText.Render("(marker comment)"))
+	}
+
+	if scUninitDryRun {
+		fmt.Fprintf(os.Stderr, "%s\n", s.MutedText.Render("(dry-run: no changes made)"))
+		return nil
+	}
+
+	if !scUninitYes {
+		if !promptYesNo("Proceed?", true) {
+			fmt.Fprintf(os.Stderr, "Aborted.\n")
+			return nil
+		}
+	}
+
+	// armis:ignore cwe:73 cwe:22 reason:DetectShells derives each RCFile by joining $HOME with a fixed filename (.bashrc/.zshrc/.config/fish/config.fish); editing the user's own shell RC files is the entire purpose of `supply-chain uninit`, and RemoveFunctions only strips armis-cli supply-chain blocks it previously injected — no externally-controlled path component is ever introduced
+	rcModified, err := supplychain.RemoveFunctions(shells)
 	if err != nil {
 		return err
 	}
 
-	if len(modified) == 0 {
-		fmt.Fprintf(os.Stderr, "%s\n", s.MutedText.Render("No armis-cli supply-chain blocks found in shell RC files."))
-		return nil
+	npmrcChanged, err := supplychain.RemoveNpmrcMarker(supplychain.NpmrcFileName)
+	if err != nil {
+		return fmt.Errorf("removing marker from %s: %w", supplychain.NpmrcFileName, err)
 	}
 
-	for _, f := range modified {
+	fmt.Fprintf(os.Stderr, "\n")
+	for _, f := range rcModified {
 		fmt.Fprintf(os.Stderr, "  %s Cleaned: %s\n", s.SuccessText.Render(output.IconSuccess), s.Bold.Render(f))
 	}
-	fmt.Fprintf(os.Stderr, "\n%s Restart your shell or source the modified file(s).\n", s.SuccessText.Render("Done!"))
+	if npmrcChanged {
+		fmt.Fprintf(os.Stderr, "  %s Cleaned: %s\n", s.SuccessText.Render(output.IconSuccess), s.Bold.Render(supplychain.NpmrcFileName))
+	}
+
+	// Only the shell RC edits need a shell reload to take effect; an .npmrc-only
+	// cleanup does not, so tailor the closing line to what actually changed.
+	if len(rcModified) > 0 {
+		fmt.Fprintf(os.Stderr, "\n%s Restart your shell or source the modified file(s).\n", s.SuccessText.Render("Done!"))
+	} else {
+		fmt.Fprintf(os.Stderr, "\n%s\n", s.SuccessText.Render("Done!"))
+	}
 	return nil
 }

--- a/internal/cmd/supply_chain_uninit_test.go
+++ b/internal/cmd/supply_chain_uninit_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -14,8 +15,13 @@ import (
 // test exercises the genuine inject→uninit round-trip), and returns the RC path.
 // $SHELL is cleared so DetectShells keys purely on which RC files exist, keeping
 // the test independent of the shell CI runs under.
+// Windows is skipped: DetectShells resolves RC paths from os.UserHomeDir(), which
+// honors $HOME on Unix but not on Windows (same constraint as shell_test.go:456).
 func seedShellInjection(t *testing.T) string {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("DetectShells home-dir resolution is exercised via $HOME, which is Unix-only")
+	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("SHELL", "")

--- a/internal/cmd/supply_chain_uninit_test.go
+++ b/internal/cmd/supply_chain_uninit_test.go
@@ -1,0 +1,206 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ArmisSecurity/armis-cli/internal/supplychain"
+)
+
+// seedShellInjection points $HOME at a fresh temp dir, writes a .bashrc carrying
+// a real supply-chain injection block (via the public InjectFunctions API so the
+// test exercises the genuine inject→uninit round-trip), and returns the RC path.
+// $SHELL is cleared so DetectShells keys purely on which RC files exist, keeping
+// the test independent of the shell CI runs under.
+func seedShellInjection(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SHELL", "")
+
+	rc := filepath.Join(home, ".bashrc")
+	if err := os.WriteFile(rc, []byte("# user config\nexport FOO=bar\n"), 0o600); err != nil {
+		t.Fatalf("seed .bashrc: %v", err)
+	}
+	shells := supplychain.DetectShells()
+	if len(shells) == 0 {
+		t.Fatal("DetectShells found nothing after seeding .bashrc")
+	}
+	if _, err := supplychain.InjectFunctions(shells, []string{"npm"}); err != nil {
+		t.Fatalf("InjectFunctions: %v", err)
+	}
+	if !supplychain.HasInjection(rc) {
+		t.Fatal("expected injection in seeded .bashrc")
+	}
+	return rc
+}
+
+// TestRunSupplyChainUninit_DryRunWritesNothing verifies the #15 CI escape hatch:
+// --dry-run previews the targets and exits 0 without modifying any file.
+func TestRunSupplyChainUninit_DryRunWritesNothing(t *testing.T) {
+	forceNoColor(t)
+	rc := seedShellInjection(t)
+	dir := chdirTemp(t)
+	npmrc := filepath.Join(dir, supplychain.NpmrcFileName)
+	if err := os.WriteFile(npmrc, []byte(supplychain.NpmrcMarkerComment+"\n"), 0o600); err != nil {
+		t.Fatalf("seed .npmrc: %v", err)
+	}
+
+	rcBefore := readCmdFile(t, rc)
+	npmrcBefore := readCmdFile(t, npmrc)
+
+	origDryRun, origYes := scUninitDryRun, scUninitYes
+	t.Cleanup(func() { scUninitDryRun, scUninitYes = origDryRun, origYes })
+	scUninitDryRun, scUninitYes = true, false
+
+	out := captureStderr(t, func() {
+		if err := runSupplyChainUninit(scUninitCmd, nil); err != nil {
+			t.Fatalf("runSupplyChainUninit: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "dry-run") {
+		t.Errorf("dry-run output missing the dry-run notice:\n%s", out)
+	}
+	// The preview block (file paths) is the informative half of --dry-run;
+	// asserting only the "dry-run" notice would still pass if it were deleted.
+	if !strings.Contains(out, rc) {
+		t.Errorf("dry-run preview missing the RC file path %q:\n%s", rc, out)
+	}
+	if !strings.Contains(out, supplychain.NpmrcFileName) {
+		t.Errorf("dry-run preview missing the .npmrc target:\n%s", out)
+	}
+	if got := readCmdFile(t, rc); got != rcBefore {
+		t.Errorf(".bashrc modified during dry-run:\n%s", got)
+	}
+	if got := readCmdFile(t, npmrc); got != npmrcBefore {
+		t.Errorf(".npmrc modified during dry-run:\n%s", got)
+	}
+}
+
+// TestRunSupplyChainUninit_NpmrcOnly covers the path a user reaches after running
+// `init --mode npmrc` with no shell wrappers: rcTargets is empty, only the .npmrc
+// marker is present. The marker must be stripped (real config preserved) and the
+// closing message must omit the "Restart your shell" hint, since no RC changed.
+func TestRunSupplyChainUninit_NpmrcOnly(t *testing.T) {
+	forceNoColor(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SHELL", "")
+	dir := chdirTemp(t)
+	npmrc := filepath.Join(dir, supplychain.NpmrcFileName)
+	if err := os.WriteFile(npmrc, []byte("registry=https://example.com/\n"+supplychain.NpmrcMarkerComment+"\n"), 0o600); err != nil {
+		t.Fatalf("seed .npmrc: %v", err)
+	}
+
+	origDryRun, origYes := scUninitDryRun, scUninitYes
+	t.Cleanup(func() { scUninitDryRun, scUninitYes = origDryRun, origYes })
+	scUninitDryRun, scUninitYes = false, true
+
+	out := captureStderr(t, func() {
+		if err := runSupplyChainUninit(scUninitCmd, nil); err != nil {
+			t.Fatalf("runSupplyChainUninit: %v", err)
+		}
+	})
+
+	if supplychain.NpmrcFileHasMarker(npmrc) {
+		t.Errorf(".npmrc still has the marker after npmrc-only uninit --yes")
+	}
+	if got := readCmdFile(t, npmrc); !strings.Contains(got, "registry=https://example.com/") {
+		t.Errorf(".npmrc lost its real config: %q", got)
+	}
+	if !strings.Contains(out, "Done!") {
+		t.Errorf("expected a Done! notice, got:\n%s", out)
+	}
+	// No RC file changed, so the shell-reload hint must not appear.
+	if strings.Contains(out, "Restart your shell") {
+		t.Errorf("npmrc-only uninit should not tell the user to restart their shell:\n%s", out)
+	}
+}
+
+// TestRunSupplyChainUninit_YesRemovesBoth verifies that --yes performs the
+// removal non-interactively, cleaning both the shell RC injection (#15) and the
+// .npmrc marker (#14) in one pass.
+func TestRunSupplyChainUninit_YesRemovesBoth(t *testing.T) {
+	forceNoColor(t)
+	rc := seedShellInjection(t)
+	dir := chdirTemp(t)
+	npmrc := filepath.Join(dir, supplychain.NpmrcFileName)
+	if err := os.WriteFile(npmrc, []byte("registry=https://example.com/\n"+supplychain.NpmrcMarkerComment+"\n"), 0o600); err != nil {
+		t.Fatalf("seed .npmrc: %v", err)
+	}
+
+	origDryRun, origYes := scUninitDryRun, scUninitYes
+	t.Cleanup(func() { scUninitDryRun, scUninitYes = origDryRun, origYes })
+	scUninitDryRun, scUninitYes = false, true
+
+	if err := runSupplyChainUninit(scUninitCmd, nil); err != nil {
+		t.Fatalf("runSupplyChainUninit: %v", err)
+	}
+
+	if supplychain.HasInjection(rc) {
+		t.Errorf(".bashrc still has an injection block after uninit --yes")
+	}
+	if supplychain.NpmrcFileHasMarker(npmrc) {
+		t.Errorf(".npmrc still has the marker after uninit --yes")
+	}
+	// Non-marker config must survive.
+	if got := readCmdFile(t, npmrc); !strings.Contains(got, "registry=https://example.com/") {
+		t.Errorf(".npmrc lost its real config: %q", got)
+	}
+}
+
+// TestRunSupplyChainUninit_NothingToDo verifies the clean exit when there is no
+// injection and no marker — no prompt, no error.
+func TestRunSupplyChainUninit_NothingToDo(t *testing.T) {
+	forceNoColor(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SHELL", "")
+	chdirTemp(t)
+
+	origDryRun, origYes := scUninitDryRun, scUninitYes
+	t.Cleanup(func() { scUninitDryRun, scUninitYes = origDryRun, origYes })
+	scUninitDryRun, scUninitYes = false, false
+
+	out := captureStderr(t, func() {
+		if err := runSupplyChainUninit(scUninitCmd, nil); err != nil {
+			t.Fatalf("runSupplyChainUninit: %v", err)
+		}
+	})
+	if !strings.Contains(out, "No armis-cli supply-chain changes found") {
+		t.Errorf("expected a nothing-to-do notice, got:\n%s", out)
+	}
+}
+
+// TestSupplyChainUninitFlagsRegistered guards #15: the real scUninitCmd built by
+// init() must expose --dry-run and --yes.
+func TestSupplyChainUninitFlagsRegistered(t *testing.T) {
+	for _, name := range []string{"dry-run", "yes"} {
+		if scUninitCmd.Flags().Lookup(name) == nil {
+			t.Errorf("supply-chain uninit must register the --%s flag", name)
+		}
+	}
+}
+
+// TestSupplyChainUninitShortScoped guards #32: the Short must describe shell
+// wrappers, not the broader "package age enforcement" it does not control.
+func TestSupplyChainUninitShortScoped(t *testing.T) {
+	if strings.Contains(scUninitCmd.Short, "package age enforcement") {
+		t.Errorf("uninit Short still overstates scope: %q", scUninitCmd.Short)
+	}
+	if !strings.Contains(scUninitCmd.Short, "shell wrapper") {
+		t.Errorf("uninit Short should mention shell wrappers: %q", scUninitCmd.Short)
+	}
+}
+
+func readCmdFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path) //nolint:gosec // test-controlled temp path
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/internal/cmd/supply_chain_wrap_summary_test.go
+++ b/internal/cmd/supply_chain_wrap_summary_test.go
@@ -29,6 +29,7 @@ func captureStderr(t *testing.T, fn func()) string {
 	go func() {
 		var buf bytes.Buffer
 		_, _ = io.Copy(&buf, r)
+		_ = r.Close()
 		done <- buf.String()
 	}()
 

--- a/internal/cmd/supply_chain_wrap_summary_test.go
+++ b/internal/cmd/supply_chain_wrap_summary_test.go
@@ -32,6 +32,13 @@ func captureStderr(t *testing.T, fn func()) string {
 		done <- buf.String()
 	}()
 
+	// t.Cleanup runs even when fn calls t.Fatalf (which calls runtime.Goexit),
+	// guaranteeing the pipe is closed and os.Stderr is restored.
+	t.Cleanup(func() {
+		_ = w.Close()
+		os.Stderr = orig
+	})
+
 	fn()
 	_ = w.Close()
 	os.Stderr = orig

--- a/internal/cmd/supply_chain_wrap_test.go
+++ b/internal/cmd/supply_chain_wrap_test.go
@@ -529,3 +529,33 @@ func TestCheckGradleStaleness(t *testing.T) {
 		checkGradleStaleness(filepath.Join(dir, "gradle.lockfile"))
 	})
 }
+
+// TestFormatDurationShort locks in the human-readable rendering used by both the
+// status text output and the JSON min_age field. It pins the singular forms (1
+// minute / 1 hour / 1 day) so the grammatical guards can't silently regress, and
+// covers each branch boundary (<1h, 1-23h, >=24h).
+func TestFormatDurationShort(t *testing.T) {
+	tests := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{"zero", 0, "0 minutes"},
+		{"one minute", time.Minute, "1 minute"},
+		{"several minutes", 30 * time.Minute, "30 minutes"},
+		{"just under an hour", 59 * time.Minute, "59 minutes"},
+		{"one hour", time.Hour, "1 hour"},
+		{"several hours", 2 * time.Hour, "2 hours"},
+		{"just under a day", 23 * time.Hour, "23 hours"},
+		{"one day", 24 * time.Hour, "1 day"},
+		{"several days", 72 * time.Hour, "3 days"},
+		{"two weeks", 14 * 24 * time.Hour, "14 days"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatDurationShort(tt.d); got != tt.want {
+				t.Errorf("formatDurationShort(%s) = %q, want %q", tt.d, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/supplychain/npmrc.go
+++ b/internal/supplychain/npmrc.go
@@ -1,0 +1,126 @@
+package supplychain
+
+import (
+	"os"
+	"strings"
+)
+
+// NpmrcFileName is the project-local npm config file that `supply-chain init
+// --mode npmrc` annotates and `supply-chain uninit` cleans.
+const NpmrcFileName = ".npmrc"
+
+// NpmrcMarkerComment is the comment line `supply-chain init --mode npmrc`
+// appends to a project's .npmrc. The registry override itself is applied
+// dynamically by `supply-chain wrap` at install time; this line is only a
+// marker so the annotation can be detected (idempotent re-init) and later
+// removed (uninit). It carries no trailing newline — the writer adds its own
+// separator.
+const NpmrcMarkerComment = "# armis-cli supply-chain: registry override applied at install time via 'supply-chain wrap'"
+
+// npmrcMarkerFragment is the stable text that identifies an armis-cli
+// supply-chain marker line, independent of the comment's exact wording.
+// Matching on this fragment (rather than the full NpmrcMarkerComment) keeps
+// detection robust if the comment text is ever reworded and still cleans
+// markers written by older versions. It is anchored to the start of the comment
+// body by isNpmrcMarkerLine — see there for why a bare substring match is unsafe.
+const npmrcMarkerFragment = "armis-cli supply-chain"
+
+// isNpmrcMarkerLine reports whether a single .npmrc line is an armis-cli
+// supply-chain marker. A marker is a comment line — after optional leading
+// whitespace it begins with '#' — whose comment body starts with the marker
+// fragment. Anchoring to the start of the comment, rather than matching the
+// fragment anywhere on the line, is what keeps detection from false-positively
+// firing on a user comment that merely *mentions* armis-cli supply-chain in
+// prose (e.g. "# managed by armis-cli supply-chain") or on a config value that
+// happens to contain the fragment (e.g. "_authToken=armis-cli supply-chain-…").
+// Either false positive would silently block re-init or, worse, delete the
+// user's own line on uninit. A reworded marker still matches, since every
+// marker we write leads with the fragment.
+func isNpmrcMarkerLine(line string) bool {
+	rest, ok := strings.CutPrefix(strings.TrimSpace(line), "#")
+	if !ok {
+		return false
+	}
+	return strings.HasPrefix(strings.TrimSpace(rest), npmrcMarkerFragment)
+}
+
+// HasNpmrcMarker reports whether content (the bytes of an .npmrc) already
+// carries an armis-cli supply-chain marker line. init uses this to stay
+// idempotent (it has already read the file for its trailing-newline check).
+func HasNpmrcMarker(content []byte) bool {
+	for _, line := range strings.Split(string(content), "\n") {
+		if isNpmrcMarkerLine(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// NpmrcFileHasMarker reports whether the .npmrc at path carries an armis-cli
+// supply-chain marker line. A missing or unreadable file reports false (nothing
+// to clean). uninit uses this for its --dry-run preview, mirroring shell.go's
+// path-based HasInjection.
+func NpmrcFileHasMarker(path string) bool {
+	// armis:ignore cwe:22 cwe:23 cwe:73 reason:path is the project-local .npmrc in the user's own working directory; reading it to report cleanup status is the purpose of `supply-chain uninit --dry-run`
+	content, err := os.ReadFile(path) //nolint:gosec // project .npmrc in current working directory
+	if err != nil {
+		return false
+	}
+	return HasNpmrcMarker(content)
+}
+
+// RemoveNpmrcMarker strips any armis-cli supply-chain marker line(s) from the
+// .npmrc at path, preserving every other line and the file's permissions. It
+// returns true when the file was changed. A missing file is not an error
+// (nothing to remove). This mirrors removeFromFile/removeBlock for shell RC
+// files so init's write side and uninit's strip side stay symmetric.
+func RemoveNpmrcMarker(path string) (bool, error) {
+	// armis:ignore cwe:22 cwe:23 cwe:73 reason:path is the project-local .npmrc in the user's own working directory; editing it is the purpose of `supply-chain uninit`
+	content, err := os.ReadFile(path) //nolint:gosec // project .npmrc in current working directory
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !HasNpmrcMarker(content) {
+		return false, nil
+	}
+
+	// Preserve the file's existing permissions. If the stat fails (it just read
+	// fine, so this is near-impossible), fall back to the restrictive 0o600
+	// rather than a world-readable 0o644: an .npmrc commonly carries registry
+	// auth tokens, so the safe default for this file is owner-only.
+	perm := os.FileMode(0o600)
+	if info, statErr := os.Stat(path); statErr == nil {
+		perm = info.Mode().Perm()
+	}
+
+	cleaned := removeNpmrcMarkerLines(string(content))
+	// armis:ignore cwe:22 cwe:23 cwe:73 reason:path is the project-local .npmrc in the user's own working directory; writing it is the purpose of `supply-chain uninit`
+	if err := os.WriteFile(path, []byte(cleaned), perm); err != nil { //nolint:gosec // project .npmrc
+		return false, err
+	}
+	return true, nil
+}
+
+// removeNpmrcMarkerLines drops every marker line from content and returns the
+// remainder. A file reduced to nothing is returned empty (not a lone newline);
+// otherwise the result is normalized to a single trailing newline, matching the
+// shell RC cleanup in removeBlock.
+func removeNpmrcMarkerLines(content string) string {
+	lines := strings.Split(content, "\n")
+	result := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if isNpmrcMarkerLine(line) {
+			continue
+		}
+		result = append(result, line)
+	}
+
+	text := strings.TrimRight(strings.Join(result, "\n"), "\n")
+	if text == "" {
+		return ""
+	}
+	return text + "\n"
+}

--- a/internal/supplychain/npmrc_test.go
+++ b/internal/supplychain/npmrc_test.go
@@ -3,6 +3,7 @@ package supplychain
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -116,6 +117,9 @@ func TestRemoveNpmrcMarker(t *testing.T) {
 	// write; a regression that hardcoded the 0o644 fallback would flip this 0o600
 	// file and be caught here. Mirrors TestRemoveFunctions_PreservesPermissions.
 	t.Run("preserves file permissions", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Unix file permissions not supported on Windows")
+		}
 		path := filepath.Join(t.TempDir(), ".npmrc")
 		writeFileAt(t, path, "foo=bar\n"+NpmrcMarkerComment+"\n") // writeFileAt uses 0o600
 

--- a/internal/supplychain/npmrc_test.go
+++ b/internal/supplychain/npmrc_test.go
@@ -1,0 +1,218 @@
+package supplychain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHasNpmrcMarker(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "empty", content: "", want: false},
+		{name: "plain config", content: "registry=https://registry.npmjs.org/\n", want: false},
+		{name: "exact marker", content: NpmrcMarkerComment + "\n", want: true},
+		{name: "marker among config", content: "registry=https://example.com/\n" + NpmrcMarkerComment + "\nfoo=bar\n", want: true},
+		// A reworded marker still matches: every marker we write leads with the
+		// fragment right after the '#', so detection survives a wording change.
+		{name: "reworded marker still matches", content: "# armis-cli supply-chain (legacy wording)\n", want: true},
+		{name: "indented marker still matches", content: "   #   armis-cli supply-chain: note\n", want: true},
+		// False positives the anchored match must NOT fire on: a user comment that
+		// merely mentions the phrase in prose, and a config value containing it.
+		{name: "user comment mentioning phrase mid-line is not a marker", content: "# managed by armis-cli supply-chain tooling\n", want: false},
+		{name: "config value containing fragment is not a marker", content: "_authToken=armis-cli supply-chain-scoped-token\n", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasNpmrcMarker([]byte(tt.content)); got != tt.want {
+				t.Errorf("HasNpmrcMarker(%q) = %v, want %v", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoveNpmrcMarker(t *testing.T) {
+	t.Run("missing file is not an error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".npmrc")
+		changed, err := RemoveNpmrcMarker(path)
+		if err != nil {
+			t.Fatalf("RemoveNpmrcMarker: %v", err)
+		}
+		if changed {
+			t.Errorf("changed = true, want false for missing file")
+		}
+	})
+
+	t.Run("file without marker is left untouched", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".npmrc")
+		const original = "registry=https://registry.npmjs.org/\nfoo=bar\n"
+		writeFileAt(t, path, original)
+
+		changed, err := RemoveNpmrcMarker(path)
+		if err != nil {
+			t.Fatalf("RemoveNpmrcMarker: %v", err)
+		}
+		if changed {
+			t.Errorf("changed = true, want false when no marker present")
+		}
+		if got := readFile(t, path); got != original {
+			t.Errorf("content = %q, want unchanged %q", got, original)
+		}
+	})
+
+	t.Run("strips marker and preserves surrounding config", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".npmrc")
+		writeFileAt(t, path, "registry=https://example.com/\n"+NpmrcMarkerComment+"\nfoo=bar\n")
+
+		changed, err := RemoveNpmrcMarker(path)
+		if err != nil {
+			t.Fatalf("RemoveNpmrcMarker: %v", err)
+		}
+		if !changed {
+			t.Errorf("changed = false, want true when marker present")
+		}
+		want := "registry=https://example.com/\nfoo=bar\n"
+		if got := readFile(t, path); got != want {
+			t.Errorf("content = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("marker-only file collapses to empty", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".npmrc")
+		writeFileAt(t, path, NpmrcMarkerComment+"\n")
+
+		changed, err := RemoveNpmrcMarker(path)
+		if err != nil {
+			t.Fatalf("RemoveNpmrcMarker: %v", err)
+		}
+		if !changed {
+			t.Errorf("changed = false, want true")
+		}
+		if got := readFile(t, path); got != "" {
+			t.Errorf("content = %q, want empty", got)
+		}
+	})
+
+	t.Run("idempotent: second removal is a no-op", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".npmrc")
+		writeFileAt(t, path, "registry=https://example.com/\n"+NpmrcMarkerComment+"\n")
+
+		if _, err := RemoveNpmrcMarker(path); err != nil {
+			t.Fatalf("first RemoveNpmrcMarker: %v", err)
+		}
+		changed, err := RemoveNpmrcMarker(path)
+		if err != nil {
+			t.Fatalf("second RemoveNpmrcMarker: %v", err)
+		}
+		if changed {
+			t.Errorf("changed = true on second pass, want false (idempotent)")
+		}
+	})
+
+	// Production code reads the original mode via os.Stat and re-applies it on
+	// write; a regression that hardcoded the 0o644 fallback would flip this 0o600
+	// file and be caught here. Mirrors TestRemoveFunctions_PreservesPermissions.
+	t.Run("preserves file permissions", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".npmrc")
+		writeFileAt(t, path, "foo=bar\n"+NpmrcMarkerComment+"\n") // writeFileAt uses 0o600
+
+		changed, err := RemoveNpmrcMarker(path)
+		if err != nil {
+			t.Fatalf("RemoveNpmrcMarker: %v", err)
+		}
+		if !changed {
+			t.Fatalf("changed = false, want true")
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Errorf("perm = %o, want 0600 (original mode must be preserved, not the 0644 fallback)", got)
+		}
+	})
+
+	// runInitNpmrc, when the original .npmrc lacks a trailing newline, writes
+	// `original + "\n" + marker + "\n"`. After strip the file normalizes to
+	// `original + "\n"` (one trailing newline) — it does not perfectly restore
+	// the missing-newline form. Lock that intentional normalization in.
+	t.Run("strips marker from no-trailing-NL form written by init", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".npmrc")
+		const original = "registry=https://example.com/"
+		writeFileAt(t, path, original+"\n"+NpmrcMarkerComment+"\n")
+
+		changed, err := RemoveNpmrcMarker(path)
+		if err != nil {
+			t.Fatalf("RemoveNpmrcMarker: %v", err)
+		}
+		if !changed {
+			t.Fatalf("changed = false, want true")
+		}
+		if got, want := readFile(t, path), original+"\n"; got != want {
+			t.Errorf("content = %q, want %q", got, want)
+		}
+	})
+
+	// The anchored match must not delete a user's own comment that merely
+	// mentions the phrase, nor a config value containing it.
+	t.Run("leaves user comment and value lines that merely mention the phrase", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".npmrc")
+		const original = "# managed by armis-cli supply-chain tooling\n_authToken=armis-cli supply-chain-scoped\n"
+		writeFileAt(t, path, original)
+
+		changed, err := RemoveNpmrcMarker(path)
+		if err != nil {
+			t.Fatalf("RemoveNpmrcMarker: %v", err)
+		}
+		if changed {
+			t.Errorf("changed = true, want false: no real marker present, user content must survive")
+		}
+		if got := readFile(t, path); got != original {
+			t.Errorf("content = %q, want unchanged %q", got, original)
+		}
+	})
+}
+
+func TestNpmrcFileHasMarker(t *testing.T) {
+	dir := t.TempDir()
+
+	missing := filepath.Join(dir, "missing", ".npmrc")
+	if NpmrcFileHasMarker(missing) {
+		t.Errorf("NpmrcFileHasMarker(missing) = true, want false")
+	}
+
+	withMarker := filepath.Join(dir, ".npmrc")
+	writeFileAt(t, withMarker, "foo=bar\n"+NpmrcMarkerComment+"\n")
+	if !NpmrcFileHasMarker(withMarker) {
+		t.Errorf("NpmrcFileHasMarker = false, want true for file with marker")
+	}
+
+	noMarker := filepath.Join(dir, "plain.npmrc")
+	writeFileAt(t, noMarker, "foo=bar\n")
+	if NpmrcFileHasMarker(noMarker) {
+		t.Errorf("NpmrcFileHasMarker = true, want false for file without marker")
+	}
+}
+
+// writeFileAt writes content to an explicit file path (0o600). It differs from
+// manifest_test.go's writeFile, which takes a (dir, name) pair; these npmrc
+// tests build their own paths via filepath.Join, so a path-based helper reads
+// more directly.
+func writeFileAt(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path) //nolint:gosec // test-controlled temp path
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
## Related Issue

* [PPSC-1010](https://armis.atlassian.net/browse/PPSC-1010)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)

## Problem

Several rough edges in the `supply-chain` command family:

1. **`check --fail-on` had a broken default** — the root persistent flag defaulted to `[CRITICAL]`, but supply-chain violations are graded MEDIUM/HIGH and never reach CRITICAL, so a copy-pasted `supply-chain check` in CI would always exit 0 regardless of violations found.
2. **`uninit` was incomplete** — it only removed shell RC injection blocks, leaving `.npmrc` marker comments written by `init --mode npmrc` untouched. It also had no `--dry-run` or `--yes` flags, making it unsuitable for CI.
3. **`.npmrc` marker handling was duplicated** — the marker comment string and idempotency check were inlined in `init`, with no shared package for `uninit` to reuse.
4. **`status` JSON emitted raw `Duration.String()`** — `min_age` rendered as `"72h0m0s"` instead of `"3 days"`, inconsistent with the human text output.
5. **`init` Long/Short docs overstated `uninit`'s scope** — promised uninit reverses *all* changes, but the committable `.armis-supply-chain.yaml` config file is intentionally left in place.

## Solution

- **`supply_chain_check.go`**: Register a check-local `--fail-on` flag (bound to `scFailOn`, not the root `failOn` global) with default `["medium"]`, shadowing the root's persistent `[CRITICAL]`. Added a notice when no git base is detected and the command falls back to auditing all packages.
- **`supply_chain_uninit.go`**: Extended to also strip the `.npmrc` marker via the new `supplychain.RemoveNpmrcMarker`. Added `--dry-run` and `--yes` flags. Preview target files before prompting. Tailor the closing "Restart your shell" hint to only appear when RC files actually changed.
- **`internal/supplychain/npmrc.go`** (new): Centralizes `NpmrcFileName`, `NpmrcMarkerComment`, `HasNpmrcMarker`, `NpmrcFileHasMarker`, and `RemoveNpmrcMarker` with anchored marker detection to avoid false positives on user comments that merely mention the phrase.
- **`supply_chain_status.go`**: Switch JSON `min_age` to `formatDurationShort` so it renders as `"3 days"` matching the text output.
- **`supply_chain_init.go`**: Update docs to scope the uninit reverse-claim to shell RC + `.npmrc`, and add `--mode config` example.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

New test coverage includes: `TestRunSupplyChainCheck_NoGitBaseNotice`, `TestSupplyChainCheckFailOnDefaultsToMedium`, `TestSupplyChainCheckDefaultGatesMediumViolation`, `TestRunSupplyChainStatusJSON_MinAgeHumanReadable`, `TestRunSupplyChainUninit_DryRunWritesNothing`, `TestRunSupplyChainUninit_NpmrcOnly`, `TestRunSupplyChainUninit_YesRemovesBoth`, `TestRunSupplyChainUninit_NothingToDo`, `TestFormatDurationShort`.

### Manual Testing

Verified with `go test ./internal/cmd/... ./internal/supplychain/...` — all pass.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] No new warnings generated

[PPSC-1010]: https://armis-security.atlassian.net/browse/PPSC-1010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ