### PR TITLE
PPSC-1087: Add `auth setup` to register a tenant's IdP config

### DIFF
--- a/README.md
+++ b/README.md
@@ -997,6 +997,8 @@ When using client credentials, the tenant ID is automatically extracted from the
 
 You can also sign in explicitly at any time with `armis-cli auth login`; setting `ARMIS_DEFAULT_AUTH_METHOD=SSO` just triggers that sign-in automatically on the first command that needs credentials.
 
+Before users can sign in with SSO, an IT admin registers the tenant's identity provider once with `armis-cli auth setup` (see below).
+
 **Basic Authentication (Legacy):**
 
 | Variable | Description |
@@ -1012,6 +1014,42 @@ You can also sign in explicitly at any time with `armis-cli auth login`; setting
 | `ARMIS_PAGE_LIMIT` | Results pagination size (default: 500) |
 | `ARMIS_THEME` | Terminal background theme: auto, dark, light (default: auto) |
 | `ARMIS_NO_UPDATE_CHECK` | Disable automatic update checking |
+
+### Registering an identity provider (IT admins)
+
+Before your users can sign in with SSO, register your tenant's identity provider once with `armis-cli auth setup`. Run it after you register `armis-cli` as an OIDC application in your IdP (Okta, Entra ID, Keycloak, …); it posts the resulting configuration to the Armis admin API. Authentication uses your existing Armis admin credentials (resolved the same way as the scan commands).
+
+```bash
+# Interactive — the CLI walks you through each value
+armis-cli auth setup
+
+# Non-interactive, from a JSON file (for MDM / CI)
+armis-cli auth setup --config idp.json --yes
+
+# Update an existing configuration (rotate the secret, change mappings)
+armis-cli auth setup --config idp.json --update
+```
+
+`--config` accepts a file path, `-` to read stdin, or an inline JSON string:
+
+```json
+{
+  "tenant_id": "acme",
+  "idp_type": "okta",
+  "issuer": "https://acme.okta.com",
+  "oidc_client_id": "0oa1b2c3d4",
+  "oidc_client_secret": "…",
+  "group_claim": "groups",
+  "group_mapping": {
+    "admin": ["eng-admins"],
+    "developer": ["core-developers", "contract-developers"]
+  }
+}
+```
+
+`group_mapping` maps each Armis role to the IdP groups that grant it, so several groups can share a role. Only the two recognized roles — `admin` and `developer` — are accepted, and a group may appear under only one role. In interactive mode the same is entered as a comma-separated list of groups per role. The command shows a review summary (with the client secret masked) and confirms before sending; the secret is transmitted only in the registration request and is never stored or printed.
+
+If a configuration already exists for your tenant, running `armis-cli auth setup` interactively lets you edit it: the form is pre-filled with the current values, and you can update just what you need — for example, change a group mapping without re-entering the client secret. To update from a JSON document non-interactively, use `--config … --update`.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `auth` commands for browser-based SSO: `auth login`/`auth logout`/`auth whoami` sign in via your organization's identity provider.
+- `auth setup`: a guided command for IT admins to register (or update) their tenant's identity-provider configuration for SSO.
+
 ### Changed
 
 ### Deprecated

--- a/internal/auth/client.go
+++ b/internal/auth/client.go
@@ -27,7 +27,30 @@ const (
 	// package's HTTPS-enforcement checks.
 	schemeHTTPS = "https"
 	schemeHTTP  = "http"
+
+	// hostLocalhost / hostLoopback are the only hosts exempt from the HTTPS
+	// requirement, so local-dev and tests can point at a plain-http listener.
+	hostLocalhost = "localhost"
+	hostLoopback  = "127.0.0.1"
 )
+
+// requireSecureBaseURL enforces the auth package's transport guard: every base
+// URL must be HTTPS unless it targets localhost. This is the shared SSRF /
+// credential-leak check used by AuthClient, DeviceClient, and IdpConfigClient —
+// the request carries a credential and must never be sent in the clear to a
+// remote host.
+//
+// armis:ignore cwe:918 reason:parsedURL comes from operator-controlled config (ARMIS_API_URL) or the hardcoded RegionalBaseURL allowlist; this function IS the SSRF guard
+func requireSecureBaseURL(parsedURL *url.URL) error {
+	if parsedURL.Scheme == schemeHTTPS {
+		return nil
+	}
+	host := parsedURL.Hostname()
+	if host == hostLocalhost || host == hostLoopback {
+		return nil
+	}
+	return fmt.Errorf("HTTPS required for non-localhost URLs")
+}
 
 // RegionalBaseURL returns the Armis API base URL for the given region code.
 //
@@ -89,11 +112,8 @@ func NewAuthClient(baseURL string, debug bool) (*AuthClient, error) {
 
 	// armis:ignore cwe:522 reason:this code IS the credential protection check (HTTPS enforcement for non-localhost)
 	// armis:ignore cwe:918 reason:baseURL is operator-controlled (ARMIS_API_URL) or the hardcoded RegionalBaseURL allowlist, never attacker-reachable input; this block IS the SSRF guard (rejects non-HTTPS non-localhost hosts)
-	if parsedURL.Scheme != schemeHTTPS {
-		host := parsedURL.Hostname()
-		if host != "localhost" && host != "127.0.0.1" {
-			return nil, fmt.Errorf("HTTPS required for non-localhost URLs")
-		}
+	if err := requireSecureBaseURL(parsedURL); err != nil {
+		return nil, err
 	}
 
 	return &AuthClient{

--- a/internal/auth/device.go
+++ b/internal/auth/device.go
@@ -109,11 +109,8 @@ func NewDeviceClient(baseURL string, debug bool) (*DeviceClient, error) {
 	}
 
 	// armis:ignore cwe:918 reason:baseURL is operator-controlled (ARMIS_API_URL) or the hardcoded RegionalBaseURL allowlist; this block IS the SSRF guard (rejects non-HTTPS non-localhost hosts)
-	if parsedURL.Scheme != schemeHTTPS {
-		host := parsedURL.Hostname()
-		if host != "localhost" && host != "127.0.0.1" {
-			return nil, fmt.Errorf("HTTPS required for non-localhost URLs")
-		}
+	if err := requireSecureBaseURL(parsedURL); err != nil {
+		return nil, err
 	}
 
 	return &DeviceClient{

--- a/internal/auth/device.go
+++ b/internal/auth/device.go
@@ -1,7 +1,7 @@
 // Package auth provides authentication for the Armis API.
 // This file implements the OAuth2 Device Authorization Grant (RFC 8628) client
 // used by `armis-cli auth login`. The server side is the Moose OAuth2
-// authorization server (PPSC-1033), mounted at the issuer root.
+// authorization server, mounted at the issuer root.
 package auth
 
 import (

--- a/internal/auth/device.go
+++ b/internal/auth/device.go
@@ -279,7 +279,7 @@ func (c *DeviceClient) tokenRequest(ctx context.Context, form url.Values, client
 // postForm issues a form-encoded POST and returns the body and status code.
 func (c *DeviceClient) postForm(ctx context.Context, path string, form url.Values) ([]byte, int, error) {
 	endpoint := c.baseURL + path
-	// armis:ignore cwe:918 reason:baseURL validated by NewDeviceClient (HTTPS enforced for non-localhost); path is a hardcoded constant
+	// armis:ignore cwe:918 reason:baseURL validated by NewDeviceClient (HTTPS enforced for non-localhost); path is a hardcoded constant; the client's CheckRedirect returns ErrUseLastResponse so the device_code/refresh_token are never replayed to a redirect target
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to create request: %w", err)

--- a/internal/auth/idpconfig.go
+++ b/internal/auth/idpconfig.go
@@ -1,6 +1,6 @@
 // Package auth provides authentication for the Armis API.
-// This file implements a client for the tenant↔IdP configuration admin API
-// (PPSC-1035), used by `armis-cli auth setup` to register a tenant's IdP with
+// This file implements a client for the tenant↔IdP configuration admin API,
+// used by `armis-cli auth setup` to register a tenant's IdP with
 // the Moose OAuth2 authorization server. The endpoints are mounted under
 // /api/v1/oauth2/idp-configs (api_controller/oauth2/admin_router.py).
 package auth

--- a/internal/auth/idpconfig.go
+++ b/internal/auth/idpconfig.go
@@ -1,0 +1,263 @@
+// Package auth provides authentication for the Armis API.
+// This file implements a client for the tenant↔IdP configuration admin API
+// (PPSC-1035), used by `armis-cli auth setup` to register a tenant's IdP with
+// the Moose OAuth2 authorization server. The endpoints are mounted under
+// /api/v1/oauth2/idp-configs (api_controller/oauth2/admin_router.py).
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/ArmisSecurity/armis-cli/internal/httpclient"
+)
+
+// idpConfigsPath is the collection endpoint, relative to the API base URL.
+const idpConfigsPath = "/api/v1/oauth2/idp-configs"
+
+// IdpConfigCreateRequest mirrors the backend IdpConfigCreateRequest
+// (api_controller/oauth2/models.py). The plaintext oidc_client_secret is sent
+// once on the wire and stored server-side in Secrets Manager; it is never
+// returned in a response.
+type IdpConfigCreateRequest struct {
+	TenantID         string            `json:"tenant_id"`
+	IdpType          string            `json:"idp_type"`
+	Issuer           string            `json:"issuer"`
+	OIDCClientID     string            `json:"oidc_client_id"`
+	OIDCClientSecret string            `json:"oidc_client_secret"` //nolint:gosec // G117: request field carrying the plaintext secret for the single registration call
+	GroupClaim       string            `json:"group_claim"`
+	GroupMapping     map[string]string `json:"group_mapping"`
+	EMAEnabled       bool              `json:"ema_enabled"`
+	Enabled          bool              `json:"enabled"`
+}
+
+// IdpConfigUpdateRequest mirrors the backend IdpConfigUpdateRequest: every field
+// is optional and only provided (non-nil) fields are changed. Supplying
+// oidc_client_secret rotates the secret. tenant_id is not part of the body —
+// it addresses the resource via the URL path.
+type IdpConfigUpdateRequest struct {
+	IdpType          *string           `json:"idp_type,omitempty"`
+	Issuer           *string           `json:"issuer,omitempty"`
+	OIDCClientID     *string           `json:"oidc_client_id,omitempty"`
+	OIDCClientSecret *string           `json:"oidc_client_secret,omitempty"` //nolint:gosec // G117: request field carrying the plaintext secret for a rotation call
+	GroupClaim       *string           `json:"group_claim,omitempty"`
+	GroupMapping     map[string]string `json:"group_mapping,omitempty"`
+	EMAEnabled       *bool             `json:"ema_enabled,omitempty"`
+	Enabled          *bool             `json:"enabled,omitempty"`
+}
+
+// IdpConfigResponse mirrors the backend IdpConfigResponse. It deliberately omits
+// the OIDC client secret and its Secrets Manager ARN.
+type IdpConfigResponse struct {
+	TenantID     string            `json:"tenant_id"`
+	IdpType      string            `json:"idp_type"`
+	Issuer       string            `json:"issuer"`
+	OIDCClientID string            `json:"oidc_client_id"`
+	GroupClaim   string            `json:"group_claim"`
+	GroupMapping map[string]string `json:"group_mapping"`
+	EMAEnabled   bool              `json:"ema_enabled"`
+	Enabled      bool              `json:"enabled"`
+	CreatedAt    string            `json:"created_at"`
+	UpdatedAt    string            `json:"updated_at"`
+}
+
+// IdpConfigError is a typed HTTP error from the admin API. It carries the status
+// code and the FastAPI {"detail": "..."} message so callers can branch on the
+// status (e.g. 409 → offer an update) and show the server's explanation.
+type IdpConfigError struct {
+	StatusCode int
+	Detail     string
+}
+
+func (e *IdpConfigError) Error() string {
+	if e.Detail != "" {
+		return fmt.Sprintf("%s (status %d)", e.Detail, e.StatusCode)
+	}
+	return fmt.Sprintf("unexpected response (status %d)", e.StatusCode)
+}
+
+// IdpConfigClient talks to the tenant↔IdP configuration admin API. It reuses an
+// AuthHeaderProvider for the Authorization header, so it works with whichever
+// credential path the CLI resolved (Basic API token or a Bearer JWT).
+type IdpConfigClient struct {
+	baseURL    string
+	authHeader AuthHeaderProvider
+	httpClient *http.Client
+	debug      bool
+}
+
+// AuthHeaderProvider supplies the Authorization header for admin API requests.
+// It matches the api.AuthHeaderProvider contract; *AuthProvider satisfies both.
+type AuthHeaderProvider interface {
+	GetAuthorizationHeader(ctx context.Context) (string, error)
+}
+
+// NewIdpConfigClient creates a client for the admin API at baseURL. HTTPS is
+// enforced for non-localhost hosts and redirects are disabled, matching the
+// hardening of DeviceClient/AuthClient — the request carries the admin's
+// credential and must not be replayed to a redirect target.
+func NewIdpConfigClient(baseURL string, authHeader AuthHeaderProvider, debug bool) (*IdpConfigClient, error) {
+	if baseURL == "" {
+		return nil, fmt.Errorf("API base URL is required to register an IdP configuration")
+	}
+	if authHeader == nil {
+		return nil, fmt.Errorf("an authorization provider is required")
+	}
+
+	parsedURL, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base URL: %w", err)
+	}
+
+	// armis:ignore cwe:918 reason:baseURL is operator-controlled (ARMIS_API_URL) or the hardcoded RegionalBaseURL allowlist; this block IS the SSRF guard (rejects non-HTTPS non-localhost hosts)
+	if err := requireSecureBaseURL(parsedURL); err != nil {
+		return nil, err
+	}
+
+	return &IdpConfigClient{
+		baseURL:    strings.TrimSuffix(baseURL, "/"),
+		authHeader: authHeader,
+		httpClient: &http.Client{
+			Timeout:   30 * time.Second,
+			Transport: httpclient.ProxyAwareTransport(),
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		debug: debug,
+	}, nil
+}
+
+// Get fetches an existing tenant's IdP configuration (GET /{tenant_id}). A 404 is
+// returned as an *IdpConfigError with StatusCode 404 so the caller can treat
+// "not configured yet" distinctly from a transport or authorization failure. The
+// response never carries the OIDC client secret.
+func (c *IdpConfigClient) Get(ctx context.Context, tenantID string) (*IdpConfigResponse, error) {
+	if tenantID == "" {
+		return nil, fmt.Errorf("tenant_id is required to fetch an IdP configuration")
+	}
+	path := idpConfigsPath + "/" + url.PathEscape(tenantID)
+	return c.send(ctx, http.MethodGet, path, nil, http.StatusOK)
+}
+
+// Create registers a new IdP configuration (POST). A 409 is returned as an
+// *IdpConfigError with StatusCode 409 so the caller can offer to update instead.
+func (c *IdpConfigClient) Create(ctx context.Context, req *IdpConfigCreateRequest) (*IdpConfigResponse, error) {
+	return c.send(ctx, http.MethodPost, idpConfigsPath, req, http.StatusCreated)
+}
+
+// Update replaces (rotates) an existing tenant's IdP configuration
+// (PUT /{tenant_id}). Supplying OIDCClientSecret rotates the stored secret.
+func (c *IdpConfigClient) Update(ctx context.Context, tenantID string, req *IdpConfigUpdateRequest) (*IdpConfigResponse, error) {
+	if tenantID == "" {
+		return nil, fmt.Errorf("tenant_id is required to update an IdP configuration")
+	}
+	path := idpConfigsPath + "/" + url.PathEscape(tenantID)
+	return c.send(ctx, http.MethodPut, path, req, http.StatusOK)
+}
+
+// send marshals body to JSON, issues the request with the Authorization header,
+// and decodes a success response (wantStatus) into an IdpConfigResponse. Any
+// other status becomes an *IdpConfigError carrying the parsed {"detail": ...}.
+func (c *IdpConfigClient) send(ctx context.Context, method, path string, body any, wantStatus int) (*IdpConfigResponse, error) {
+	// GET requests carry no body; only marshal and set Content-Type when there is
+	// one, so a read never sends a stray Content-Type header.
+	var reqBody io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode request: %w", err)
+		}
+		reqBody = bytes.NewReader(payload)
+	}
+
+	authz, err := c.authHeader.GetAuthorizationHeader(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve credentials: %w", err)
+	}
+
+	endpoint := c.baseURL + path
+	// armis:ignore cwe:918 reason:baseURL validated by NewIdpConfigClient (HTTPS enforced for non-localhost); path is built from a hardcoded constant plus a URL-escaped tenant id
+	httpReq, err := http.NewRequestWithContext(ctx, method, endpoint, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", authz)
+	if reqBody != nil {
+		httpReq.Header.Set("Content-Type", "application/json")
+	}
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq) //nolint:gosec // endpoint built from validated config, not user input
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", annotateTransportError(err))
+	}
+	defer resp.Body.Close() //nolint:errcheck // response body read-only
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != wantStatus {
+		return nil, parseIdpConfigError(respBody, resp.StatusCode)
+	}
+
+	var out IdpConfigResponse
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return &out, nil
+}
+
+// parseIdpConfigError extracts the FastAPI {"detail": "..."} message. The detail
+// field may be a plain string or, for 422 validation errors, a list of error
+// objects; both are rendered into a readable message.
+func parseIdpConfigError(body []byte, status int) *IdpConfigError {
+	var asString struct {
+		Detail string `json:"detail"`
+	}
+	if err := json.Unmarshal(body, &asString); err == nil && asString.Detail != "" {
+		return &IdpConfigError{StatusCode: status, Detail: asString.Detail}
+	}
+
+	// 422 validation errors carry a list of {loc, msg, type} objects.
+	var asList struct {
+		Detail []struct {
+			Loc []any  `json:"loc"`
+			Msg string `json:"msg"`
+		} `json:"detail"`
+	}
+	if err := json.Unmarshal(body, &asList); err == nil && len(asList.Detail) > 0 {
+		parts := make([]string, 0, len(asList.Detail))
+		for _, d := range asList.Detail {
+			field := lastLocField(d.Loc)
+			if field != "" {
+				parts = append(parts, fmt.Sprintf("%s: %s", field, d.Msg))
+			} else {
+				parts = append(parts, d.Msg)
+			}
+		}
+		return &IdpConfigError{StatusCode: status, Detail: strings.Join(parts, "; ")}
+	}
+
+	return &IdpConfigError{StatusCode: status}
+}
+
+// lastLocField returns the last string element of a FastAPI error "loc" array,
+// which names the offending field (e.g. ["body", "issuer"] → "issuer").
+func lastLocField(loc []any) string {
+	for i := len(loc) - 1; i >= 0; i-- {
+		if s, ok := loc[i].(string); ok && s != "body" {
+			return s
+		}
+	}
+	return ""
+}

--- a/internal/auth/idpconfig_test.go
+++ b/internal/auth/idpconfig_test.go
@@ -10,6 +10,13 @@ import (
 	"testing"
 )
 
+// roleAdmin / roleDeveloper are the Armis roles used across these tests as
+// group_mapping values.
+const (
+	roleAdmin     = "admin"
+	roleDeveloper = "developer"
+)
+
 // staticAuthHeader is a trivial AuthHeaderProvider for tests.
 type staticAuthHeader struct {
 	value string
@@ -28,7 +35,7 @@ func sampleCreateReq() *IdpConfigCreateRequest {
 		OIDCClientID:     "client-abc",
 		OIDCClientSecret: "s3cr3t",
 		GroupClaim:       "groups",
-		GroupMapping:     map[string]string{"eng-admins": "admin", "eng": "developer"},
+		GroupMapping:     map[string]string{"eng-admins": roleAdmin, "eng": roleDeveloper},
 		EMAEnabled:       false,
 		Enabled:          true,
 	}
@@ -51,7 +58,7 @@ func TestIdpConfigClientCreateSuccess(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"tenant_id": "tenant-7", "idp_type": "okta",
 			"issuer": "https://example.okta.com", "oidc_client_id": "client-abc",
-			"group_claim": "groups", "group_mapping": map[string]string{"eng-admins": "admin"},
+			"group_claim": "groups", "group_mapping": map[string]string{"eng-admins": roleAdmin},
 			"ema_enabled": false, "enabled": true,
 			"created_at": "2026-07-02T00:00:00Z", "updated_at": "2026-07-02T00:00:00Z",
 		})
@@ -86,7 +93,7 @@ func TestIdpConfigClientCreateSuccess(t *testing.T) {
 	if gotBody.OIDCClientSecret != "s3cr3t" {
 		t.Errorf("body secret = %q, want s3cr3t", gotBody.OIDCClientSecret)
 	}
-	if gotBody.GroupMapping["eng-admins"] != "admin" || gotBody.GroupMapping["eng"] != "developer" {
+	if gotBody.GroupMapping["eng-admins"] != roleAdmin || gotBody.GroupMapping["eng"] != roleDeveloper {
 		t.Errorf("group_mapping = %v", gotBody.GroupMapping)
 	}
 	if gotBody.EMAEnabled {
@@ -108,7 +115,7 @@ func TestIdpConfigClientGetSuccess(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"tenant_id": "tenant-7", "idp_type": "okta",
 			"issuer": "https://example.okta.com", "oidc_client_id": "client-abc",
-			"group_claim": "groups", "group_mapping": map[string]string{"eng-admins": "admin"},
+			"group_claim": "groups", "group_mapping": map[string]string{"eng-admins": roleAdmin},
 			"ema_enabled": false, "enabled": true,
 			"created_at": "2026-07-02T00:00:00Z", "updated_at": "2026-07-02T00:00:00Z",
 		})
@@ -133,7 +140,7 @@ func TestIdpConfigClientGetSuccess(t *testing.T) {
 	if gotContentType != "" {
 		t.Errorf("GET Content-Type = %q, want empty", gotContentType)
 	}
-	if resp.OIDCClientID != "client-abc" || resp.GroupMapping["eng-admins"] != "admin" {
+	if resp.OIDCClientID != "client-abc" || resp.GroupMapping["eng-admins"] != roleAdmin {
 		t.Errorf("unexpected response %+v", resp)
 	}
 }

--- a/internal/auth/idpconfig_test.go
+++ b/internal/auth/idpconfig_test.go
@@ -1,0 +1,278 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// staticAuthHeader is a trivial AuthHeaderProvider for tests.
+type staticAuthHeader struct {
+	value string
+	err   error
+}
+
+func (s staticAuthHeader) GetAuthorizationHeader(context.Context) (string, error) {
+	return s.value, s.err
+}
+
+func sampleCreateReq() *IdpConfigCreateRequest {
+	return &IdpConfigCreateRequest{
+		TenantID:         "tenant-7",
+		IdpType:          "okta",
+		Issuer:           "https://example.okta.com",
+		OIDCClientID:     "client-abc",
+		OIDCClientSecret: "s3cr3t",
+		GroupClaim:       "groups",
+		GroupMapping:     map[string]string{"eng-admins": "admin", "eng": "developer"},
+		EMAEnabled:       false,
+		Enabled:          true,
+	}
+}
+
+func TestIdpConfigClientCreateSuccess(t *testing.T) {
+	var gotBody IdpConfigCreateRequest
+	var gotAuth, gotMethod, gotPath, gotContentType string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tenant_id": "tenant-7", "idp_type": "okta",
+			"issuer": "https://example.okta.com", "oidc_client_id": "client-abc",
+			"group_claim": "groups", "group_mapping": map[string]string{"eng-admins": "admin"},
+			"ema_enabled": false, "enabled": true,
+			"created_at": "2026-07-02T00:00:00Z", "updated_at": "2026-07-02T00:00:00Z",
+		})
+	}))
+	defer srv.Close()
+
+	c, err := NewIdpConfigClient(srv.URL, staticAuthHeader{value: "Basic abc123"}, false)
+	if err != nil {
+		t.Fatalf("NewIdpConfigClient: %v", err)
+	}
+
+	resp, err := c.Create(context.Background(), sampleCreateReq())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if resp.TenantID != "tenant-7" {
+		t.Errorf("resp.TenantID = %q, want tenant-7", resp.TenantID)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/api/v1/oauth2/idp-configs" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotAuth != "Basic abc123" {
+		t.Errorf("Authorization = %q", gotAuth)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q", gotContentType)
+	}
+	// The secret must be transmitted in the body exactly once.
+	if gotBody.OIDCClientSecret != "s3cr3t" {
+		t.Errorf("body secret = %q, want s3cr3t", gotBody.OIDCClientSecret)
+	}
+	if gotBody.GroupMapping["eng-admins"] != "admin" || gotBody.GroupMapping["eng"] != "developer" {
+		t.Errorf("group_mapping = %v", gotBody.GroupMapping)
+	}
+	if gotBody.EMAEnabled {
+		t.Error("ema_enabled should be sent false")
+	}
+}
+
+func TestIdpConfigClientGetSuccess(t *testing.T) {
+	var gotMethod, gotPath, gotContentType string
+	var gotBodyLen int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotContentType = r.Header.Get("Content-Type")
+		b, _ := io.ReadAll(r.Body)
+		gotBodyLen = len(b)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tenant_id": "tenant-7", "idp_type": "okta",
+			"issuer": "https://example.okta.com", "oidc_client_id": "client-abc",
+			"group_claim": "groups", "group_mapping": map[string]string{"eng-admins": "admin"},
+			"ema_enabled": false, "enabled": true,
+			"created_at": "2026-07-02T00:00:00Z", "updated_at": "2026-07-02T00:00:00Z",
+		})
+	}))
+	defer srv.Close()
+
+	c, _ := NewIdpConfigClient(srv.URL, staticAuthHeader{value: "Basic x"}, false)
+	resp, err := c.Get(context.Background(), "tenant-7")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q, want GET", gotMethod)
+	}
+	if gotPath != "/api/v1/oauth2/idp-configs/tenant-7" {
+		t.Errorf("path = %q", gotPath)
+	}
+	// A GET must carry no body and no Content-Type header.
+	if gotBodyLen != 0 {
+		t.Errorf("GET body length = %d, want 0", gotBodyLen)
+	}
+	if gotContentType != "" {
+		t.Errorf("GET Content-Type = %q, want empty", gotContentType)
+	}
+	if resp.OIDCClientID != "client-abc" || resp.GroupMapping["eng-admins"] != "admin" {
+		t.Errorf("unexpected response %+v", resp)
+	}
+}
+
+func TestIdpConfigClientGetNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"detail": "IdP configuration not found"})
+	}))
+	defer srv.Close()
+
+	c, _ := NewIdpConfigClient(srv.URL, staticAuthHeader{value: "Basic x"}, false)
+	_, err := c.Get(context.Background(), "tenant-7")
+	var ce *IdpConfigError
+	if !errors.As(err, &ce) || ce.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 IdpConfigError, got %v", err)
+	}
+}
+
+func TestIdpConfigClientCreateConflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"detail": "IdP configuration already exists for this tenant",
+		})
+	}))
+	defer srv.Close()
+
+	c, _ := NewIdpConfigClient(srv.URL, staticAuthHeader{value: "Basic x"}, false)
+	_, err := c.Create(context.Background(), sampleCreateReq())
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	var ce *IdpConfigError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error type = %T, want *IdpConfigError", err)
+	}
+	if ce.StatusCode != http.StatusConflict {
+		t.Errorf("StatusCode = %d, want 409", ce.StatusCode)
+	}
+	if ce.Detail == "" {
+		t.Error("expected detail message")
+	}
+}
+
+func TestIdpConfigClientUpdateSuccess(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tenant_id": "tenant-7", "idp_type": "okta",
+			"issuer": "https://example.okta.com", "oidc_client_id": "client-abc",
+			"group_claim": "groups", "group_mapping": map[string]string{},
+			"ema_enabled": false, "enabled": true,
+			"created_at": "2026-07-02T00:00:00Z", "updated_at": "2026-07-02T01:00:00Z",
+		})
+	}))
+	defer srv.Close()
+
+	c, _ := NewIdpConfigClient(srv.URL, staticAuthHeader{value: "Bearer jwt"}, false)
+	secret := "rotated"
+	_, err := c.Update(context.Background(), "tenant-7", &IdpConfigUpdateRequest{
+		OIDCClientSecret: &secret,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	if gotPath != "/api/v1/oauth2/idp-configs/tenant-7" {
+		t.Errorf("path = %q", gotPath)
+	}
+	// Omitted (nil) fields must not appear in the update body.
+	if _, present := gotBody["issuer"]; present {
+		t.Error("nil issuer should be omitted from update body")
+	}
+	if gotBody["oidc_client_secret"] != "rotated" {
+		t.Errorf("secret in body = %v", gotBody["oidc_client_secret"])
+	}
+}
+
+func TestIdpConfigClientUpdateNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"detail": "IdP configuration not found"})
+	}))
+	defer srv.Close()
+
+	c, _ := NewIdpConfigClient(srv.URL, staticAuthHeader{value: "Basic x"}, false)
+	_, err := c.Update(context.Background(), "tenant-7", &IdpConfigUpdateRequest{})
+	var ce *IdpConfigError
+	if !errors.As(err, &ce) || ce.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 IdpConfigError, got %v", err)
+	}
+}
+
+func TestIdpConfigClientValidationError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		// FastAPI list-shaped validation error.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"detail": []map[string]any{
+				{"loc": []any{"body", "issuer"}, "msg": "field required", "type": "value_error.missing"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c, _ := NewIdpConfigClient(srv.URL, staticAuthHeader{value: "Basic x"}, false)
+	_, err := c.Create(context.Background(), sampleCreateReq())
+	var ce *IdpConfigError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error type = %T, want *IdpConfigError", err)
+	}
+	if ce.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("StatusCode = %d, want 422", ce.StatusCode)
+	}
+	if ce.Detail != "issuer: field required" {
+		t.Errorf("Detail = %q, want 'issuer: field required'", ce.Detail)
+	}
+}
+
+func TestNewIdpConfigClientRejectsInsecureURL(t *testing.T) {
+	_, err := NewIdpConfigClient("http://example.com", staticAuthHeader{value: "x"}, false)
+	if err == nil {
+		t.Fatal("expected HTTPS-required error for non-localhost http URL")
+	}
+}
+
+func TestNewIdpConfigClientAllowsLocalhost(t *testing.T) {
+	if _, err := NewIdpConfigClient("http://localhost:8001", staticAuthHeader{value: "x"}, false); err != nil {
+		t.Errorf("localhost http should be allowed: %v", err)
+	}
+}

--- a/internal/auth/tokenstore.go
+++ b/internal/auth/tokenstore.go
@@ -21,7 +21,7 @@ import (
 // epic PPSC-1032). Those tools read and write the SAME file so a single
 // `armis-cli auth login` keeps every tool authenticated.
 //
-// A plain file (not the OS keychain) is the deliberate choice: the MCP plugins
+// A plain file is the deliberate choice: the MCP plugins
 // are Python, and the refresh-token rotation + reuse-detection on the backend
 // requires a SINGLE source of truth (a divergent second store would replay a
 // rotated token and get the whole token family revoked). This matches the

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -20,6 +20,11 @@ The recommended path is browser-based SSO:
   armis-cli auth whoami    Show the current identity, tenant, and token expiry
   armis-cli auth logout    Remove stored credentials
 
+IT admins register their tenant's identity provider (a one-time setup that
+enables SSO login) with:
+
+  armis-cli auth setup     Register your tenant's IdP configuration
+
 For CI/CD and service accounts, set ARMIS_CLIENT_ID / ARMIS_CLIENT_SECRET
 (client-credentials) instead of logging in interactively.`,
 }

--- a/internal/cmd/auth_setup.go
+++ b/internal/cmd/auth_setup.go
@@ -26,6 +26,10 @@ import (
 const (
 	roleAdmin     = "admin"
 	roleDeveloper = "developer"
+
+	// maxConfigBytes bounds a --config document read from stdin. A configuration
+	// is only a few hundred bytes; the cap guards against an unbounded pipe.
+	maxConfigBytes = 2 << 10 // 2 KiB
 )
 
 var (
@@ -732,6 +736,18 @@ type idpConfigInput struct {
 	Enabled          *bool               `json:"enabled"`
 }
 
+// readConfigFile reads an operator-supplied --config file, bounding the read to
+// maxConfigBytes so a path to a huge file cannot exhaust memory.
+func readConfigFile(path string) ([]byte, error) {
+	// armis:ignore cwe:22 reason:path is the --config value the operator running the CLI chose; reading their own file from any location is the intended behavior, not attacker-controlled input
+	f, err := os.Open(path) // #nosec G304 -- operator-supplied config path, read intentionally
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close() //nolint:errcheck // read-only
+	return io.ReadAll(io.LimitReader(f, maxConfigBytes))
+}
+
 // loadIdpConfigFromJSON resolves --config (inline JSON, stdin, or a file path)
 // and decodes it. Unknown fields are rejected so typos surface immediately.
 func loadIdpConfigFromJSON(input string) (*auth.IdpConfigCreateRequest, error) {
@@ -740,11 +756,13 @@ func loadIdpConfigFromJSON(input string) (*auth.IdpConfigCreateRequest, error) {
 
 	switch {
 	case input == "-":
-		raw, err = io.ReadAll(os.Stdin)
+		// An IdP config is a few hundred bytes; cap the read so an unbounded pipe
+		// cannot exhaust memory.
+		raw, err = io.ReadAll(io.LimitReader(os.Stdin, maxConfigBytes))
 	case strings.HasPrefix(strings.TrimSpace(input), "{"):
 		raw = []byte(input)
 	default:
-		raw, err = os.ReadFile(input) // #nosec G304 -- operator-supplied config path, read intentionally
+		raw, err = readConfigFile(input)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config: %w", err)

--- a/internal/cmd/auth_setup.go
+++ b/internal/cmd/auth_setup.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -145,6 +146,9 @@ func runConfigFileSetup(ctx context.Context, client *auth.IdpConfigClient) error
 	// Review + confirm (unless --yes). The client secret is masked.
 	printIdpConfigSummary(reqCfg)
 	if !setupYes {
+		if !cli.IsInteractive() {
+			return fmt.Errorf("cannot confirm in a non-interactive terminal: re-run with --yes to apply the configuration")
+		}
 		confirmed, cerr := confirmSetup(setupUpdate)
 		if cerr != nil {
 			return cerr
@@ -162,10 +166,10 @@ func runConfigFileSetup(ctx context.Context, client *auth.IdpConfigClient) error
 }
 
 // runInteractiveSetup guides an admin through setup. It first resolves the tenant
-// and fetches any existing configuration: if one exists, it shows a pre-filled
-// form where every field is optional (blank means "keep") and sends only the
-// changed fields — so an admin can, say, tweak a group mapping without re-entering
-// the client secret. Otherwise it collects a full configuration and creates it.
+// and fetches any existing configuration: if one exists, it shows a form pre-filled
+// with the current values and sends only the fields the admin edited — so an admin
+// can, say, tweak a group mapping without re-entering the client secret (which the
+// form leaves blank). Otherwise it collects a full configuration and creates it.
 func runInteractiveSetup(ctx context.Context, client *auth.IdpConfigClient) error {
 	tenant, err := promptSetupTenantID(strings.TrimSpace(tenantID))
 	if err != nil {
@@ -269,7 +273,8 @@ func fetchExistingConfig(ctx context.Context, client *auth.IdpConfigClient, tena
 }
 
 // sendCreate POSTs a new configuration. On 409 it offers to switch to the update
-// (PUT) path, automatically when --yes is set and interactively otherwise.
+// (PUT) path interactively; when non-interactive or --yes is set it errors and
+// points at --update, so a scripted create never silently overwrites.
 func sendCreate(ctx context.Context, client *auth.IdpConfigClient, reqCfg *auth.IdpConfigCreateRequest) error {
 	reqCtx, cancel := withRequestTimeout(ctx)
 	defer cancel()
@@ -740,8 +745,8 @@ type idpConfigInput struct {
 	Enabled          *bool               `json:"enabled"`
 }
 
-// readConfigFile reads an operator-supplied --config file, bounding the read to
-// maxConfigBytes so a path to a huge file cannot exhaust memory.
+// readConfigFile reads an operator-supplied --config file, bounding the read so a
+// path to a huge file cannot exhaust memory.
 func readConfigFile(path string) ([]byte, error) {
 	// armis:ignore cwe:22 reason:path is the --config value the operator running the CLI chose; reading their own file from any location is the intended behavior, not attacker-controlled input
 	f, err := os.Open(path) // #nosec G304 -- operator-supplied config path, read intentionally
@@ -749,7 +754,21 @@ func readConfigFile(path string) ([]byte, error) {
 		return nil, err
 	}
 	defer f.Close() //nolint:errcheck // read-only
-	return io.ReadAll(io.LimitReader(f, maxConfigBytes))
+	return readBoundedConfig(f)
+}
+
+// readBoundedConfig reads at most maxConfigBytes, returning an explicit error when
+// the input is larger rather than silently truncating it into a confusing parse
+// failure.
+func readBoundedConfig(r io.Reader) ([]byte, error) {
+	raw, err := io.ReadAll(io.LimitReader(r, maxConfigBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) > maxConfigBytes {
+		return nil, fmt.Errorf("configuration is larger than %d bytes; a valid IdP configuration is far smaller", maxConfigBytes)
+	}
+	return raw, nil
 }
 
 // loadIdpConfigFromJSON resolves --config (inline JSON, stdin, or a file path)
@@ -760,9 +779,7 @@ func loadIdpConfigFromJSON(input string) (*auth.IdpConfigCreateRequest, error) {
 
 	switch {
 	case input == "-":
-		// An IdP config is a few hundred bytes; cap the read so an unbounded pipe
-		// cannot exhaust memory.
-		raw, err = io.ReadAll(io.LimitReader(os.Stdin, maxConfigBytes))
+		raw, err = readBoundedConfig(os.Stdin)
 	case strings.HasPrefix(strings.TrimSpace(input), "{"):
 		raw = []byte(input)
 	default:
@@ -773,10 +790,13 @@ func loadIdpConfigFromJSON(input string) (*auth.IdpConfigCreateRequest, error) {
 	}
 
 	in := &idpConfigInput{}
-	dec := json.NewDecoder(strings.NewReader(string(raw)))
+	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(in); err != nil {
 		return nil, fmt.Errorf("invalid config JSON: %w", err)
+	}
+	if dec.More() {
+		return nil, fmt.Errorf("invalid config JSON: unexpected trailing content after the configuration object")
 	}
 
 	mapping, err := assembleGroupMapping(in.GroupMapping)
@@ -875,8 +895,8 @@ func groupsByRole(mapping map[string]string) map[string][]string {
 	return out
 }
 
-// maskSecret returns a fixed-width mask that reveals only the secret's length
-// category, never its content.
+// maskSecret returns a fixed-width mask and the secret's length, never its content,
+// so the admin can sanity-check they pasted the right value.
 func maskSecret(s string) string {
 	if s == "" {
 		return "(none)"

--- a/internal/cmd/auth_setup.go
+++ b/internal/cmd/auth_setup.go
@@ -1,0 +1,866 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ArmisSecurity/armis-cli/internal/auth"
+	"github.com/ArmisSecurity/armis-cli/internal/cli"
+	"github.com/ArmisSecurity/armis-cli/internal/cmd/cmdutil"
+	"github.com/ArmisSecurity/armis-cli/internal/output"
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+)
+
+// Recognized Armis roles for group_mapping values. The backend maps an IdP
+// group to one of these; anything else is silently unrecognized at login time,
+// so we constrain the input here to catch typos early.
+const (
+	roleAdmin     = "admin"
+	roleDeveloper = "developer"
+)
+
+var (
+	setupConfigInput string // --config: file path, "-" for stdin, or inline JSON
+	setupUpdate      bool   // --update: force the PUT (update) path
+	setupYes         bool   // --yes: skip the review confirmation
+)
+
+var authSetupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Register your tenant's identity provider (IdP) for SSO",
+	Long: `Register (or update) your tenant's identity-provider configuration so your
+users can sign in with 'armis-cli auth login'.
+
+This is an IT-admin task: run it once after you register armis-cli as an OIDC
+application in your IdP (Okta, Entra ID, Keycloak, …). It posts the resulting
+configuration to the Armis admin API.
+
+Two ways to provide the configuration:
+
+  Interactive (default)   The CLI walks you through each value and explains
+                          where to find it.
+
+  From JSON (--config)    Provide the whole configuration as one JSON document
+                          for scripting (MDM, CI). --config accepts a file path,
+                          '-' to read stdin, or an inline JSON string.
+
+Authentication uses your existing Armis credentials, resolved the same way as
+the scan commands (a stored SSO session, client credentials, or an API token).
+Your OIDC client secret is sent only in this request — it is never stored or
+printed.`,
+	Example: `  # Interactive setup
+  armis-cli auth setup
+
+  # From a JSON file
+  armis-cli auth setup --config idp.json
+
+  # Inline JSON, non-interactive (e.g. in a script)
+  armis-cli auth setup --config '{"tenant_id":"acme",...}' --yes
+
+  # Update an existing configuration (rotate the secret, change mappings)
+  armis-cli auth setup --config idp.json --update`,
+	Args: cobra.NoArgs,
+	RunE: runAuthSetup,
+}
+
+func init() {
+	authSetupCmd.Flags().StringVar(&setupConfigInput, "config", "", "IdP configuration as JSON: a file path, '-' for stdin, or an inline JSON string")
+	authSetupCmd.Flags().BoolVar(&setupUpdate, "update", false, "Update an existing configuration (PUT) instead of creating a new one")
+	authSetupCmd.Flags().BoolVar(&setupYes, "yes", false, "Skip the review confirmation (for non-interactive use)")
+	authCmd.AddCommand(authSetupCmd)
+}
+
+func runAuthSetup(cmd *cobra.Command, _ []string) error {
+	// Resolve the admin's credentials up front so authentication problems surface
+	// before we prompt for (or read) any IdP details.
+	provider, err := getAuthProvider(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	client, err := auth.NewIdpConfigClient(getAPIBaseURL(), provider, debug)
+	if err != nil {
+		return err
+	}
+
+	// Pass the command's context through; each network call applies its own
+	// per-request timeout (see withRequestTimeout). We must NOT wrap a single
+	// deadline around the whole flow — the interactive forms can take minutes and
+	// would otherwise consume the budget before the request is even sent.
+	ctx := cmd.Context()
+
+	// The --config path is for scripting (MDM, CI): the caller supplies the whole
+	// configuration as one document, so we don't pre-flight or prompt.
+	if setupConfigInput != "" {
+		return runConfigFileSetup(ctx, client)
+	}
+	if !cli.IsInteractive() {
+		return fmt.Errorf("no configuration provided: pass --config (a file, '-' for stdin, or inline JSON), or run in an interactive terminal")
+	}
+	return runInteractiveSetup(ctx, client)
+}
+
+// idpRequestTimeout bounds a single admin-API request. It is applied per call so
+// that time spent in the interactive forms never counts against a request's
+// deadline.
+const idpRequestTimeout = 30 * time.Second
+
+// withRequestTimeout derives a per-request context from the command context.
+func withRequestTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, idpRequestTimeout)
+}
+
+// runConfigFileSetup handles the non-interactive --config path: load the full
+// configuration from JSON and create it (or update it wholesale with --update).
+func runConfigFileSetup(ctx context.Context, client *auth.IdpConfigClient) error {
+	reqCfg, err := loadIdpConfigFromJSON(setupConfigInput)
+	if err != nil {
+		return err
+	}
+
+	// ema_enabled is not supported by the backend yet; always send false.
+	reqCfg.EMAEnabled = false
+
+	if err := validateIdpConfig(reqCfg); err != nil {
+		return err
+	}
+
+	// Review + confirm (unless --yes). The client secret is masked.
+	printIdpConfigSummary(reqCfg)
+	if !setupYes {
+		confirmed, cerr := confirmSetup(setupUpdate)
+		if cerr != nil {
+			return cerr
+		}
+		if !confirmed {
+			fmt.Fprintln(os.Stderr, "  Cancelled — nothing was sent.")
+			return nil
+		}
+	}
+
+	if setupUpdate {
+		return sendUpdate(ctx, client, reqCfg)
+	}
+	return sendCreate(ctx, client, reqCfg)
+}
+
+// runInteractiveSetup guides an admin through setup. It first resolves the tenant
+// and fetches any existing configuration: if one exists, it shows a pre-filled
+// form where every field is optional (blank means "keep") and sends only the
+// changed fields — so an admin can, say, tweak a group mapping without re-entering
+// the client secret. Otherwise it collects a full configuration and creates it.
+func runInteractiveSetup(ctx context.Context, client *auth.IdpConfigClient) error {
+	tenant, err := promptSetupTenantID(strings.TrimSpace(tenantID))
+	if err != nil {
+		return err
+	}
+	if tenant == "" {
+		return fmt.Errorf("tenant ID is required")
+	}
+
+	existing, err := fetchExistingConfig(ctx, client, tenant)
+	if err != nil {
+		return err
+	}
+
+	if existing != nil {
+		return runInteractiveUpdate(ctx, client, existing)
+	}
+	return runInteractiveCreate(ctx, client, tenant)
+}
+
+// runInteractiveCreate collects a full configuration for a tenant that has none
+// yet and creates it.
+func runInteractiveCreate(ctx context.Context, client *auth.IdpConfigClient, tenant string) error {
+	reqCfg, err := promptIdpConfig(tenant)
+	if err != nil {
+		return err
+	}
+	reqCfg.EMAEnabled = false
+
+	if err := validateIdpConfig(reqCfg); err != nil {
+		return err
+	}
+
+	printIdpConfigSummary(reqCfg)
+	if !setupYes {
+		confirmed, cerr := confirmSetup(false)
+		if cerr != nil {
+			return cerr
+		}
+		if !confirmed {
+			fmt.Fprintln(os.Stderr, "  Cancelled — nothing was sent.")
+			return nil
+		}
+	}
+	return sendCreate(ctx, client, reqCfg)
+}
+
+// runInteractiveUpdate shows a form pre-filled from the existing configuration and
+// PUTs only the fields the admin changed, relying on the backend to merge them.
+func runInteractiveUpdate(ctx context.Context, client *auth.IdpConfigClient, existing *auth.IdpConfigResponse) error {
+	fmt.Fprintf(os.Stderr, "%s Found an existing IdP configuration for tenant %q — editing it.\n",
+		output.IconPointer, existing.TenantID)
+	fmt.Fprintln(os.Stderr, "  Leave a field unchanged to keep its current value; only edits are sent.")
+
+	upd, changed, err := promptIdpConfigUpdate(existing)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		fmt.Fprintln(os.Stderr, "  No changes — nothing to update.")
+		return nil
+	}
+
+	printIdpConfigUpdateSummary(existing, upd)
+	if !setupYes {
+		confirmed, cerr := confirmSetup(true)
+		if cerr != nil {
+			return cerr
+		}
+		if !confirmed {
+			fmt.Fprintln(os.Stderr, "  Cancelled — the existing configuration was left unchanged.")
+			return nil
+		}
+	}
+
+	reqCtx, cancel := withRequestTimeout(ctx)
+	defer cancel()
+	if _, err := client.Update(reqCtx, existing.TenantID, upd); err != nil {
+		return describeIdpConfigError(err)
+	}
+	fmt.Fprintf(os.Stderr, "%s IdP configuration updated for tenant %q.\n", output.IconSuccess, existing.TenantID)
+	printPostSetupHint(existing.TenantID)
+	return nil
+}
+
+// fetchExistingConfig returns the tenant's current configuration, or nil if none
+// exists yet (404). Other failures (401/403/transport) are returned as actionable
+// errors so we don't fall through to a create form after, say, an auth failure.
+func fetchExistingConfig(ctx context.Context, client *auth.IdpConfigClient, tenant string) (*auth.IdpConfigResponse, error) {
+	reqCtx, cancel := withRequestTimeout(ctx)
+	defer cancel()
+	cfg, err := client.Get(reqCtx, tenant)
+	if err == nil {
+		return cfg, nil
+	}
+	var ce *auth.IdpConfigError
+	if errors.As(err, &ce) && ce.StatusCode == http.StatusNotFound {
+		return nil, nil // not configured yet — proceed to create
+	}
+	return nil, describeIdpConfigError(err)
+}
+
+// sendCreate POSTs a new configuration. On 409 it offers to switch to the update
+// (PUT) path, automatically when --yes is set and interactively otherwise.
+func sendCreate(ctx context.Context, client *auth.IdpConfigClient, reqCfg *auth.IdpConfigCreateRequest) error {
+	reqCtx, cancel := withRequestTimeout(ctx)
+	defer cancel()
+	_, err := client.Create(reqCtx, reqCfg)
+	if err == nil {
+		fmt.Fprintf(os.Stderr, "%s IdP configuration created for tenant %q.\n", output.IconSuccess, reqCfg.TenantID)
+		printPostSetupHint(reqCfg.TenantID)
+		return nil
+	}
+
+	// On conflict, offer to switch to the update path. In an interactive terminal
+	// (and when not already skipping prompts with --yes) we ask; otherwise we
+	// stop and point the user at --update, so a scripted create never silently
+	// overwrites an existing configuration.
+	var ce *auth.IdpConfigError
+	if errors.As(err, &ce) && ce.StatusCode == http.StatusConflict {
+		if !setupYes && cli.IsInteractive() {
+			ok, cerr := confirmUpdateExisting(reqCfg.TenantID)
+			if cerr != nil {
+				return cerr
+			}
+			if ok {
+				return sendUpdate(ctx, client, reqCfg)
+			}
+			fmt.Fprintln(os.Stderr, "  Cancelled — the existing configuration was left unchanged.")
+			return nil
+		}
+		return fmt.Errorf("an IdP configuration already exists for tenant %q; re-run with --update to replace it", reqCfg.TenantID)
+	}
+
+	return describeIdpConfigError(err)
+}
+
+// sendUpdate PUTs the configuration for the tenant. Every field is sent, so an
+// update fully replaces the stored values (and rotates the secret).
+func sendUpdate(ctx context.Context, client *auth.IdpConfigClient, reqCfg *auth.IdpConfigCreateRequest) error {
+	upd := &auth.IdpConfigUpdateRequest{
+		IdpType:          setupStrPtr(reqCfg.IdpType),
+		Issuer:           setupStrPtr(reqCfg.Issuer),
+		OIDCClientID:     setupStrPtr(reqCfg.OIDCClientID),
+		OIDCClientSecret: setupStrPtr(reqCfg.OIDCClientSecret),
+		GroupClaim:       setupStrPtr(reqCfg.GroupClaim),
+		GroupMapping:     reqCfg.GroupMapping,
+		EMAEnabled:       setupBoolPtr(false),
+		Enabled:          setupBoolPtr(reqCfg.Enabled),
+	}
+	reqCtx, cancel := withRequestTimeout(ctx)
+	defer cancel()
+	if _, err := client.Update(reqCtx, reqCfg.TenantID, upd); err != nil {
+		return describeIdpConfigError(err)
+	}
+	fmt.Fprintf(os.Stderr, "%s IdP configuration updated for tenant %q.\n", output.IconSuccess, reqCfg.TenantID)
+	printPostSetupHint(reqCfg.TenantID)
+	return nil
+}
+
+// describeIdpConfigError turns an *IdpConfigError into an actionable message for
+// the common statuses (401/404/422); other errors pass through.
+func describeIdpConfigError(err error) error {
+	var ce *auth.IdpConfigError
+	if !errors.As(err, &ce) {
+		return err
+	}
+	switch ce.StatusCode {
+	case http.StatusUnauthorized:
+		return fmt.Errorf("not authorized (401): %s\n  Check your Armis credentials — an admin API token is required to register an IdP configuration", detailOr(ce, "authentication failed"))
+	case http.StatusForbidden:
+		return fmt.Errorf("forbidden (403): %s\n  Your credentials may be scoped to a different tenant", detailOr(ce, "access denied"))
+	case http.StatusNotFound:
+		return fmt.Errorf("no existing configuration to update (404): %s\n  Run 'armis-cli auth setup' without --update to create it first", detailOr(ce, "not found"))
+	case http.StatusUnprocessableEntity:
+		return fmt.Errorf("the configuration was rejected (422): %s", detailOr(ce, "validation failed"))
+	default:
+		return err
+	}
+}
+
+func detailOr(ce *auth.IdpConfigError, fallback string) string {
+	if ce.Detail != "" {
+		return ce.Detail
+	}
+	return fallback
+}
+
+// printPostSetupHint points the admin at the next step once a config exists.
+func printPostSetupHint(tenantID string) {
+	fmt.Fprintf(os.Stderr, "  Users can now sign in with: armis-cli auth login --tenant-id %s\n", tenantID)
+}
+
+// -- Interactive prompting ---------------------------------------------------
+
+// promptSetupTenantID resolves the tenant to configure. When a value is already
+// known (from --tenant-id / ARMIS_TENANT_ID) it is used as-is; otherwise the admin
+// is asked. The tenant is resolved before anything else so we can pre-flight an
+// existence check and branch between the create and update forms.
+func promptSetupTenantID(known string) (string, error) {
+	if known != "" {
+		return known, nil
+	}
+	tenant := ""
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Title("Armis tenant ID").
+				Description("Your Armis tenant identifier (also set via --tenant-id / ARMIS_TENANT_ID).").
+				Value(&tenant),
+		),
+	).WithTheme(cmdutil.GetInstallTheme()).WithAccessible(!cli.ColorsEnabled())
+	if err := form.Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return "", fmt.Errorf("setup cancelled")
+		}
+		return "", err
+	}
+	return strings.TrimSpace(tenant), nil
+}
+
+// promptIdpConfig walks the admin through every configuration value, explaining
+// where each comes from. Groups are collected per-role (admin, developer) so the
+// admin maps IdP groups to known Armis roles rather than typing role names. Each
+// role accepts a comma-separated list, so several groups can grant the same role.
+// The tenant is resolved by the caller and shown for confirmation.
+func promptIdpConfig(tenant string) (*auth.IdpConfigCreateRequest, error) {
+	theme := cmdutil.GetInstallTheme()
+	accessible := !cli.ColorsEnabled()
+
+	cfg := &auth.IdpConfigCreateRequest{
+		TenantID:   tenant,
+		GroupClaim: "groups",
+		Enabled:    true,
+	}
+	var adminGroups, developerGroups string
+
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Title("IdP type").
+				Description("Your identity provider, e.g. okta, entra, keycloak.").
+				Value(&cfg.IdpType),
+			huh.NewInput().
+				Title("Issuer URL").
+				Description("The IdP's OIDC issuer (from its discovery document), e.g. https://acme.okta.com.").
+				Value(&cfg.Issuer),
+		),
+		huh.NewGroup(
+			huh.NewInput().
+				Title("OIDC client ID").
+				Description("The client ID from the armis-cli app you registered in your IdP.").
+				Value(&cfg.OIDCClientID),
+			huh.NewInput().
+				Title("OIDC client secret").
+				Description("The client secret for that app. Sent once to register — never stored or printed.").
+				EchoMode(huh.EchoModePassword).
+				Value(&cfg.OIDCClientSecret),
+			huh.NewInput().
+				Title("Group claim").
+				Description("The ID-token claim carrying the user's groups (default: groups).").
+				Value(&cfg.GroupClaim),
+		),
+		huh.NewGroup(
+			huh.NewNote().
+				Title("Map IdP groups to Armis roles").
+				Description("Enter the IdP group names that grant each role, comma-separated.\nList several groups for a role if more than one should have it.\nLeave a role blank to skip it — at least one is required."),
+			huh.NewInput().
+				Title("IdP groups for the 'admin' role").
+				Description("Comma-separated. Users in any of these groups become Armis admins.").
+				Value(&adminGroups),
+			huh.NewInput().
+				Title("IdP groups for the 'developer' role").
+				Description("Comma-separated, e.g. core-developers, contract-developers.").
+				Value(&developerGroups),
+		),
+	).WithTheme(theme).WithAccessible(accessible)
+
+	if err := form.Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return nil, fmt.Errorf("setup cancelled")
+		}
+		return nil, err
+	}
+
+	if cfg.GroupClaim == "" {
+		cfg.GroupClaim = "groups"
+	}
+
+	byRole := map[string][]string{}
+	if g := splitGroups(adminGroups); len(g) > 0 {
+		byRole[roleAdmin] = g
+	}
+	if g := splitGroups(developerGroups); len(g) > 0 {
+		byRole[roleDeveloper] = g
+	}
+	mapping, err := assembleGroupMapping(byRole)
+	if err != nil {
+		return nil, err
+	}
+	cfg.GroupMapping = mapping
+
+	return cfg, nil
+}
+
+// splitGroups parses a comma-separated group list, trimming blanks.
+func splitGroups(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// assembleGroupMapping flattens the role→groups input the CLI collects into the
+// group→role map the backend stores. It validates every role and rejects a group
+// listed under two different roles (a group can grant only one Armis role).
+func assembleGroupMapping(byRole map[string][]string) (map[string]string, error) {
+	out := map[string]string{}
+	for role, groups := range byRole {
+		if role != roleAdmin && role != roleDeveloper {
+			return nil, fmt.Errorf("group_mapping has unrecognized role %q; use %q or %q", role, roleAdmin, roleDeveloper)
+		}
+		for _, g := range groups {
+			g = strings.TrimSpace(g)
+			if g == "" {
+				continue
+			}
+			if existing, ok := out[g]; ok && existing != role {
+				return nil, fmt.Errorf("group %q is mapped to both %q and %q; a group can grant only one role", g, existing, role)
+			}
+			out[g] = role
+		}
+	}
+	return out, nil
+}
+
+// promptIdpConfigUpdate shows an edit form pre-filled from the existing config and
+// returns an update request carrying only the fields the admin changed, plus a
+// flag indicating whether anything changed. The secret starts blank (the API never
+// returns it) and is sent only if the admin types a new one — so a group-mapping
+// tweak needs no secret. Group mappings are edited per role as comma-separated
+// lists, pre-filled from the current mapping.
+func promptIdpConfigUpdate(existing *auth.IdpConfigResponse) (*auth.IdpConfigUpdateRequest, bool, error) {
+	theme := cmdutil.GetInstallTheme()
+	accessible := !cli.ColorsEnabled()
+
+	byRole := groupsByRole(existing.GroupMapping)
+	idpType := existing.IdpType
+	issuer := existing.Issuer
+	clientID := existing.OIDCClientID
+	groupClaim := existing.GroupClaim
+	adminGroups := strings.Join(byRole[roleAdmin], ", ")
+	developerGroups := strings.Join(byRole[roleDeveloper], ", ")
+	enabled := existing.Enabled
+	var newSecret string
+
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Title("IdP type").
+				Description("Your identity provider, e.g. okta, entra, keycloak.").
+				Value(&idpType),
+			huh.NewInput().
+				Title("Issuer URL").
+				Description("The IdP's OIDC issuer (from its discovery document).").
+				Value(&issuer),
+		),
+		huh.NewGroup(
+			huh.NewInput().
+				Title("OIDC client ID").
+				Description("The client ID from the armis-cli app you registered in your IdP.").
+				Value(&clientID),
+			huh.NewInput().
+				Title("New OIDC client secret").
+				Description("Leave blank to keep the current secret. Type a value only to rotate it.").
+				EchoMode(huh.EchoModePassword).
+				Value(&newSecret),
+			huh.NewInput().
+				Title("Group claim").
+				Description("The ID-token claim carrying the user's groups.").
+				Value(&groupClaim),
+		),
+		huh.NewGroup(
+			huh.NewNote().
+				Title("Map IdP groups to Armis roles").
+				Description("Comma-separated IdP group names per role. Edit to change the mapping;\nclear a role to remove all its groups. The mapping is replaced as edited."),
+			huh.NewInput().
+				Title("IdP groups for the 'admin' role").
+				Value(&adminGroups),
+			huh.NewInput().
+				Title("IdP groups for the 'developer' role").
+				Value(&developerGroups),
+			huh.NewConfirm().
+				Title("Enabled?").
+				Description("Whether SSO login is active for this tenant.").
+				Value(&enabled),
+		),
+	).WithTheme(theme).WithAccessible(accessible)
+
+	if err := form.Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return nil, false, fmt.Errorf("setup cancelled")
+		}
+		return nil, false, err
+	}
+
+	upd := &auth.IdpConfigUpdateRequest{}
+	changed := false
+
+	if v := strings.TrimSpace(idpType); v != existing.IdpType {
+		upd.IdpType = setupStrPtr(v)
+		changed = true
+	}
+	if v := strings.TrimSpace(issuer); v != existing.Issuer {
+		upd.Issuer = setupStrPtr(v)
+		changed = true
+	}
+	if v := strings.TrimSpace(clientID); v != existing.OIDCClientID {
+		upd.OIDCClientID = setupStrPtr(v)
+		changed = true
+	}
+	if v := strings.TrimSpace(groupClaim); v != existing.GroupClaim {
+		upd.GroupClaim = setupStrPtr(v)
+		changed = true
+	}
+	// Only rotate the secret when the admin actually typed one.
+	if newSecret != "" {
+		upd.OIDCClientSecret = setupStrPtr(newSecret)
+		changed = true
+	}
+	if enabled != existing.Enabled {
+		upd.Enabled = setupBoolPtr(enabled)
+		changed = true
+	}
+
+	// Re-derive the mapping from the (possibly edited) per-role lists and send it
+	// only when it differs from the stored one.
+	newByRole := map[string][]string{}
+	if g := splitGroups(adminGroups); len(g) > 0 {
+		newByRole[roleAdmin] = g
+	}
+	if g := splitGroups(developerGroups); len(g) > 0 {
+		newByRole[roleDeveloper] = g
+	}
+	mapping, err := assembleGroupMapping(newByRole)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(mapping) == 0 {
+		return nil, false, fmt.Errorf("at least one group→role mapping is required (map an IdP group to %q or %q)", roleAdmin, roleDeveloper)
+	}
+	if !sameMapping(mapping, existing.GroupMapping) {
+		upd.GroupMapping = mapping
+		changed = true
+	}
+
+	return upd, changed, nil
+}
+
+// sameMapping reports whether two group→role maps are identical.
+func sameMapping(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// printIdpConfigUpdateSummary renders only the fields that will change, so the
+// admin sees exactly what the merge update sends. The secret is shown as rotated
+// (never printed) when present.
+func printIdpConfigUpdateSummary(existing *auth.IdpConfigResponse, upd *auth.IdpConfigUpdateRequest) {
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintf(os.Stderr, "  Changes to send for tenant %q:\n", existing.TenantID)
+	if upd.IdpType != nil {
+		fmt.Fprintf(os.Stderr, "    IdP type:         %s → %s\n", existing.IdpType, *upd.IdpType)
+	}
+	if upd.Issuer != nil {
+		fmt.Fprintf(os.Stderr, "    Issuer:           %s → %s\n", existing.Issuer, *upd.Issuer)
+	}
+	if upd.OIDCClientID != nil {
+		fmt.Fprintf(os.Stderr, "    OIDC client ID:   %s → %s\n", existing.OIDCClientID, *upd.OIDCClientID)
+	}
+	if upd.OIDCClientSecret != nil {
+		fmt.Fprintln(os.Stderr, "    OIDC secret:      (rotated)")
+	}
+	if upd.GroupClaim != nil {
+		fmt.Fprintf(os.Stderr, "    Group claim:      %s → %s\n", existing.GroupClaim, *upd.GroupClaim)
+	}
+	if upd.Enabled != nil {
+		fmt.Fprintf(os.Stderr, "    Enabled:          %t → %t\n", existing.Enabled, *upd.Enabled)
+	}
+	if upd.GroupMapping != nil {
+		fmt.Fprintln(os.Stderr, "    Role → IdP groups:")
+		byRole := groupsByRole(upd.GroupMapping)
+		for _, role := range []string{roleAdmin, roleDeveloper} {
+			if groups := byRole[role]; len(groups) > 0 {
+				fmt.Fprintf(os.Stderr, "      %s: %s\n", role, strings.Join(groups, ", "))
+			}
+		}
+	}
+	fmt.Fprintln(os.Stderr, "")
+}
+
+// confirmSetup shows a yes/no confirmation before sending.
+func confirmSetup(update bool) (bool, error) {
+	action := "Create this IdP configuration?"
+	if update {
+		action = "Update this IdP configuration?"
+	}
+	confirmed := true
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title(action).
+				Affirmative("Yes, send it").
+				Negative("No, cancel").
+				Value(&confirmed),
+		),
+	).WithTheme(cmdutil.GetInstallTheme()).WithAccessible(!cli.ColorsEnabled())
+	if err := form.Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return false, nil
+		}
+		return false, err
+	}
+	return confirmed, nil
+}
+
+// confirmUpdateExisting asks whether to replace an existing config after a 409.
+func confirmUpdateExisting(tenantID string) (bool, error) {
+	update := true
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title(fmt.Sprintf("A configuration already exists for tenant %q. Replace it?", tenantID)).
+				Affirmative("Yes, update it").
+				Negative("No, cancel").
+				Value(&update),
+		),
+	).WithTheme(cmdutil.GetInstallTheme()).WithAccessible(!cli.ColorsEnabled())
+	if err := form.Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return false, nil
+		}
+		return false, err
+	}
+	return update, nil
+}
+
+// -- JSON input --------------------------------------------------------------
+
+// idpConfigInput is the JSON shape accepted by --config. It mirrors the backend
+// request except group_mapping, which is role→[groups] here (an admin thinks
+// "which groups get the developer role?"), and is flattened to the backend's
+// group→role map before sending.
+type idpConfigInput struct {
+	TenantID         string              `json:"tenant_id"`
+	IdpType          string              `json:"idp_type"`
+	Issuer           string              `json:"issuer"`
+	OIDCClientID     string              `json:"oidc_client_id"`
+	OIDCClientSecret string              `json:"oidc_client_secret"` //nolint:gosec // G117: JSON field name, not a secret value
+	GroupClaim       string              `json:"group_claim"`
+	GroupMapping     map[string][]string `json:"group_mapping"`
+	Enabled          *bool               `json:"enabled"`
+}
+
+// loadIdpConfigFromJSON resolves --config (inline JSON, stdin, or a file path)
+// and decodes it. Unknown fields are rejected so typos surface immediately.
+func loadIdpConfigFromJSON(input string) (*auth.IdpConfigCreateRequest, error) {
+	var raw []byte
+	var err error
+
+	switch {
+	case input == "-":
+		raw, err = io.ReadAll(os.Stdin)
+	case strings.HasPrefix(strings.TrimSpace(input), "{"):
+		raw = []byte(input)
+	default:
+		raw, err = os.ReadFile(input) // #nosec G304 -- operator-supplied config path, read intentionally
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config: %w", err)
+	}
+
+	in := &idpConfigInput{}
+	dec := json.NewDecoder(strings.NewReader(string(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(in); err != nil {
+		return nil, fmt.Errorf("invalid config JSON: %w", err)
+	}
+
+	mapping, err := assembleGroupMapping(in.GroupMapping)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &auth.IdpConfigCreateRequest{
+		TenantID:         in.TenantID,
+		IdpType:          in.IdpType,
+		Issuer:           in.Issuer,
+		OIDCClientID:     in.OIDCClientID,
+		OIDCClientSecret: in.OIDCClientSecret,
+		GroupClaim:       in.GroupClaim,
+		GroupMapping:     mapping,
+		// Default enabled to true when omitted, matching the interactive path
+		// and the backend model.
+		Enabled: in.Enabled == nil || *in.Enabled,
+	}
+	if cfg.GroupClaim == "" {
+		cfg.GroupClaim = "groups"
+	}
+	return cfg, nil
+}
+
+// -- Validation & summary ----------------------------------------------------
+
+// validateIdpConfig checks the required fields and that every group_mapping
+// value is a recognized Armis role.
+func validateIdpConfig(cfg *auth.IdpConfigCreateRequest) error {
+	var missing []string
+	if strings.TrimSpace(cfg.TenantID) == "" {
+		missing = append(missing, "tenant_id")
+	}
+	if strings.TrimSpace(cfg.IdpType) == "" {
+		missing = append(missing, "idp_type")
+	}
+	if strings.TrimSpace(cfg.Issuer) == "" {
+		missing = append(missing, "issuer")
+	}
+	if strings.TrimSpace(cfg.OIDCClientID) == "" {
+		missing = append(missing, "oidc_client_id")
+	}
+	if strings.TrimSpace(cfg.OIDCClientSecret) == "" {
+		missing = append(missing, "oidc_client_secret")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required field(s): %s", strings.Join(missing, ", "))
+	}
+
+	if len(cfg.GroupMapping) == 0 {
+		return fmt.Errorf("at least one group→role mapping is required (map an IdP group to %q or %q)", roleAdmin, roleDeveloper)
+	}
+	for group, role := range cfg.GroupMapping {
+		if strings.TrimSpace(group) == "" {
+			return fmt.Errorf("group_mapping has an empty group name")
+		}
+		if role != roleAdmin && role != roleDeveloper {
+			return fmt.Errorf("group_mapping[%q] = %q is not a recognized role; use %q or %q", group, role, roleAdmin, roleDeveloper)
+		}
+	}
+	return nil
+}
+
+// printIdpConfigSummary renders the configuration for review, masking the secret.
+func printIdpConfigSummary(cfg *auth.IdpConfigCreateRequest) {
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "  Review IdP configuration:")
+	fmt.Fprintf(os.Stderr, "    Tenant ID:        %s\n", cfg.TenantID)
+	fmt.Fprintf(os.Stderr, "    IdP type:         %s\n", cfg.IdpType)
+	fmt.Fprintf(os.Stderr, "    Issuer:           %s\n", cfg.Issuer)
+	fmt.Fprintf(os.Stderr, "    OIDC client ID:   %s\n", cfg.OIDCClientID)
+	fmt.Fprintf(os.Stderr, "    OIDC secret:      %s\n", maskSecret(cfg.OIDCClientSecret))
+	fmt.Fprintf(os.Stderr, "    Group claim:      %s\n", cfg.GroupClaim)
+	fmt.Fprintf(os.Stderr, "    Enabled:          %t\n", cfg.Enabled)
+	fmt.Fprintln(os.Stderr, "    Role → IdP groups:")
+	byRole := groupsByRole(cfg.GroupMapping)
+	for _, role := range []string{roleAdmin, roleDeveloper} {
+		if groups := byRole[role]; len(groups) > 0 {
+			fmt.Fprintf(os.Stderr, "      %s: %s\n", role, strings.Join(groups, ", "))
+		}
+	}
+	fmt.Fprintln(os.Stderr, "")
+}
+
+// groupsByRole inverts the backend's group→role map into role→[groups] for
+// display, with each role's groups sorted for stable output.
+func groupsByRole(mapping map[string]string) map[string][]string {
+	out := map[string][]string{}
+	for group, role := range mapping {
+		out[role] = append(out[role], group)
+	}
+	for role := range out {
+		sort.Strings(out[role])
+	}
+	return out
+}
+
+// maskSecret returns a fixed-width mask that reveals only the secret's length
+// category, never its content.
+func maskSecret(s string) string {
+	if s == "" {
+		return "(none)"
+	}
+	return fmt.Sprintf("•••••••• (%d chars)", len(s))
+}
+
+func setupStrPtr(s string) *string { return &s }
+func setupBoolPtr(b bool) *bool     { return &b }

--- a/internal/cmd/auth_setup.go
+++ b/internal/cmd/auth_setup.go
@@ -30,6 +30,10 @@ const (
 	// maxConfigBytes bounds a --config document read from stdin. A configuration
 	// is only a few hundred bytes; the cap guards against an unbounded pipe.
 	maxConfigBytes = 2 << 10 // 2 KiB
+
+	// defaultGroupClaim is the ID-token claim carrying the user's groups, used
+	// when the admin does not specify one.
+	defaultGroupClaim = "groups"
 )
 
 var (
@@ -394,7 +398,7 @@ func promptIdpConfig(tenant string) (*auth.IdpConfigCreateRequest, error) {
 
 	cfg := &auth.IdpConfigCreateRequest{
 		TenantID:   tenant,
-		GroupClaim: "groups",
+		GroupClaim: defaultGroupClaim,
 		Enabled:    true,
 	}
 	var adminGroups, developerGroups string
@@ -448,7 +452,7 @@ func promptIdpConfig(tenant string) (*auth.IdpConfigCreateRequest, error) {
 	}
 
 	if cfg.GroupClaim == "" {
-		cfg.GroupClaim = "groups"
+		cfg.GroupClaim = defaultGroupClaim
 	}
 
 	byRole := map[string][]string{}
@@ -793,7 +797,7 @@ func loadIdpConfigFromJSON(input string) (*auth.IdpConfigCreateRequest, error) {
 		Enabled: in.Enabled == nil || *in.Enabled,
 	}
 	if cfg.GroupClaim == "" {
-		cfg.GroupClaim = "groups"
+		cfg.GroupClaim = defaultGroupClaim
 	}
 	return cfg, nil
 }

--- a/internal/cmd/auth_setup.go
+++ b/internal/cmd/auth_setup.go
@@ -881,4 +881,4 @@ func maskSecret(s string) string {
 }
 
 func setupStrPtr(s string) *string { return &s }
-func setupBoolPtr(b bool) *bool     { return &b }
+func setupBoolPtr(b bool) *bool    { return &b }

--- a/internal/cmd/auth_setup_test.go
+++ b/internal/cmd/auth_setup_test.go
@@ -1,0 +1,316 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// setupSetupTest isolates global state used by `auth setup` and points the CLI
+// at the mock server via a legacy API token (Basic auth), so getAuthProvider
+// resolves without a stored session.
+func setupSetupTest(t *testing.T, serverURL string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+
+	orig := struct {
+		clientID, clientSecret, token, tenantID, cfg string
+		update, yes                                  bool
+	}{clientID, clientSecret, token, tenantID, setupConfigInput, setupUpdate, setupYes}
+	t.Cleanup(func() {
+		clientID, clientSecret, token, tenantID = orig.clientID, orig.clientSecret, orig.token, orig.tenantID
+		setupConfigInput, setupUpdate, setupYes = orig.cfg, orig.update, orig.yes
+		credFlagsExplicit = false
+	})
+
+	clientID, clientSecret = "", ""
+	token = "admin-token" // Basic auth path
+	tenantID = "acme"      // Basic auth requires a tenant for AuthProvider construction
+	credFlagsExplicit = true // force the token path (skip stored-session lookup)
+	setupConfigInput, setupUpdate, setupYes = "", false, false
+
+	t.Setenv("ARMIS_API_URL", serverURL)
+}
+
+func validConfigJSON(tenant string) string {
+	b, _ := json.Marshal(map[string]any{
+		"tenant_id":          tenant,
+		"idp_type":           "okta",
+		"issuer":             "https://acme.okta.com",
+		"oidc_client_id":     "client-abc",
+		"oidc_client_secret": "s3cr3t",
+		"group_claim":        "groups",
+		// role → [groups]; several groups may grant the same role.
+		"group_mapping": map[string][]string{
+			"admin":     {"eng-admins"},
+			"developer": {"core-developers", "contract-developers"},
+		},
+	})
+	return string(b)
+}
+
+func TestAuthSetupCreateSuccess(t *testing.T) {
+	var gotMethod, gotAuth string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tenant_id": "acme", "idp_type": "okta", "issuer": "https://acme.okta.com",
+			"oidc_client_id": "client-abc", "group_claim": "groups",
+			"group_mapping": map[string]string{}, "ema_enabled": false, "enabled": true,
+			"created_at": "t", "updated_at": "t",
+		})
+	}))
+	defer srv.Close()
+
+	setupSetupTest(t, srv.URL)
+	setupConfigInput = validConfigJSON("acme")
+	setupYes = true
+
+	if err := runAuthSetup(newCmdWithCtx(), nil); err != nil {
+		t.Fatalf("runAuthSetup: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotAuth != "Basic admin-token" {
+		t.Errorf("Authorization = %q, want Basic admin-token", gotAuth)
+	}
+	if gotBody["ema_enabled"] != false {
+		t.Errorf("ema_enabled = %v, want false", gotBody["ema_enabled"])
+	}
+	// The role→[groups] input is flattened to the backend's group→role map;
+	// several groups can share a role.
+	gm, _ := gotBody["group_mapping"].(map[string]any)
+	if gm["eng-admins"] != "admin" ||
+		gm["core-developers"] != "developer" ||
+		gm["contract-developers"] != "developer" {
+		t.Errorf("group_mapping = %v", gm)
+	}
+}
+
+// A scripted create (--yes, non-interactive) that hits a 409 must NOT silently
+// overwrite the existing config: it should only POST, then error, pointing the
+// user at --update.
+func TestAuthSetupConflictWithYesDoesNotOverwrite(t *testing.T) {
+	var mu sync.Mutex
+	var methods []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		methods = append(methods, r.Method)
+		mu.Unlock()
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]string{"detail": "already exists"})
+	}))
+	defer srv.Close()
+
+	setupSetupTest(t, srv.URL)
+	setupConfigInput = validConfigJSON("acme")
+	setupYes = true // non-interactive: 409 must error, not fall through to PUT
+
+	err := runAuthSetup(newCmdWithCtx(), nil)
+	if err == nil || !strings.Contains(err.Error(), "--update") {
+		t.Fatalf("expected --update error, got %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(methods) != 1 || methods[0] != http.MethodPost {
+		t.Errorf("expected a single POST (no PUT), got %v", methods)
+	}
+}
+
+func TestAuthSetupUpdateFlagUsesPut(t *testing.T) {
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tenant_id": "acme", "idp_type": "okta", "issuer": "https://acme.okta.com",
+			"oidc_client_id": "client-abc", "group_claim": "groups",
+			"group_mapping": map[string]string{}, "ema_enabled": false, "enabled": true,
+			"created_at": "t", "updated_at": "t",
+		})
+	}))
+	defer srv.Close()
+
+	setupSetupTest(t, srv.URL)
+	setupConfigInput = validConfigJSON("acme")
+	setupUpdate = true
+	setupYes = true
+
+	if err := runAuthSetup(newCmdWithCtx(), nil); err != nil {
+		t.Fatalf("runAuthSetup: %v", err)
+	}
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	if gotPath != "/api/v1/oauth2/idp-configs/acme" {
+		t.Errorf("path = %q", gotPath)
+	}
+}
+
+func TestAuthSetupConflictWithoutUpdateErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]string{"detail": "already exists"})
+	}))
+	defer srv.Close()
+
+	setupSetupTest(t, srv.URL)
+	setupConfigInput = validConfigJSON("acme")
+	setupYes = true // no --update, non-interactive → should error, not silently PUT
+
+	err := runAuthSetup(newCmdWithCtx(), nil)
+	if err == nil {
+		t.Fatal("expected error on conflict without --update")
+	}
+	if !strings.Contains(err.Error(), "--update") {
+		t.Errorf("error %q should suggest --update", err.Error())
+	}
+}
+
+func TestAuthSetupValidationErrorSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"detail": []map[string]any{
+				{"loc": []any{"body", "issuer"}, "msg": "field required"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	setupSetupTest(t, srv.URL)
+	setupConfigInput = validConfigJSON("acme")
+	setupYes = true
+
+	err := runAuthSetup(newCmdWithCtx(), nil)
+	if err == nil {
+		t.Fatal("expected 422 error")
+	}
+	if !strings.Contains(err.Error(), "issuer: field required") {
+		t.Errorf("error %q should carry the server detail", err.Error())
+	}
+}
+
+func TestAuthSetupRejectsUnknownRole(t *testing.T) {
+	setupSetupTest(t, "https://moose.armis.com")
+	setupConfigInput = `{"tenant_id":"acme","idp_type":"okta","issuer":"https://acme.okta.com","oidc_client_id":"c","oidc_client_secret":"s","group_mapping":{"superuser":["eng"]}}`
+	setupYes = true
+
+	err := runAuthSetup(newCmdWithCtx(), nil)
+	if err == nil {
+		t.Fatal("expected error for unrecognized role")
+	}
+	if !strings.Contains(err.Error(), "unrecognized role") {
+		t.Errorf("error %q should reject the bad role", err.Error())
+	}
+}
+
+// A group listed under two roles is ambiguous and must be rejected.
+func TestAuthSetupRejectsGroupInTwoRoles(t *testing.T) {
+	setupSetupTest(t, "https://moose.armis.com")
+	setupConfigInput = `{"tenant_id":"acme","idp_type":"okta","issuer":"https://acme.okta.com","oidc_client_id":"c","oidc_client_secret":"s","group_mapping":{"admin":["eng"],"developer":["eng"]}}`
+	setupYes = true
+
+	err := runAuthSetup(newCmdWithCtx(), nil)
+	if err == nil || !strings.Contains(err.Error(), "only one role") {
+		t.Fatalf("expected single-role conflict error, got %v", err)
+	}
+}
+
+func TestAuthSetupRequiresMappings(t *testing.T) {
+	setupSetupTest(t, "https://moose.armis.com")
+	setupConfigInput = `{"tenant_id":"acme","idp_type":"okta","issuer":"https://acme.okta.com","oidc_client_id":"c","oidc_client_secret":"s","group_mapping":{}}`
+	setupYes = true
+
+	err := runAuthSetup(newCmdWithCtx(), nil)
+	if err == nil || !strings.Contains(err.Error(), "at least one group") {
+		t.Fatalf("expected 'at least one group' error, got %v", err)
+	}
+}
+
+func TestAuthSetupMissingRequiredField(t *testing.T) {
+	setupSetupTest(t, "https://moose.armis.com")
+	// Missing issuer and oidc_client_secret.
+	setupConfigInput = `{"tenant_id":"acme","idp_type":"okta","oidc_client_id":"c","group_mapping":{"admin":["eng"]}}`
+	setupYes = true
+
+	err := runAuthSetup(newCmdWithCtx(), nil)
+	if err == nil || !strings.Contains(err.Error(), "missing required field") {
+		t.Fatalf("expected missing-field error, got %v", err)
+	}
+}
+
+func TestAuthSetupRejectsUnknownJSONField(t *testing.T) {
+	setupSetupTest(t, "https://moose.armis.com")
+	setupConfigInput = `{"tenant_id":"acme","typpo":"x"}`
+	setupYes = true
+
+	err := runAuthSetup(newCmdWithCtx(), nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid config JSON") {
+		t.Fatalf("expected invalid-config error, got %v", err)
+	}
+}
+
+func TestSameMapping(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b map[string]string
+		want bool
+	}{
+		{"both empty", map[string]string{}, map[string]string{}, true},
+		{"identical", map[string]string{"eng": "developer", "ops": "admin"}, map[string]string{"ops": "admin", "eng": "developer"}, true},
+		{"different length", map[string]string{"eng": "developer"}, map[string]string{"eng": "developer", "ops": "admin"}, false},
+		{"different role", map[string]string{"eng": "developer"}, map[string]string{"eng": "admin"}, false},
+		{"different group", map[string]string{"eng": "developer"}, map[string]string{"dev": "developer"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sameMapping(tc.a, tc.b); got != tc.want {
+				t.Errorf("sameMapping = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAuthSetupConfigFromFile(t *testing.T) {
+	var gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tenant_id": "acme", "idp_type": "okta", "issuer": "https://acme.okta.com",
+			"oidc_client_id": "client-abc", "group_claim": "groups",
+			"group_mapping": map[string]string{}, "ema_enabled": false, "enabled": true,
+			"created_at": "t", "updated_at": "t",
+		})
+	}))
+	defer srv.Close()
+
+	setupSetupTest(t, srv.URL)
+	dir := t.TempDir()
+	path := dir + "/idp.json"
+	if err := os.WriteFile(path, []byte(validConfigJSON("acme")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	setupConfigInput = path
+	setupYes = true
+
+	if err := runAuthSetup(newCmdWithCtx(), nil); err != nil {
+		t.Fatalf("runAuthSetup: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+}

--- a/internal/cmd/auth_setup_test.go
+++ b/internal/cmd/auth_setup_test.go
@@ -284,6 +284,33 @@ func TestSameMapping(t *testing.T) {
 	}
 }
 
+func TestAuthSetupRejectsTrailingContent(t *testing.T) {
+	setupSetupTest(t, "https://moose.armis.com")
+	setupConfigInput = validConfigJSON("acme") + "garbage"
+	setupYes = true
+
+	err := runAuthSetup(newCmdWithCtx(), nil)
+	if err == nil || !strings.Contains(err.Error(), "trailing content") {
+		t.Fatalf("expected trailing-content error, got %v", err)
+	}
+}
+
+func TestAuthSetupRejectsOversizeConfig(t *testing.T) {
+	setupSetupTest(t, "https://moose.armis.com")
+	dir := t.TempDir()
+	path := dir + "/big.json"
+	if err := os.WriteFile(path, []byte(strings.Repeat("a", maxConfigBytes+1)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	setupConfigInput = path
+	setupYes = true
+
+	err := runAuthSetup(newCmdWithCtx(), nil)
+	if err == nil || !strings.Contains(err.Error(), "larger than") {
+		t.Fatalf("expected oversize error, got %v", err)
+	}
+}
+
 func TestAuthSetupConfigFromFile(t *testing.T) {
 	var gotMethod string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmd/auth_setup_test.go
+++ b/internal/cmd/auth_setup_test.go
@@ -29,8 +29,8 @@ func setupSetupTest(t *testing.T, serverURL string) {
 	})
 
 	clientID, clientSecret = "", ""
-	token = "admin-token" // Basic auth path
-	tenantID = "acme"      // Basic auth requires a tenant for AuthProvider construction
+	token = "admin-token"    // Basic auth path
+	tenantID = "acme"        // Basic auth requires a tenant for AuthProvider construction
 	credFlagsExplicit = true // force the token path (skip stored-session lookup)
 	setupConfigInput, setupUpdate, setupYes = "", false, false
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -445,8 +445,8 @@ func resolveDataPlaneURL(ctx context.Context, authProvider *auth.AuthProvider) s
 
 // getAuthProvider creates an AuthProvider based on the available credentials.
 //
-// Resolution order (PPSC-1037):
-//  1. Stored SSO token (keychain / fallback file) from `armis-cli auth login`,
+// Resolution order:
+//  1. Stored SSO token from `armis-cli auth login`,
 //     unless the user explicitly passed --client-id/--client-secret/--token,
 //     which act as an escape hatch to force the credential path.
 //  2. Client credentials (--client-id/--client-secret or ARMIS_CLIENT_ID/SECRET).


### PR DESCRIPTION
## Related Issue

* [PPSC-1087](https://armis-security.atlassian.net/browse/PPSC-1087)

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Refactoring (no functional changes)
* [ ] Performance improvement

## Problem

To enable SSO for Armis developer tools, an IT admin must register their corporate IdP (Okta, Entra ID, Keycloak, …) with the AppSec API by POSTing to `/api/v1/oauth2/idp-configs`. Until the VIPR UI exposes this, admins have no guided way to do it — they must hand-craft a `curl` call with the correct issuer, client ID/secret, group claim, and group mapping.

`armis-cli` is already distributed to all and is where SSO is configured on the client side (`auth login`/`logout`/`whoami`, PPSC-1037). The IdP-registration helper belongs there too, so admins configure everything from one place.

## Solution

Add an `armis-cli auth setup` command that guides an admin through registering their tenant's IdP and posts the configuration to the OAuth2 admin API.

- **Two input modes**: interactive by default (the CLI walks through each value and explains where to find it), or `--config` for a full JSON document (file path, `-` for stdin, or inline) for scripting.
- **Role-centric group mapping**: the admin maps IdP groups to the two recognized Armis roles (`admin`, `developer`); several groups can share a role. Input is role→[groups] and flattened to the backend's group→role map. A group under two roles is rejected.
- **Pre-flight existence check (interactive)**: `Get` the tenant's config first. If one exists, pre-fill an edit form where every field is optional and send only the changed fields (server-side merge) — so a group mapping can be changed without re-entering the client secret (the API never returns it). Otherwise collect a full config and create it.
- **Create vs. update**: `201` success; `409 Conflict` offers an interactive update or, non-interactively, errors and points at `--update` (never silently overwrites); `--update` forces the `PUT` path for the `--config` flow. 4xx errors map to actionable messages.
- **Secret handling**: the OIDC client secret is sent only in the request, masked in the review summary, and never stored or printed.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [ ] Integration tests added/updated
* [x] All tests passing locally

### Manual Testing

Smoke-tested end-to-end against a local backend.

## Reviewer Notes

- `ema_enabled` is always sent `false` (backend not ready for EMA yet).
- Only `admin` and `developer` roles are accepted, matching the backend.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] Documentation updated (if needed)
* [ ] Breaking changes documented (if applicable)
* [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PPSC-1087]: https://armis-security.atlassian.net/browse/PPSC-1087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ