### PR TITLE
[PPSC-1108] fix(supply-chain): accurate wording for npm uninstall commands

### DIFF
--- a/internal/cmd/supply_chain_wrap.go
+++ b/internal/cmd/supply_chain_wrap.go
@@ -408,12 +408,29 @@ var removalSubcommands = map[string]bool{
 	"unlink":    true,
 }
 
+// flagsWithValue are global package-manager flags that consume the following
+// token as their value rather than a subcommand, e.g. `--prefix /tmp`.
+// firstSubcommand must skip both the flag and its value, or it mistakes the
+// value (like a directory path) for the subcommand and misses a removal verb
+// that follows (`npm --prefix /tmp remove vercel`).
+var flagsWithValue = map[string]bool{
+	"--prefix":   true,
+	"--cwd":      true,
+	"--registry": true,
+	"--filter":   true,
+	"-C":         true,
+}
+
 // firstSubcommand returns the first non-flag token in pmArgs — the
 // package-manager subcommand the user actually typed (e.g. "uninstall" out of
 // ["uninstall", "--save", "vercel"]) — or "" if pmArgs is empty or all flags.
 func firstSubcommand(pmArgs []string) string {
-	for _, a := range pmArgs {
+	for i := 0; i < len(pmArgs); i++ {
+		a := pmArgs[i]
 		if strings.HasPrefix(a, "-") {
+			if flagsWithValue[a] && i+1 < len(pmArgs) {
+				i++
+			}
 			continue
 		}
 		return a
@@ -877,10 +894,13 @@ func printPkgFilterLine(s *output.Styles, r pkgFilterResult, mixed, installOK, p
 
 	resolvedWord := "installed"
 	switch {
+	case !installOK:
+		// A failed run never completed, so nothing was kept or installed —
+		// this must win over isRemoval or a failed uninstall would misreport
+		// "kept" for a package the PM never finished touching.
+		resolvedWord = "available"
 	case isRemoval:
 		resolvedWord = "kept"
-	case !installOK:
-		resolvedWord = "available"
 	}
 
 	var glyph string

--- a/internal/cmd/supply_chain_wrap.go
+++ b/internal/cmd/supply_chain_wrap.go
@@ -391,6 +391,49 @@ func exitWithCode(code int, err error) error {
 
 const maxBlockedDisplay = 5
 
+// removalSubcommands are npm/pnpm/yarn/bun subcommands whose purpose is to
+// remove a package, not install one. npm (7+), pnpm, and bun still hit the
+// registry during these: they run a full dependency-tree reify pass to keep
+// the lockfile consistent after the removal, so any *remaining* package
+// pinned to a loose semver range gets its "latest" re-resolved and re-checked
+// by the proxy. That traffic is real and the filter result is real, but
+// "installed safe version" reads as a non sequitur to someone who only ran
+// `npm uninstall` — this set drives the wording override in actionLabel.
+var removalSubcommands = map[string]bool{
+	"uninstall": true,
+	"remove":    true,
+	"rm":        true,
+	"un":        true,
+	"r":         true,
+	"unlink":    true,
+}
+
+// firstSubcommand returns the first non-flag token in pmArgs — the
+// package-manager subcommand the user actually typed (e.g. "uninstall" out of
+// ["uninstall", "--save", "vercel"]) — or "" if pmArgs is empty or all flags.
+func firstSubcommand(pmArgs []string) string {
+	for _, a := range pmArgs {
+		if strings.HasPrefix(a, "-") {
+			continue
+		}
+		return a
+	}
+	return ""
+}
+
+// actionLabel names, for summary wording, what the wrapped command was doing.
+// It returns the actual subcommand for a known removal verb, since "install"
+// would misdescribe the registry traffic an uninstall triggers; every other
+// invocation (install, add, ci, update, or an unrecognized/absent subcommand)
+// falls back to "install" — the case this summary's wording was designed
+// around and still the overwhelming common case.
+func actionLabel(pmArgs []string) string {
+	if sub := firstSubcommand(pmArgs); removalSubcommands[sub] {
+		return sub
+	}
+	return "install"
+}
+
 // pkgFilterResult is the per-package view of the proxy's filtering decision. It
 // collapses the possibly-several blocked versions of one package into a single
 // line: the youngest blocked version (the one the PM would have installed as
@@ -454,6 +497,15 @@ func printBlockSummary(blocked []supplychain.BlockedPackage, allowed []supplycha
 	// the PM exited non-zero we report the filter as a fact and stay neutral.
 	success := allResolved && installOK
 
+	// action names what the wrapped command was actually doing, for wording only.
+	// It defaults to "install" (the common case this summary was written for) but
+	// switches to the real verb (uninstall, remove, rm, …) for removal-style
+	// subcommands, and isRemoval gates the extra clarifying clause below — someone
+	// who typed `npm uninstall` sees registry-filtering output and needs to know
+	// it came from npm's own dependency-tree reify pass, not a hidden install.
+	action := actionLabel(pmArgs)
+	isRemoval := action != "install"
+
 	// Header. When every filtered package resolved to a safe older version AND the
 	// install completed, the user was both protected and unblocked — frame it as
 	// success (green). Otherwise stay neutral (muted): either a package had no safe
@@ -468,6 +520,20 @@ func printBlockSummary(blocked []supplychain.BlockedPackage, allowed []supplycha
 			s.MutedText.Render(scPrefix),
 			s.MutedText.Render(fmt.Sprintf("supply-chain: withheld %s; a default install was unaffected (%s policy)",
 				countNoun(len(results), "prerelease"), policyShort)))
+	case success && isRemoval:
+		// npm/pnpm/bun re-resolve the remaining dependency tree during uninstall to
+		// keep the lockfile consistent, which can touch the registry even though the
+		// user asked to remove a package, not install one. Name the real subcommand
+		// and explain the registry hit so this doesn't read as a non sequitur.
+		versionWord := "version"
+		if len(results) > 1 {
+			versionWord = "versions"
+		}
+		fmt.Fprintf(os.Stderr, "\n%s %s %s\n",
+			s.MutedText.Render(scPrefix),
+			s.SuccessText.Render(output.IconSuccess),
+			s.SuccessText.Render(fmt.Sprintf("supply-chain: %s re-resolved remaining dependencies; filtered %s → kept safe %s (%s policy)",
+				action, countNoun(len(results), "too-new release"), versionWord, policyShort)))
 	case success:
 		versionWord := "version"
 		if len(results) > 1 {
@@ -481,8 +547,8 @@ func printBlockSummary(blocked []supplychain.BlockedPackage, allowed []supplycha
 	case !installOK:
 		fmt.Fprintf(os.Stderr, "\n%s %s\n",
 			s.MutedText.Render(scPrefix),
-			s.WarningText.Render(fmt.Sprintf("supply-chain: filtered %s; install did not complete (%s policy)",
-				countNoun(len(results), "too-new release"), policyShort)))
+			s.WarningText.Render(fmt.Sprintf("supply-chain: filtered %s; %s did not complete (%s policy)",
+				countNoun(len(results), "too-new release"), action, policyShort)))
 	default:
 		fmt.Fprintf(os.Stderr, "\n%s %s\n",
 			s.MutedText.Render(scPrefix),
@@ -512,7 +578,7 @@ func printBlockSummary(blocked []supplychain.BlockedPackage, allowed []supplycha
 		}
 	}
 	for _, r := range results[:displayCount] {
-		printPkgFilterLine(s, r, !allResolved, installOK, onlyPrerelease, cols)
+		printPkgFilterLine(s, r, !allResolved, installOK, onlyPrerelease, isRemoval, cols)
 	}
 	if remaining := len(results) - displayCount; remaining > 0 {
 		fmt.Fprintf(os.Stderr, "    %s\n",
@@ -524,7 +590,7 @@ func printBlockSummary(blocked []supplychain.BlockedPackage, allowed []supplycha
 	// error), so the language stays hedged — but pointing at a specific package is
 	// far more actionable than "if a dependency pins a version…".
 	if !installOK {
-		printFailureCulprits(s, results, conflicts, policy, pmName, pmArgs)
+		printFailureCulprits(s, results, conflicts, policy, pmName, pmArgs, action)
 	}
 
 	// One-time rationale: the first time a user sees a filter on an interactive
@@ -550,7 +616,7 @@ func printBlockSummary(blocked []supplychain.BlockedPackage, allowed []supplycha
 			fmt.Fprintf(os.Stderr, "\n  %s\n", s.MutedText.Render(strings.Repeat("─", scSepLen)))
 			fmt.Fprintf(os.Stderr, "  %s %s\n\n",
 				s.MutedText.Render("Disable:"),
-				s.Bold.Render(fmt.Sprintf("%s=off %s install", envSCOff, pmName)))
+				s.Bold.Render(fmt.Sprintf("%s=off %s %s", envSCOff, pmName, action)))
 		} else {
 			fmt.Fprintf(os.Stderr, "  %s %s\n",
 				s.MutedText.Render("Disable:"),
@@ -577,7 +643,7 @@ func printBlockSummary(blocked []supplychain.BlockedPackage, allowed []supplycha
 // exclusions → min-age (surgical/reviewable → broad), and deliberately omits the
 // global ARMIS_SUPPLY_CHAIN=off kill switch so a 3am developer does not reach for
 // the nuclear option first.
-func printFailureCulprits(s *output.Styles, results []pkgFilterResult, conflicts []supplychain.ConstraintConflict, policy supplychain.Policy, pmName string, pmArgs []string) {
+func printFailureCulprits(s *output.Styles, results []pkgFilterResult, conflicts []supplychain.ConstraintConflict, policy supplychain.Policy, pmName string, pmArgs []string, action string) {
 	policyShort := formatPolicyShort(policy.MinReleaseAge)
 
 	// Lead with protection, not apology: state the security win first so the
@@ -585,7 +651,7 @@ func printFailureCulprits(s *output.Styles, results []pkgFilterResult, conflicts
 	// source obvious to someone who didn't add armis to their pipeline.
 	fmt.Fprintf(os.Stderr, "\n  %s %s\n",
 		s.Bold.Render("[armis supply-chain]"),
-		s.MutedText.Render("the install did not complete. This tool withheld brand-new releases on purpose — a common supply-chain attack vector. The block may be why the install failed (or it could be unrelated, e.g. a typo or network error)."))
+		s.MutedText.Render(fmt.Sprintf("the %s did not complete. This tool withheld brand-new releases on purpose — a common supply-chain attack vector. The block may be why the %s failed (or it could be unrelated, e.g. a typo or network error).", action, action)))
 
 	// nuclearShown tracks whether we named at least one specific culprit; it
 	// gates the closing "managed by your platform team" pointer.
@@ -782,10 +848,14 @@ func rightPad(s string, width int) string {
 // colored severity tier that would imply averted risk. The resolved-version
 // wording is "installed" only when the PM completed (installOK); otherwise it
 // reads "available" — the safe version exists, but we cannot claim it was
-// installed. When no safe fallback existed (NewVersion == "") the line inverts:
-// it leads with a warning instead of an install. cols pads the columns so the
-// skipped clauses line up across rows.
-func printPkgFilterLine(s *output.Styles, r pkgFilterResult, mixed, installOK, prerelease bool, cols colWidths) {
+// installed. When the wrapped command was a removal (isRemoval) — the PM
+// re-resolved this package as a side effect of uninstalling another one, not
+// because the user asked to install it — the line reads "kept" instead, since
+// "installed" would misdescribe what a removal command did. When no safe
+// fallback existed (NewVersion == "") the line inverts: it leads with a
+// warning instead of an install. cols pads the columns so the skipped clauses
+// line up across rows.
+func printPkgFilterLine(s *output.Styles, r pkgFilterResult, mixed, installOK, prerelease, isRemoval bool, cols colWidths) {
 	// Omit the age when it is unknown (OldAge == 0 for an undatable PyPI file, or
 	// non-positive under clock skew) rather than claiming a precise "(0 minutes
 	// old)". The version alone is still actionable.
@@ -806,7 +876,10 @@ func printPkgFilterLine(s *output.Styles, r pkgFilterResult, mixed, installOK, p
 	}
 
 	resolvedWord := "installed"
-	if !installOK {
+	switch {
+	case isRemoval:
+		resolvedWord = "kept"
+	case !installOK:
 		resolvedWord = "available"
 	}
 

--- a/internal/cmd/supply_chain_wrap_summary_test.go
+++ b/internal/cmd/supply_chain_wrap_summary_test.go
@@ -146,6 +146,85 @@ func TestPrintBlockSummary_SingleResolved(t *testing.T) {
 	}
 }
 
+func TestPrintBlockSummary_UninstallReframesWording(t *testing.T) {
+	// `npm uninstall` (and remove/rm/un/r/unlink) can still hit the registry via
+	// npm's dependency-tree reify pass. The summary must name the real verb and
+	// explain the registry hit, not claim an install happened.
+	forceNoColor(t)
+	blocked := []supplychain.BlockedPackage{{Name: "axios", Version: "1.17.0", DisplayVersion: "1.17.0", Age: 24 * time.Hour}}
+	allowed := []supplychain.InstalledPackage{{Name: "axios", Version: "1.16.1", Age: 10 * 24 * time.Hour}}
+
+	out := captureStderr(t, func() {
+		printBlockSummary(blocked, allowed, 5, testPolicy(), pmNPM, true, []string{"uninstall", "vercel"}, nil)
+	})
+
+	wantSubstrings := []string{
+		"uninstall re-resolved remaining dependencies",
+		"filtered 1 too-new release → kept safe version (3-day policy)",
+		"axios",
+		"1.16.1 kept (10 days old)",
+		"— skipped 1.17.0 (1 day old)",
+		"Disable: ARMIS_SUPPLY_CHAIN=off",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q; got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "installed") {
+		t.Errorf("uninstall summary must not claim anything was \"installed\"; got:\n%s", out)
+	}
+}
+
+func TestPrintBlockSummary_UninstallFailureNamesRealVerb(t *testing.T) {
+	// A failed uninstall must say "uninstall did not complete", not "install did
+	// not complete" — the wording drives the culprit explanation too.
+	forceNoColor(t)
+	blocked := []supplychain.BlockedPackage{{Name: "axios", Version: "1.17.0", DisplayVersion: "1.17.0", Age: 24 * time.Hour}}
+
+	out := captureStderr(t, func() {
+		printBlockSummary(blocked, nil, 5, testPolicy(), pmNPM, false, []string{"remove", "axios"}, nil)
+	})
+
+	wantSubstrings := []string{
+		"filtered 1 too-new release; remove did not complete",
+		"the remove did not complete",
+		"why the remove failed",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestActionLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"install (default)", []string{"install", "axios"}, "install"},
+		{"add", []string{"add", "axios"}, "install"},
+		{"no args", nil, "install"},
+		{"only flags", []string{"--save-dev"}, "install"},
+		{"uninstall", []string{"uninstall", "vercel"}, "uninstall"},
+		{"remove", []string{"remove", "vercel"}, "remove"},
+		{"rm", []string{"rm", "vercel"}, "rm"},
+		{"un shorthand", []string{"un", "vercel"}, "un"},
+		{"r shorthand", []string{"r", "vercel"}, "r"},
+		{"unlink", []string{"unlink", "vercel"}, "unlink"},
+		{"flag before uninstall", []string{"--global", "uninstall", "vercel"}, "uninstall"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := actionLabel(tc.args); got != tc.want {
+				t.Errorf("actionLabel(%v) = %q, want %q", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestPrintBlockSummary_PyPIFilenameNotPrerelease(t *testing.T) {
 	// Regression: a PyPI BlockedPackage carries a *filename* in Version
 	// ("filelock-3.29.2.tar.gz"). The summary must classify on DisplayVersion, not

--- a/internal/cmd/supply_chain_wrap_summary_test.go
+++ b/internal/cmd/supply_chain_wrap_summary_test.go
@@ -198,6 +198,26 @@ func TestPrintBlockSummary_UninstallFailureNamesRealVerb(t *testing.T) {
 	}
 }
 
+func TestPrintBlockSummary_FailedUninstallNeverSaysKept(t *testing.T) {
+	// A failed uninstall (installOK=false) must say "available", not "kept" —
+	// installOK must win over isRemoval, since a run that never completed kept
+	// nothing.
+	forceNoColor(t)
+	blocked := []supplychain.BlockedPackage{{Name: "axios", Version: "1.17.0", DisplayVersion: "1.17.0", Age: 24 * time.Hour}}
+	allowed := []supplychain.InstalledPackage{{Name: "axios", Version: "1.16.1", Age: 10 * 24 * time.Hour}}
+
+	out := captureStderr(t, func() {
+		printBlockSummary(blocked, allowed, 5, testPolicy(), pmNPM, false, []string{"uninstall", "vercel"}, nil)
+	})
+
+	if strings.Contains(out, "kept") {
+		t.Errorf("failed uninstall must not claim a version was \"kept\"; got:\n%s", out)
+	}
+	if !strings.Contains(out, "1.16.1 available") {
+		t.Errorf("failed uninstall must say \"available\", not \"installed\"/\"kept\"; got:\n%s", out)
+	}
+}
+
 func TestActionLabel(t *testing.T) {
 	tests := []struct {
 		name string
@@ -215,6 +235,8 @@ func TestActionLabel(t *testing.T) {
 		{"r shorthand", []string{"r", "vercel"}, "r"},
 		{"unlink", []string{"unlink", "vercel"}, "unlink"},
 		{"flag before uninstall", []string{"--global", "uninstall", "vercel"}, "uninstall"},
+		{"value-taking flag before uninstall", []string{"--prefix", "/tmp", "uninstall", "vercel"}, "uninstall"},
+		{"value-taking flag before remove", []string{"--cwd", "/tmp", "remove", "vercel"}, "remove"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Related Issue

* [PPSC-1108](https://armis.atlassian.net/browse/PPSC-1108)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

The supply-chain summary always described the wrapped command as an "install", even when the user ran `npm uninstall`/`remove`/`rm`/`un`/`r`/`unlink`. npm/pnpm/bun still hit the registry during removal (a dependency-tree reify pass), so the filter output was real, but claiming a package was "installed" during an uninstall read as a non sequitur.

## Solution

Added `actionLabel`/`firstSubcommand` to detect removal-style subcommands from the package-manager args, and threaded an `isRemoval` flag through the summary printing so wording switches to the real verb: "kept" instead of "installed", "uninstall did not complete" instead of "install did not complete", and an explanatory clause about the reify pass touching the registry.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

Covered by `TestActionLabel`, `TestPrintBlockSummary_UninstallReframesWording`, and `TestPrintBlockSummary_UninstallFailureNamesRealVerb`.

## Reviewer Notes

No functional/filtering logic changed — this is summary wording only.

[PPSC-1108]: https://armis-security.atlassian.net/browse/PPSC-1108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ