### PR TITLE
[PPSC-994] feat(supply-chain): custom artifactory support with auth + TLS trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,10 @@ exclusions:
 #   - pip
 # transitive-policy: warn   # optional: let young TRANSITIVE deps through with a warning
 #                           # (direct deps still blocked); default: block
+# registries:               # optional: route age checks through a private artifactory
+#   npm: https://nexus.corp/repository/npm-group/
+#   pypi: https://nexus.corp/repository/pypi-group/simple/
+# registry-ca-bundle: /etc/armis/nexus-ca.pem   # optional: trust a private CA
 fail-open: false
 ```
 
@@ -707,7 +711,7 @@ When a brand-new release is blocking you, prefer the most reviewable option:
 3. **Relax the window for all packages**: edit `min-age:` in `.armis-supply-chain.yaml`
 4. **Emergency kill switch**: `ARMIS_SUPPLY_CHAIN=off npm install`
 
-Because the age proxy is graph-blind, a withheld young version can make a transitive dependency unsatisfiable and fail an install. On the npm family Armis names the culprit (and who required it); you can also opt into `transitive-policy: warn` to let young *transitive* deps through while still blocking young *direct* ones. Generate an audit trail with `ARMIS_SUPPLY_CHAIN_REPORT=<path>` (wrapped installs) or `--report <path>` (`check`). See **[docs/FEATURES.md → Supply Chain Enforcement](docs/FEATURES.md#-supply-chain-enforcement)** for the full model, limitations, and residual-risk notes.
+Because the age proxy is graph-blind, a withheld young version can make a transitive dependency unsatisfiable and fail an install. On the npm family Armis names the culprit (and who required it); you can also opt into `transitive-policy: warn` to let young *transitive* deps through while still blocking young *direct* ones. Generate an audit trail with `ARMIS_SUPPLY_CHAIN_REPORT=<path>` (wrapped installs) or `--report <path>` (`check`). Route age checks through a private artifactory instead of the public registries with `registries:` (see **[docs/FEATURES.md → Custom approved registry](docs/FEATURES.md#supply-chain-custom-registry)**). See **[docs/FEATURES.md → Supply Chain Enforcement](docs/FEATURES.md#-supply-chain-enforcement)** for the full model, limitations, and residual-risk notes.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -237,6 +237,57 @@ The report carries the effective `policy`, the enforcement `mode`, and the
 jq -e '.install_status == "ok" and (.warned_through | length) == 0' supply-chain-report.json
 ```
 
+<a name="supply-chain-custom-registry"></a>
+
+### Custom approved registry (private artifactory)
+
+By default, age checks query the public registries (npm, PyPI). If your org
+routes installs through a private artifactory (Nexus, JFrog Artifactory), point
+Armis at it so age checks — and the `wrap`/`check` age enforcement — run against
+the registry you actually use, not the public one:
+
+```yaml
+# .armis-supply-chain.yaml
+registries:
+  npm: https://nexus.corp/repository/npm-group/
+  pypi: https://nexus.corp/repository/pypi-group/simple/   # must expose the PEP 503 Simple API
+registry-enforcement: warn   # optional: warn when an install resolves off the approved registry
+registry-ca-bundle: /etc/armis/nexus-ca.pem   # optional: trust a private/corporate CA
+```
+
+- **`registries.<npm|pypi>`** — the approved registry URL for that ecosystem.
+  Must be `https://` with no embedded credentials and no loopback/private/
+  link-local host (the committed config is a trust boundary — validated at
+  load time, not a best-effort parse). The PyPI URL must end in `/simple` or
+  `/simple/` (the PEP 503 Simple API path); Maven/Gradle are audit-path only
+  and not routable to a custom registry in this version.
+- **`registry-enforcement: warn`** — when set, a package that resolves from a
+  host *other than* the approved registry is flagged with a warning (currently
+  npm-family only). Only `warn` is supported; `block` is rejected at config
+  load so it can never be silently downgraded.
+- **`registry-ca-bundle`** — path to a PEM file to trust a private CA for the
+  registry connection, e.g. a self-signed or corporate-CA-issued artifactory
+  certificate. Override per-run with `ARMIS_REGISTRY_CA_BUNDLE=<path>`. A bad
+  or unreadable bundle is a hard error, never a silent fallback to unverified
+  TLS.
+
+**Credentials** are read from your existing package-manager config, never from
+the committed policy file: npm-family reads the `.npmrc` `_authToken` (host- or
+host+path-scoped); pip/uv read Basic-auth userinfo embedded in
+`PIP_INDEX_URL`/`UV_INDEX_URL`. If a credential is configured but unusable
+(e.g. an `.npmrc` referencing an unset `${VAR}`), that's a hard error rather
+than a silent unauthenticated request.
+
+**Check your setup** before relying on it:
+
+```bash
+armis-cli supply-chain wrap --dry-run npm
+```
+
+This resolves and prints the approved registry, whether a credential was
+found, the enforcement posture, and the CA bundle in use — without running
+the package manager.
+
 <a name="supply-chain-scope-notes"></a>
 
 ### Scope and known limitations
@@ -495,6 +546,7 @@ JWT authentication is recommended. Obtain JWT credentials from the VIPR external
 | `ARMIS_SUPPLY_CHAIN_SKIP` | Comma/space-separated package names to exempt from the age check (persists in the env; exempts future versions) |
 | `ARMIS_SUPPLY_CHAIN_TRANSITIVE` | Set to `warn` to let young *transitive* deps through with a warning (direct deps still blocked); default `block` |
 | `ARMIS_SUPPLY_CHAIN_REPORT` | Path to write the JSON compliance report for a wrapped install (`-` for stderr) |
+| `ARMIS_REGISTRY_CA_BUNDLE` | Path to a PEM CA bundle to trust for the configured custom registry connection; overrides `registry-ca-bundle` in `.armis-supply-chain.yaml` |
 
 ### Default Behavior
 

--- a/docs/ci-examples/github-actions-supply-chain.yml
+++ b/docs/ci-examples/github-actions-supply-chain.yml
@@ -8,7 +8,10 @@
 #
 # No Armis Cloud authentication is required: supply-chain queries public
 # registries (npm, PyPI, Maven Central) directly, so this workflow needs no
-# secrets.
+# secrets. If your org routes installs through a private artifactory (Nexus,
+# JFrog), configure `registries:` in .armis-supply-chain.yaml so age checks
+# run against it instead — see docs/FEATURES.md → "Custom approved registry".
+# That setup may need a registry credential and/or CA bundle available to CI.
 #
 # Notes:
 #   - By default `check` reports only packages that are NEW versus the base

--- a/internal/cmd/supply_chain_check.go
+++ b/internal/cmd/supply_chain_check.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -217,9 +218,19 @@ func runSupplyChainCheck(cmd *cobra.Command, args []string) error {
 			s.MutedText.Render("supply-chain: no git base detected, checking all packages (use --all to suppress this notice)"))
 	}
 
+	// Thread the approved registry for this lockfile's ecosystem (PPSC-994): age
+	// checks query it, and npm-family packages resolved from a different host are
+	// flagged. The URL was validated at config-load; validate once more defensively.
+	registryURL := cfg.RegistryURLFor(eco)
+	if registryURL != "" {
+		if _, verr := supplychain.ValidateRegistryURL(registryURL); verr != nil {
+			return fmt.Errorf("approved registry for %s is invalid: %w", eco, verr)
+		}
+	}
+
 	ctx := cmd.Context()
 	// armis:ignore cwe:73 cwe:22 reason:lockfilePath and baseLockfile derive from the user-controlled --lockfile/--base-lockfile CLI flags (or auto-detected paths) naming files on the user's own machine; reading them is the purpose of `supply-chain check`, same no-trust-boundary pattern as --output suppressed at the flag registration above
-	result, err := check.RunCheck(ctx, policy, lockfilePath, baseLockfile)
+	result, err := check.RunCheckWithRegistry(ctx, policy, lockfilePath, baseLockfile, registryURL)
 	if err != nil {
 		if policy.FailOpen {
 			cli.PrintWarningf("supply-chain check failed (--fail-open): %v", err)
@@ -238,6 +249,13 @@ func runSupplyChainCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	s := output.GetStyles()
+
+	// Coverage header LEADS the output when any registry is configured, so a
+	// CISO reading CI logs sees exactly which ecosystems are covered and which
+	// fall back to the public registry — never a green checkmark that implies
+	// coverage the org isn't getting (E4/DX3 honesty).
+	printRegistryCoverage(s, cfg, eco, registryURL, result.RegistryChecked)
+
 	fmt.Fprintf(os.Stderr, "%s %s\n",
 		s.MutedText.Render("[armis]"),
 		s.MutedText.Render(fmt.Sprintf("supply-chain: checked %s, %d skipped, %s (%s policy)",
@@ -273,9 +291,12 @@ func runSupplyChainCheck(cmd *cobra.Command, args []string) error {
 		writeComplianceReport(scReport, rep)
 	} // armis:ignore cwe:22 cwe:23 cwe:73 reason:scanner attributes the scReport write-path finding to this closing brace; scReport is the user's own --report CLI flag naming a file on their machine (same trust model as scan's --output), not attacker-controlled input crossing a trust boundary
 
-	findings := make([]model.Finding, 0, len(result.Violations))
+	findings := make([]model.Finding, 0, len(result.Violations)+len(result.RegistryViolations))
 	for _, v := range result.Violations {
 		findings = append(findings, supplychain.ViolationToFinding(v, lockfilePath))
+	}
+	for _, rv := range result.RegistryViolations {
+		findings = append(findings, registryViolationToFinding(rv, lockfilePath))
 	}
 
 	scanResult := &model.ScanResult{
@@ -306,6 +327,73 @@ func runSupplyChainCheck(cmd *cobra.Command, args []string) error {
 	// function (before the scan ran) from the check-local scFailOn flag, so a
 	// lowercase "medium" correctly trips ShouldFail's exact match here.
 	return output.CheckExit(scanResult, failOnSeverities, exitCode)
+}
+
+// printRegistryCoverage emits the CISO-facing coverage header (E4/DX3). It
+// prints NOTHING when no registry is configured anywhere (the pre-PPSC-994
+// behavior — no header noise for users not using this feature). Once ANY
+// registry is set, it states this ecosystem's coverage explicitly: a configured
+// host with a scoped count, or "not configured — public registry" so a green
+// check never implies coverage the org isn't getting.
+func printRegistryCoverage(s *output.Styles, cfg *supplychain.Config, eco supplychain.Ecosystem, registryURL string, registryChecked int) {
+	if !cfg.HasAnyRegistry() {
+		return
+	}
+
+	ecoName := string(eco)
+	if registryURL != "" {
+		host := registryURL
+		if u, err := url.Parse(registryURL); err == nil && u.Host != "" {
+			host = u.Host
+		}
+		fmt.Fprintf(os.Stderr, "%s %s\n",
+			s.MutedText.Render("[armis] Registry coverage:"),
+			s.SuccessText.Render(fmt.Sprintf("%s ✓ (%s)", ecoName, host)))
+		if isNPMFamilyEco(eco) {
+			fmt.Fprintf(os.Stderr, "%s\n",
+				s.MutedText.Render(fmt.Sprintf("  %s resolved-registry checked; packages from other registries are flagged.",
+					countNoun(registryChecked, ecoName+" package"))))
+		}
+		return
+	}
+
+	// No registry configured for THIS ecosystem, but one is set for another —
+	// be explicit that this ecosystem falls back to the public registry.
+	fmt.Fprintf(os.Stderr, "%s %s\n",
+		s.MutedText.Render("[armis] Registry coverage:"),
+		s.WarningText.Render(fmt.Sprintf("%s ✗ (not configured — public registry)", ecoName)))
+}
+
+// isNPMFamilyEco reports whether an ecosystem is part of the npm family (the
+// only family whose lockfiles record a per-package resolved registry URL, and
+// thus the only one the non-approved-registry check covers in v1). Mirrors
+// check.isNPMFamily without exporting it across the package boundary.
+func isNPMFamilyEco(eco supplychain.Ecosystem) bool {
+	switch eco {
+	case supplychain.EcosystemNPM, supplychain.EcosystemPNPM, supplychain.EcosystemBun, supplychain.EcosystemYarn:
+		return true
+	default:
+		return false
+	}
+}
+
+// registryViolationToFinding converts a non-approved-registry violation into a
+// model.Finding so it flows through the existing output formatters and the
+// --fail-on gate, mirroring ViolationToFinding's shape. Severity is MEDIUM:
+// resolving from an unapproved registry is a policy/routing concern, not the
+// HIGH-severity "brand-new release" age signal.
+func registryViolationToFinding(rv check.RegistryViolation, lockfilePath string) model.Finding {
+	return model.Finding{
+		ID:              fmt.Sprintf("SUPPLY_CHAIN_REGISTRY/%s@%s", rv.Name, rv.Version),
+		Type:            model.FindingTypeSCA,
+		Severity:        model.SeverityMedium,
+		Title:           fmt.Sprintf("Package resolved from non-approved registry: %s@%s", rv.Name, rv.Version),
+		Description:     fmt.Sprintf("Package %s@%s was resolved from %s, which is not the approved registry (%s). Re-resolve it through the approved registry.", rv.Name, rv.Version, rv.ResolvedHost, rv.ApprovedHost),
+		File:            lockfilePath,
+		Package:         rv.Name,
+		Version:         rv.Version,
+		FindingCategory: "SUPPLY_CHAIN_REGISTRY",
+	}
 }
 
 // countNoun formats a count with its noun, pluralizing with a trailing "s" when

--- a/internal/cmd/supply_chain_check.go
+++ b/internal/cmd/supply_chain_check.go
@@ -175,7 +175,7 @@ func runSupplyChainCheck(cmd *cobra.Command, args []string) error {
 	// pass rather than checking an out-of-scope ecosystem. loadConfigUpward
 	// returns nil (enforce-all) when no config is present, and EnforcesEcosystem
 	// fails safe on an all-typo list.
-	cfg, _, err := loadConfigUpward(dir)
+	cfg, configDir, err := loadConfigUpward(dir)
 	if err != nil {
 		return err
 	}
@@ -228,9 +228,42 @@ func runSupplyChainCheck(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Build the age-query HTTP client with the approved registry's private-CA
+	// trust (registry-ca-bundle / ARMIS_REGISTRY_CA_BUNDLE), so `check` can reach
+	// a corporate-CA Nexus exactly as the wrap proxy does. Without this, every age
+	// query against such a registry fails TLS verification and is silently reduced
+	// to a warning — a green "0 violations" that never actually checked anything.
+	// A nil client means no custom trust is needed (public registry); a bad bundle
+	// is a hard error so the misconfiguration surfaces instead of failing open.
+	// armis:ignore cwe:295 reason:resolveCABundlePath returns the operator-supplied ARMIS_REGISTRY_CA_BUNDLE env or the committed registry-ca-bundle config path (the deploying platform team's own file), not attacker-controlled input; same trust source already suppressed for newUpstreamHTTPClient in proxy.go
+	registryHTTPClient, err := supplychain.NewRegistryHTTPClient(registryURL, resolveCABundlePath(cfg))
+	if err != nil {
+		return fmt.Errorf("configuring registry TLS trust for %s: %w", eco, err)
+	}
+
+	// Resolve the developer's registry credential from their NATIVE config (the
+	// .npmrc _authToken / index-url userinfo — never the committed policy file) so
+	// `check` authenticates its age queries the same way the wrap proxy does. An
+	// auth-gated artifactory returns 401 without it, which would silently degrade
+	// every age check to an unverified warning. An unusable credential (e.g. an
+	// unset ${VAR} in the .npmrc) is a hard error — the same fail-loud contract
+	// resolveRegistrySettings uses for wrap — never a silent 401.
+	var registryAuthHeader string
+	if registryURL != "" {
+		upstreamURL, perr := url.Parse(registryURL)
+		if perr != nil {
+			return fmt.Errorf("parsing approved registry URL for %s: %w", eco, perr)
+		}
+		authHeader, _, aerr := resolveUpstreamAuth(eco, configDir, upstreamURL)
+		if aerr != nil {
+			return fmt.Errorf("resolving registry credentials for %s: %w", eco, aerr)
+		}
+		registryAuthHeader = authHeader
+	}
+
 	ctx := cmd.Context()
 	// armis:ignore cwe:73 cwe:22 reason:lockfilePath and baseLockfile derive from the user-controlled --lockfile/--base-lockfile CLI flags (or auto-detected paths) naming files on the user's own machine; reading them is the purpose of `supply-chain check`, same no-trust-boundary pattern as --output suppressed at the flag registration above
-	result, err := check.RunCheckWithRegistry(ctx, policy, lockfilePath, baseLockfile, registryURL)
+	result, err := check.RunCheckWithRegistryClient(ctx, policy, lockfilePath, baseLockfile, registryURL, registryHTTPClient, registryAuthHeader)
 	if err != nil {
 		if policy.FailOpen {
 			cli.PrintWarningf("supply-chain check failed (--fail-open): %v", err)

--- a/internal/cmd/supply_chain_check.go
+++ b/internal/cmd/supply_chain_check.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -233,12 +234,21 @@ func runSupplyChainCheck(cmd *cobra.Command, args []string) error {
 	// a corporate-CA Nexus exactly as the wrap proxy does. Without this, every age
 	// query against such a registry fails TLS verification and is silently reduced
 	// to a warning — a green "0 violations" that never actually checked anything.
-	// A nil client means no custom trust is needed (public registry); a bad bundle
-	// is a hard error so the misconfiguration surfaces instead of failing open.
-	// armis:ignore cwe:295 reason:resolveCABundlePath returns the operator-supplied ARMIS_REGISTRY_CA_BUNDLE env or the committed registry-ca-bundle config path (the deploying platform team's own file), not attacker-controlled input; same trust source already suppressed for newUpstreamHTTPClient in proxy.go
-	registryHTTPClient, err := supplychain.NewRegistryHTTPClient(registryURL, resolveCABundlePath(cfg))
-	if err != nil {
-		return fmt.Errorf("configuring registry TLS trust for %s: %w", eco, err)
+	// Gated on registryURL != "": RunCheckWithRegistryClient ignores this client
+	// entirely when there's no approved registry for this ecosystem (it falls
+	// back to the public-registry queryRegistry path), so building it anyway
+	// would be pointless work — reading a CA bundle configured for a DIFFERENT
+	// ecosystem (registry-ca-bundle is global, not per-ecosystem) even though
+	// this ecosystem has no registries.<eco> entry to use it with. A nil client
+	// means no custom trust is needed; a bad bundle is a hard error so the
+	// misconfiguration surfaces instead of failing open.
+	var registryHTTPClient *http.Client
+	if registryURL != "" {
+		// armis:ignore cwe:295 reason:resolveCABundlePath returns the operator-supplied ARMIS_REGISTRY_CA_BUNDLE env or the committed registry-ca-bundle config path (the deploying platform team's own file), not attacker-controlled input; same trust source already suppressed for newUpstreamHTTPClient in proxy.go
+		registryHTTPClient, err = supplychain.NewRegistryHTTPClient(registryURL, resolveCABundlePath(cfg))
+		if err != nil {
+			return fmt.Errorf("configuring registry TLS trust for %s: %w", eco, err)
+		}
 	}
 
 	// Resolve the developer's registry credential from their NATIVE config (the

--- a/internal/cmd/supply_chain_init.go
+++ b/internal/cmd/supply_chain_init.go
@@ -619,9 +619,34 @@ min-age: 72h
 %s
 # Restrict enforcement to specific ecosystems (default: all detected).
 # Supported: npm, pnpm, bun, yarn, pip, poetry, pipenv, pdm, uv, maven, gradle
+# NOTE: if you set "ecosystems" below, any "registries" entry for an excluded
+# ecosystem is ignored — scoping enforcement out also scopes out its routing.
 # ecosystems:
 #   - npm
 #   - pip
+
+# Approved corporate registry per ecosystem (Nexus / JFrog Artifactory).
+# When set, wrapped installs route through this registry (with your existing
+# credentials forwarded) and CI 'check' flags packages resolved elsewhere.
+#   - npm:  the npm group/proxy repo URL.
+#   - pypi: the PyPI index URL — it MUST end in /simple/ (PEP 503).
+# Credentials are read from your NATIVE config, never from this file:
+#   - npm:  .npmrc  //host/path/:_authToken=...   (use _authToken, NOT _auth;
+#           the legacy base64 _auth form is not supported in this version)
+#   - pip:  the userinfo embedded in your index-url (https://user:token@host/...)
+# registries:
+#   npm: https://nexus.corp/repository/npm-group/
+#   pypi: https://nexus.corp/repository/pypi-group/simple/
+
+# Routing enforcement posture. Only "warn" is supported in this version:
+# it prints a one-time notice when your effective registry is explicitly
+# off-policy. ("block" is rejected at load time — it is not yet implemented,
+# and silently downgrading it would give a false sense of enforcement.)
+# registry-enforcement: warn
+
+# Optional CA bundle (PEM) for the proxy's TLS connection to the registry, for
+# a Nexus fronted by a corporate/private CA. Overridable via ARMIS_REGISTRY_CA_BUNDLE.
+# registry-ca-bundle: /etc/ssl/corp-ca.pem
 
 # If true, allow installs when the registry is unreachable
 fail-open: false

--- a/internal/cmd/supply_chain_init_test.go
+++ b/internal/cmd/supply_chain_init_test.go
@@ -654,6 +654,47 @@ func TestRunInitNpmrc_PrependsNewline(t *testing.T) {
 	}
 }
 
+// TestRunInitConfig_RegistryScaffold verifies the generated config carries the
+// PPSC-994 registries scaffold and the DX7/DX8 guidance notes, and that the
+// generated file itself parses cleanly (the commented examples must not break
+// LoadConfig).
+func TestRunInitConfig_RegistryScaffold(t *testing.T) {
+	dir := chdirTemp(t)
+	scInitDryRun = false
+	scInitYes = true
+	t.Cleanup(func() { scInitDryRun = false; scInitYes = false })
+
+	if err := runInitConfig(); err != nil {
+		t.Fatalf("runInitConfig: %v", err)
+	}
+	// runInitConfig writes ConfigFileName into the cwd (chdir'd to dir above);
+	// read the constant leaf directly to avoid a tainted-path lint on a join.
+	data, err := os.ReadFile(supplychain.ConfigFileName)
+	if err != nil {
+		t.Fatalf("reading generated config: %v", err)
+	}
+	content := string(data)
+
+	for _, want := range []string{
+		"registries:",
+		"registry-enforcement: warn",
+		"_authToken", // DX7: credential note
+		"NOT _auth",  // DX7: explicit "not _auth"
+		"/simple/",   // pypi URL guidance
+		"ignored",    // DX8: ecosystems-scope-suppresses-registries note
+		"registry-ca-bundle",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("generated scaffold missing %q", want)
+		}
+	}
+
+	// The scaffold (with registries commented out) must parse cleanly.
+	if _, err := supplychain.LoadConfig(dir); err != nil {
+		t.Errorf("generated scaffold does not parse: %v", err)
+	}
+}
+
 func TestRunInitNpmrc_Idempotent(t *testing.T) {
 	chdirTemp(t)
 	scInitDryRun = false

--- a/internal/cmd/supply_chain_registry.go
+++ b/internal/cmd/supply_chain_registry.go
@@ -1,0 +1,357 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ArmisSecurity/armis-cli/internal/cli"
+	"github.com/ArmisSecurity/armis-cli/internal/output"
+	"github.com/ArmisSecurity/armis-cli/internal/supplychain"
+	"github.com/ArmisSecurity/armis-cli/internal/util"
+)
+
+// envRegistryCABundle overrides the config's registry-ca-bundle for the
+// proxy→upstream TLS leg (S6), mirroring how ARMIS_API_URL overrides the API
+// base. A minimal CI runner can point at its corporate CA without editing the
+// committed policy file.
+const envRegistryCABundle = "ARMIS_REGISTRY_CA_BUNDLE"
+
+// registrySettings is the resolved, proxy-ready view of the registries config
+// for one ecosystem. Configured is false on the default public path (no
+// registries entry for this ecosystem), in which case the other fields are
+// zero and the proxy behaves exactly as before this feature.
+type registrySettings struct {
+	Configured   bool   // an approved registry is set for this ecosystem
+	ApprovedURL  string // the registries.<eco> value (for warnings/dry-run)
+	UpstreamURL  string // == ApprovedURL; the proxy upstream
+	AuthHeader   string // "Bearer <tok>" / "Basic <b64>", or "" if none found
+	CABundlePath string // resolved CA bundle path (env over config), or ""
+	Enforcement  string // routing-enforcement posture ("warn" or "")
+	authFound    bool   // a credential was located (for dry-run reporting)
+}
+
+// resolveRegistrySettings reads the supply-chain config (searched upward from
+// the current directory) and resolves the approved registry + credentials for
+// the given canonical package manager. It returns a zero-value
+// registrySettings{Configured:false} on any of: no config, no registries entry
+// for this ecosystem, or an audit-path ecosystem that is not routable in v1.
+//
+// A credential-resolution error (e.g. an unset ${VAR} in the .npmrc token, or a
+// resolved token failing the safe charset) is returned as an error — it must
+// fail loudly rather than silently produce an unauthenticated proxy that 401s
+// with a confusing message.
+func resolveRegistrySettings(canonicalPMName string) (registrySettings, error) {
+	eco := pmToEcosystem(canonicalPMName)
+	if eco == "" {
+		return registrySettings{}, nil
+	}
+
+	cfg, configDir, err := loadConfigUpward(".")
+	if err != nil || cfg == nil {
+		// A load error here is non-fatal for routing: resolveWrapPolicy already
+		// fails safe to the default policy, and an absent/unreadable config simply
+		// means "no custom registry." Surface nothing; stay on the public path.
+		return registrySettings{}, nil //nolint:nilerr // absent/invalid config → public path, by design
+	}
+
+	approved := cfg.RegistryURLFor(eco)
+	if approved == "" {
+		return registrySettings{}, nil
+	}
+
+	// The URL was validated at config-load (LoadConfig → validate). Parse it here
+	// for credential lookup; a parse failure at this point would be a logic error
+	// rather than user input, but handle it defensively.
+	upstreamURL, err := url.Parse(approved)
+	if err != nil {
+		return registrySettings{}, fmt.Errorf("parsing approved registry URL: %w", err)
+	}
+
+	rs := registrySettings{
+		Configured:   true,
+		ApprovedURL:  approved,
+		UpstreamURL:  approved,
+		Enforcement:  cfg.RegistryEnforcement,
+		CABundlePath: resolveCABundlePath(cfg),
+	}
+
+	authHeader, found, err := resolveUpstreamAuth(eco, configDir, upstreamURL)
+	if err != nil {
+		return registrySettings{}, err
+	}
+	rs.AuthHeader = authHeader
+	rs.authFound = found
+
+	return rs, nil
+}
+
+// resolveUpstreamAuth builds the Authorization header for the upstream from the
+// developer's NATIVE package-manager config (never from the committed policy
+// file, which is validated to carry no credentials):
+//
+//   - npm family: the .npmrc _authToken (host- and host+path-scoped), forwarded
+//     as "Bearer <token>".
+//   - pip/uv: credentials embedded in the developer's index-url env
+//     (PIP_INDEX_URL / UV_INDEX_URL), forwarded as "Basic <base64(user:pass)>".
+//
+// Returns ("", false, nil) when no credential is configured (a valid no-auth
+// state for a public-mirror repo), and an error when a credential is present
+// but unusable.
+func resolveUpstreamAuth(eco supplychain.Ecosystem, configDir string, upstreamURL *url.URL) (string, bool, error) {
+	switch eco {
+	case supplychain.EcosystemNPM, supplychain.EcosystemPNPM, supplychain.EcosystemBun, supplychain.EcosystemYarn:
+		// Read the project .npmrc from the config directory (the project root) and
+		// the user ~/.npmrc; project wins.
+		dir := configDir
+		if dir == "" {
+			dir = "."
+		}
+		token, ok, err := supplychain.ReadNpmrcAuthToken(dir, upstreamURL)
+		if err != nil {
+			return "", false, err
+		}
+		if !ok {
+			return "", false, nil
+		}
+		return "Bearer " + token, true, nil
+
+	case supplychain.EcosystemPip:
+		return basicAuthFromIndexURL(os.Getenv("PIP_INDEX_URL"))
+	case supplychain.EcosystemUV:
+		// uv honors UV_INDEX_URL; fall back to PIP_INDEX_URL which uv also reads.
+		if v := os.Getenv("UV_INDEX_URL"); v != "" {
+			return basicAuthFromIndexURL(v)
+		}
+		return basicAuthFromIndexURL(os.Getenv("PIP_INDEX_URL"))
+	default:
+		return "", false, nil
+	}
+}
+
+// basicAuthFromIndexURL extracts userinfo from a pip/uv index URL and renders an
+// HTTP Basic Authorization header value. It returns ("", false, nil) when the
+// URL is empty or carries no userinfo.
+func basicAuthFromIndexURL(rawIndexURL string) (string, bool, error) {
+	if rawIndexURL == "" {
+		return "", false, nil
+	}
+	cred, ok, err := supplychain.IndexURLBasicAuth(rawIndexURL)
+	if err != nil {
+		return "", false, err
+	}
+	if !ok {
+		return "", false, nil
+	}
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(cred)), true, nil
+}
+
+// resolveCABundlePath returns the CA bundle path for the proxy→upstream TLS leg,
+// preferring the ARMIS_REGISTRY_CA_BUNDLE env var over the config field so a
+// per-runner override works without editing the committed policy.
+func resolveCABundlePath(cfg *supplychain.Config) string {
+	if v := os.Getenv(envRegistryCABundle); v != "" {
+		return v
+	}
+	if cfg != nil {
+		return cfg.RegistryCABundle
+	}
+	return ""
+}
+
+// runWrapDryRun prints the resolved registry configuration for pmName and
+// returns without running the package manager (DX6). It is the platform
+// engineer's fastest "did I configure this right?" check.
+func runWrapDryRun(pmName string) error {
+	rs, err := resolveRegistrySettings(canonicalPM(pmName))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[armis] supply-chain (dry-run): credential error: %v\n", err)
+		return nil
+	}
+	printWrapDryRun(pmName, rs)
+	return nil
+}
+
+// printWrapDryRun renders the dry-run report to stderr (all wrap output goes to
+// stderr per project convention; nothing is written to stdout).
+func printWrapDryRun(pmName string, rs registrySettings) {
+	s := output.GetStyles()
+	fmt.Fprintf(os.Stderr, "%s supply-chain wrap dry-run for %s\n", s.MutedText.Render(scPrefix), s.Bold.Render(pmName))
+
+	if !rs.Configured {
+		fmt.Fprintf(os.Stderr, "  %s no approved registry configured for this ecosystem — installs use the public registry\n",
+			s.MutedText.Render("Registry:"))
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "  %s %s\n", s.MutedText.Render("Approved registry:"), s.Bold.Render(rs.ApprovedURL))
+
+	authState := s.WarningText.Render("not found (private packages may 401)")
+	if rs.authFound {
+		authState = s.SuccessText.Render("found")
+	}
+	fmt.Fprintf(os.Stderr, "  %s %s\n", s.MutedText.Render("Credentials:     "), authState)
+
+	enforcement := rs.Enforcement
+	if enforcement == "" {
+		enforcement = "off (no routing warning)"
+	}
+	fmt.Fprintf(os.Stderr, "  %s %s\n", s.MutedText.Render("Routing warning: "), enforcement)
+
+	if rs.CABundlePath != "" {
+		fmt.Fprintf(os.Stderr, "  %s %s\n", s.MutedText.Render("CA bundle:       "), rs.CABundlePath)
+	}
+
+	fmt.Fprintf(os.Stderr, "  %s\n",
+		s.MutedText.Render("Publish timestamps: probed at install time; if absent, age enforcement degrades to `supply-chain check` in CI."))
+}
+
+// effectiveRegistryHost resolves the registry host the developer's environment
+// would have used ABSENT the wrapper, returning ("", false) when it cannot be
+// determined from an EXPLICIT source. "Explicit" is the operative word (DX1):
+// only an env var the developer set (npm_config_registry / PIP_INDEX_URL /
+// UV_INDEX_URL) or an explicit `registry=` in their .npmrc counts. A silent
+// default to the public registry is NOT explicit and returns ("", false) — so
+// the off-policy warning never fires on the common hybrid Nexus setup, which
+// was the self-defeating-warning failure mode the DX review flagged.
+//
+// Returns the lowercased host (with port) of the effective registry.
+func effectiveRegistryHost(canonicalPMName string) (string, bool) {
+	eco := pmToEcosystem(canonicalPMName)
+	switch eco {
+	case supplychain.EcosystemNPM, supplychain.EcosystemPNPM, supplychain.EcosystemBun, supplychain.EcosystemYarn:
+		if v := os.Getenv("npm_config_registry"); v != "" {
+			return urlHost(v)
+		}
+		// Explicit registry= in the project .npmrc (NOT a scoped @x:registry=,
+		// which v1 does not compare — see the design's scoped-registry exclusion).
+		if host, ok := npmrcDefaultRegistryHost("."); ok {
+			return host, true
+		}
+	case supplychain.EcosystemPip:
+		if v := os.Getenv("PIP_INDEX_URL"); v != "" {
+			return urlHost(v)
+		}
+	case supplychain.EcosystemUV:
+		if v := os.Getenv("UV_INDEX_URL"); v != "" {
+			return urlHost(v)
+		}
+		if v := os.Getenv("PIP_INDEX_URL"); v != "" {
+			return urlHost(v)
+		}
+	}
+	return "", false
+}
+
+// urlHost parses raw and returns its lowercased host, or ("", false) on failure
+// or when no host is present.
+func urlHost(raw string) (string, bool) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Host == "" {
+		return "", false
+	}
+	return strings.ToLower(u.Host), true
+}
+
+// npmrcDefaultRegistryHost reads the project .npmrc in dir and returns the host
+// of an explicit default `registry=` line, if present. Scoped registry keys
+// (@scope:registry=) are intentionally ignored (out of v1 scope).
+func npmrcDefaultRegistryHost(dir string) (string, bool) {
+	// armis:ignore cwe:22 cwe:23 cwe:73 reason:reading the developer's own project .npmrc to compare their configured registry against the approved one; the path is a fixed ".npmrc" leaf in the project dir, not untrusted input crossing a trust boundary
+	data, err := os.ReadFile(filepath.Join(dir, ".npmrc")) //nolint:gosec // developer's own project .npmrc
+	if err != nil {
+		return "", false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		// Match the bare "registry=" key only — not "@scope:registry=" and not
+		// "//host/:_authToken=". A scoped key contains ':' before '='.
+		if after, ok := strings.CutPrefix(line, "registry="); ok {
+			return urlHost(strings.TrimSpace(after))
+		}
+	}
+	return "", false
+}
+
+// maybeWarnOffPolicyRegistry prints the soft routing warning when the
+// developer's EXPLICIT effective registry host differs from the approved one
+// (DX1). It is gated three ways to avoid the self-defeating-warning trap:
+//   - only an explicit off-policy choice triggers it (effectiveRegistryHost
+//     returns ok only for an explicit env/config source);
+//   - it is rate-limited to once per shell session via a marker file (reusing
+//     the shouldShowRationale marker pattern);
+//   - it fires only when registry-enforcement is "warn" (the configured posture);
+//   - the footer shows the FIX (set your registry to the approved one), never
+//     ARMIS_SUPPLY_CHAIN=off — that would train devs toward disabling ALL
+//     enforcement, including age.
+func maybeWarnOffPolicyRegistry(canonicalPMName, approvedURL string) {
+	cfg, _, err := loadConfigUpward(".")
+	if err != nil || cfg == nil || cfg.RegistryEnforcement != "warn" {
+		return
+	}
+
+	effHost, ok := effectiveRegistryHost(canonicalPMName)
+	if !ok {
+		return // no EXPLICIT effective registry → not a trigger (silent default is fine)
+	}
+
+	approvedHost, ok := urlHost(approvedURL)
+	if !ok || effHost == approvedHost {
+		return // matches approved (or unparseable) → nothing to warn about
+	}
+
+	if !shouldShowRegistryWarning() {
+		return // already shown this session
+	}
+
+	s := output.GetStyles()
+	fmt.Fprintf(os.Stderr, "\n%s %s\n",
+		s.MutedText.Render(scPrefix),
+		s.WarningText.Render(fmt.Sprintf("supply-chain: your %s registry (%s) is not the approved registry", canonicalPMName, effHost)))
+	fmt.Fprintf(os.Stderr, "  %s %s\n",
+		s.MutedText.Render("Fix:"),
+		s.Bold.Render(fmt.Sprintf("set your registry to %s", approvedURL)))
+	markRegistryWarningShown()
+}
+
+// registryWarningMarkerFile records that the once-per-session off-policy
+// registry warning has been shown, mirroring rationaleMarkerFile.
+const registryWarningMarkerFile = "supply-chain-registry-warned"
+
+// shouldShowRegistryWarning reports whether to print the off-policy registry
+// warning: on an interactive terminal and not already shown this session.
+// Mirrors shouldShowRationale so CI/piped output stays terse.
+func shouldShowRegistryWarning() bool {
+	if !cli.IsInteractive() {
+		return false
+	}
+	path := util.GetCacheFilePath(registryWarningMarkerFile)
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err != nil
+}
+
+// markRegistryWarningShown creates the once-per-session marker. Best-effort: any
+// failure is ignored so a marker-write error never blocks an install.
+func markRegistryWarningShown() {
+	dir := util.GetCacheDir()
+	if dir == "" {
+		return
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return
+	}
+	path := util.GetCacheFilePath(registryWarningMarkerFile)
+	if path == "" {
+		return
+	}
+	_ = os.WriteFile(path, []byte("1"), 0o600)
+}

--- a/internal/cmd/supply_chain_registry.go
+++ b/internal/cmd/supply_chain_registry.go
@@ -146,6 +146,7 @@ func basicAuthFromIndexURL(rawIndexURL string) (string, bool, error) {
 	if !ok {
 		return "", false, nil
 	}
+	// armis:ignore cwe:522 reason:base64-encoding is the standard HTTP Basic Authorization header encoding (RFC 7617), not a secrecy mechanism; the credential is sent only to the registry URL that resolveUpstreamAuth's caller has validated via supplychain.ValidateRegistryURL (https-only), same as the HTTPS-enforced credential pattern already suppressed in internal/auth/client.go
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte(cred)), true, nil
 }
 
@@ -153,6 +154,7 @@ func basicAuthFromIndexURL(rawIndexURL string) (string, bool, error) {
 // preferring the ARMIS_REGISTRY_CA_BUNDLE env var over the config field so a
 // per-runner override works without editing the committed policy.
 func resolveCABundlePath(cfg *supplychain.Config) string {
+	// armis:ignore cwe:295 reason:ARMIS_REGISTRY_CA_BUNDLE is an operator-set env var (the deploying platform team's own file path), not attacker-controlled; every caller of this value (NewRegistryHTTPClient in supply_chain_check.go and supply_chain_wrap.go) is already suppressed for the same reason
 	if v := os.Getenv(envRegistryCABundle); v != "" {
 		return v
 	}

--- a/internal/cmd/supply_chain_registry_test.go
+++ b/internal/cmd/supply_chain_registry_test.go
@@ -1,0 +1,254 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ArmisSecurity/armis-cli/internal/output"
+	"github.com/ArmisSecurity/armis-cli/internal/supplychain"
+)
+
+// writeProject creates a temp dir with the given .armis-supply-chain.yaml and
+// optional .npmrc, chdirs into it for the test, and returns the dir.
+func writeProject(t *testing.T, configYAML, npmrc string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if configYAML != "" {
+		if err := os.WriteFile(filepath.Join(dir, supplychain.ConfigFileName), []byte(configYAML), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if npmrc != "" {
+		if err := os.WriteFile(filepath.Join(dir, ".npmrc"), []byte(npmrc), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Chdir(dir)
+	return dir
+}
+
+func TestResolveRegistrySettings(t *testing.T) {
+	t.Run("npm with token → bearer auth", func(t *testing.T) {
+		writeProject(t,
+			"version: 1\nregistries:\n  npm: https://nexus.corp/repository/npm-group/\n",
+			"//nexus.corp/repository/npm-group/:_authToken=tok123\n")
+
+		rs, err := resolveRegistrySettings("npm")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !rs.Configured {
+			t.Fatal("expected Configured=true")
+		}
+		if rs.UpstreamURL != "https://nexus.corp/repository/npm-group/" {
+			t.Errorf("UpstreamURL = %q", rs.UpstreamURL)
+		}
+		if rs.AuthHeader != "Bearer tok123" {
+			t.Errorf("AuthHeader = %q", rs.AuthHeader)
+		}
+		if !rs.authFound {
+			t.Error("authFound should be true")
+		}
+	})
+
+	t.Run("npm without token → no auth, still configured", func(t *testing.T) {
+		writeProject(t,
+			"version: 1\nregistries:\n  npm: https://nexus.corp/repository/npm-group/\n", "")
+
+		rs, err := resolveRegistrySettings("npm")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !rs.Configured || rs.AuthHeader != "" || rs.authFound {
+			t.Errorf("expected configured-but-no-auth, got %+v", rs)
+		}
+	})
+
+	t.Run("no registries → not configured", func(t *testing.T) {
+		writeProject(t, "version: 1\nmin-age: 72h\n", "")
+		rs, err := resolveRegistrySettings("npm")
+		if err != nil || rs.Configured {
+			t.Errorf("expected not configured, got %+v err=%v", rs, err)
+		}
+	})
+
+	t.Run("unset ${VAR} token → hard error", func(t *testing.T) {
+		writeProject(t,
+			"version: 1\nregistries:\n  npm: https://nexus.corp/repository/npm-group/\n",
+			"//nexus.corp/repository/npm-group/:_authToken=${ARMIS_UNSET_WRAP_VAR}\n")
+
+		_, err := resolveRegistrySettings("npm")
+		if err == nil {
+			t.Fatal("expected a hard error for an unset token var")
+		}
+	})
+
+	t.Run("pip index-url userinfo → basic auth", func(t *testing.T) {
+		writeProject(t,
+			"version: 1\nregistries:\n  pypi: https://nexus.corp/repository/pypi-group/simple/\n", "")
+		t.Setenv("PIP_INDEX_URL", "https://user:pass@nexus.corp/repository/pypi-group/simple/")
+
+		rs, err := resolveRegistrySettings("pip")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass"))
+		if rs.AuthHeader != want {
+			t.Errorf("AuthHeader = %q, want %q", rs.AuthHeader, want)
+		}
+	})
+
+	t.Run("maven is not routable", func(t *testing.T) {
+		writeProject(t,
+			"version: 1\nregistries:\n  npm: https://nexus.corp/npm/\n", "")
+		rs, err := resolveRegistrySettings("mvn")
+		if err != nil || rs.Configured {
+			t.Errorf("maven should not be routable, got %+v", rs)
+		}
+	})
+}
+
+// TestEffectiveRegistryHost is test-plan case #13: explicit off-policy is
+// detected; a silent/default public registry is NOT (returns not-ok).
+func TestEffectiveRegistryHost(t *testing.T) {
+	t.Run("explicit npm_config_registry env", func(t *testing.T) {
+		writeProject(t, "version: 1\n", "")
+		t.Setenv("npm_config_registry", "https://registry.npmjs.org/")
+		host, ok := effectiveRegistryHost("npm")
+		if !ok || host != "registry.npmjs.org" {
+			t.Errorf("host=%q ok=%v", host, ok)
+		}
+	})
+
+	t.Run("explicit registry= in .npmrc", func(t *testing.T) {
+		writeProject(t, "version: 1\n", "registry=https://registry.npmjs.org/\n")
+		t.Setenv("npm_config_registry", "")
+		host, ok := effectiveRegistryHost("npm")
+		if !ok || host != "registry.npmjs.org" {
+			t.Errorf("host=%q ok=%v", host, ok)
+		}
+	})
+
+	t.Run("no explicit source → not ok (silent default not a trigger)", func(t *testing.T) {
+		writeProject(t, "version: 1\n", "")
+		t.Setenv("npm_config_registry", "")
+		_, ok := effectiveRegistryHost("npm")
+		if ok {
+			t.Error("a silent/default registry must NOT be an explicit off-policy trigger")
+		}
+	})
+
+	t.Run("scoped registry key is ignored", func(t *testing.T) {
+		// A @scope:registry= line must not be read as the default registry (v1
+		// explicitly excludes scoped-registry divergence).
+		writeProject(t, "version: 1\n", "@myorg:registry=https://npm.pkg.github.com/\n")
+		t.Setenv("npm_config_registry", "")
+		_, ok := effectiveRegistryHost("npm")
+		if ok {
+			t.Error("a scoped @x:registry= must not count as the default registry")
+		}
+	})
+
+	t.Run("pip PIP_INDEX_URL env", func(t *testing.T) {
+		writeProject(t, "version: 1\n", "")
+		t.Setenv("PIP_INDEX_URL", "https://pypi.org/simple/")
+		host, ok := effectiveRegistryHost("pip")
+		if !ok || host != "pypi.org" {
+			t.Errorf("host=%q ok=%v", host, ok)
+		}
+	})
+}
+
+// TestWrapDryRun verifies --dry-run reports the resolved registry and never
+// executes the package manager.
+func TestWrapDryRun(t *testing.T) {
+	writeProject(t,
+		"version: 1\nregistries:\n  npm: https://nexus.corp/repository/npm-group/\nregistry-enforcement: warn\n",
+		"//nexus.corp/repository/npm-group/:_authToken=tok\n")
+	t.Setenv(envSCActive, "")
+	t.Setenv(envSCOff, "")
+
+	cap := stubExecPM(t, 0)
+	err := runSupplyChainWrap(newWrapTestCmd(), []string{"--dry-run", "npm", "install", "express"})
+	if err != nil {
+		t.Fatalf("dry-run returned error: %v", err)
+	}
+	if cap.called {
+		t.Error("--dry-run must NOT execute the package manager")
+	}
+}
+
+func TestWrapDryRunRequiresPM(t *testing.T) {
+	err := runSupplyChainWrap(newWrapTestCmd(), []string{"--dry-run"})
+	if err == nil {
+		t.Fatal("--dry-run with no PM should error")
+	}
+}
+
+// TestRegistryCoverageHonesty is test-plan case #16 (E4/DX3): with registries.npm
+// set but registries.pypi absent, a pip check must say "not configured — public
+// registry" rather than implying coverage; and an npm check shows the host.
+func TestRegistryCoverageHonesty(t *testing.T) {
+	forceNoColor(t)
+	npmOnly := "version: 1\nregistries:\n  npm: https://nexus.corp/repository/npm-group/\n"
+
+	t.Run("pip reports not configured when only npm is set", func(t *testing.T) {
+		dir := writeProject(t, npmOnly, "")
+		cfg, err := supplychain.LoadConfig(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := output.GetStyles()
+		out := captureStderr(t, func() {
+			printRegistryCoverage(s, cfg, supplychain.EcosystemPip, cfg.RegistryURLFor(supplychain.EcosystemPip), 0)
+		})
+		if !strings.Contains(out, "not configured") || !strings.Contains(out, "pip") {
+			t.Errorf("pip coverage should say 'not configured', got: %q", out)
+		}
+	})
+
+	t.Run("npm reports the configured host", func(t *testing.T) {
+		dir := writeProject(t, npmOnly, "")
+		cfg, _ := supplychain.LoadConfig(dir)
+		s := output.GetStyles()
+		out := captureStderr(t, func() {
+			printRegistryCoverage(s, cfg, supplychain.EcosystemNPM, cfg.RegistryURLFor(supplychain.EcosystemNPM), 5)
+		})
+		if !strings.Contains(out, "nexus.corp") || !strings.Contains(out, "npm") {
+			t.Errorf("npm coverage should name the host, got: %q", out)
+		}
+	})
+
+	t.Run("no header when no registry configured", func(t *testing.T) {
+		dir := writeProject(t, "version: 1\nmin-age: 72h\n", "")
+		cfg, _ := supplychain.LoadConfig(dir)
+		s := output.GetStyles()
+		out := captureStderr(t, func() {
+			printRegistryCoverage(s, cfg, supplychain.EcosystemNPM, "", 0)
+		})
+		if strings.Contains(out, "Registry coverage") {
+			t.Errorf("no coverage header expected when no registry configured, got: %q", out)
+		}
+	})
+}
+
+func TestBasicAuthFromIndexURL(t *testing.T) {
+	t.Run("with userinfo", func(t *testing.T) {
+		h, ok, err := basicAuthFromIndexURL("https://u:p@nexus.corp/simple/")
+		if err != nil || !ok {
+			t.Fatalf("ok=%v err=%v", ok, err)
+		}
+		if !strings.HasPrefix(h, "Basic ") {
+			t.Errorf("header = %q", h)
+		}
+	})
+	t.Run("empty url", func(t *testing.T) {
+		_, ok, _ := basicAuthFromIndexURL("")
+		if ok {
+			t.Error("empty url should yield no auth")
+		}
+	})
+}

--- a/internal/cmd/supply_chain_wrap.go
+++ b/internal/cmd/supply_chain_wrap.go
@@ -75,7 +75,26 @@ var allowedPMs = map[string]bool{
 // runProxyWrap/runPreInstallBlock unit-testable.
 var execPMFunc = execPM
 
+// scWrapDryRun, when set, makes runProxyWrap resolve and report the registry
+// configuration (approved registry, whether auth/timestamps were found) without
+// running the package manager (DX6). Because the wrap command sets
+// DisableFlagParsing (so PM flags pass through verbatim), it is recognized only
+// as a LEADING token before the PM name — `wrap --dry-run npm install` — which
+// cannot collide with a package manager's own flags.
+var scWrapDryRun bool
+
 func runSupplyChainWrap(cmd *cobra.Command, args []string) error {
+	// Strip a leading --dry-run (armis's own flag) before the PM name. Reset each
+	// call so the package-level var never leaks across invocations in tests.
+	scWrapDryRun = false
+	if len(args) > 0 && args[0] == "--dry-run" {
+		scWrapDryRun = true
+		args = args[1:]
+		if len(args) == 0 {
+			return fmt.Errorf("wrap --dry-run requires a package manager name")
+		}
+	}
+
 	// pmName is the exact command the user invoked (e.g. "pip3.12"); execName is
 	// the binary actually run. canonicalPM collapses pip variants (pip3, pip3.12)
 	// to "pip" for every policy decision — the allowlist, pre-install routing, and
@@ -87,6 +106,14 @@ func runSupplyChainWrap(cmd *cobra.Command, args []string) error {
 
 	if !allowedPMs[canonical] {
 		return fmt.Errorf("unsupported package manager: %s (allowed: npm, npx, pnpm, bun, yarn, pip, uv, uvx, poetry, pipenv, pdm, mvn, gradle)", pmName)
+	}
+
+	// --dry-run resolves and reports the registry configuration without running
+	// the package manager (DX6). It short-circuits every execution path so it is
+	// always safe to run, including for audit-path PMs (which report "no proxy
+	// registry routing in this version").
+	if scWrapDryRun {
+		return runWrapDryRun(pmName)
 	}
 
 	if os.Getenv(envSCActive) == "1" {
@@ -170,6 +197,27 @@ func runProxyWrap(cmd *cobra.Command, pmName string, pmArgs []string) error {
 		}
 	}
 
+	// Resolve the approved registry + credentials for this ecosystem (PPSC-994).
+	// A zero-value result keeps the proxy on the public-registry path with the
+	// pre-existing behavior unchanged. A credential-resolution error (unset
+	// ${VAR}, bad token charset) is fatal — a misconfigured credential must fail
+	// loudly, not silently fall through to an unauthenticated 401.
+	rs, err := resolveRegistrySettings(canonicalPM(pmName))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[armis] supply-chain: registry credential error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// When an approved registry is configured, validate it once more here (S1)
+	// before constructing a proxy that forwards credentials to it — defense in
+	// depth even though LoadConfig already validated it.
+	if rs.Configured {
+		if _, verr := supplychain.ValidateRegistryURL(rs.UpstreamURL); verr != nil {
+			fmt.Fprintf(os.Stderr, "[armis] supply-chain: invalid approved registry, falling through: %v\n", verr)
+			return exitWithCode(execPMFunc(pmName, pmArgs, nil))
+		}
+	}
+
 	cfg := supplychain.ProxyConfig{
 		Policy:       policy,
 		Mode:         mode,
@@ -177,7 +225,20 @@ func runProxyWrap(cmd *cobra.Command, pmName string, pmArgs []string) error {
 		// Pass nil when undeterminable so the proxy treats every package as direct
 		// (fail-safe block). When warn is off, directDeps is nil too — harmless,
 		// since the proxy never consults it under the block policy.
-		DirectDeps: directDeps,
+		DirectDeps:   directDeps,
+		UpstreamURL:  rs.UpstreamURL,
+		AuthHeader:   rs.AuthHeader,
+		CABundlePath: rs.CABundlePath,
+		// Degrade gracefully on missing timestamps ONLY for a configured
+		// artifactory upstream; the default public path stays fail-closed.
+		DegradeOnMissingTimestamps: rs.Configured,
+	}
+
+	// The soft routing warning fires before the install when the developer's
+	// effective registry is EXPLICITLY off-policy (DX1). It is rate-limited to
+	// once per shell session and never trains the user toward the kill switch.
+	if rs.Configured {
+		maybeWarnOffPolicyRegistry(canonicalPM(pmName), rs.ApprovedURL)
 	}
 
 	proxy, err := supplychain.NewProxy(cfg)
@@ -212,7 +273,13 @@ func runProxyWrap(cmd *cobra.Command, pmName string, pmArgs []string) error {
 	// the wrapper. Sweep those artifacts and rewrite the origin back to the real
 	// upstream — even when the PM exited non-zero, since a failed install can
 	// still have rewritten the lockfile first.
-	normalizeProxyResidue(canonicalPM(pmName), pmArgs, "http://"+addr, proxy.Upstream())
+	// Strip any embedded userinfo from the upstream origin before it becomes the
+	// rewrite target (S3): a credential must never be written into a lockfile.
+	// proxy.Upstream() is already userinfo-free for a registries.<eco> URL
+	// (validated to carry none), but stripping defensively covers any future
+	// origin derived from an index-url that did carry userinfo.
+	upstreamOrigin := supplychain.StripURLUserinfo(proxy.Upstream())
+	normalizeProxyResidue(canonicalPM(pmName), pmArgs, "http://"+addr, upstreamOrigin)
 
 	// installOK reflects what the package manager actually did, not what the proxy
 	// offered: proxy.Allowed() only records the version "latest" was repointed to,

--- a/internal/cmd/supply_chain_wrap.go
+++ b/internal/cmd/supply_chain_wrap.go
@@ -1286,6 +1286,7 @@ func runPreInstallBlock(cmd *cobra.Command, pmName string, pmArgs []string) erro
 		if _, verr := supplychain.ValidateRegistryURL(rs.UpstreamURL); verr != nil {
 			fmt.Fprintf(os.Stderr, "[armis] supply-chain: invalid approved registry, checking against the public registry: %v\n", verr)
 		} else {
+			// armis:ignore cwe:295 cwe:918 reason:this branch only runs after ValidateRegistryURL returned no error on the line above (https-only, no userinfo, rejects loopback/RFC1918/link-local) — the same validated-then-used pattern already suppressed at every other ValidateRegistryURL call site in this codebase (supply_chain_check.go, proxy.go); rs.CABundlePath below is separately the operator-supplied ARMIS_REGISTRY_CA_BUNDLE env or committed config path, not attacker-controlled
 			registryURL = rs.UpstreamURL
 			registryHTTPClient, err = supplychain.NewRegistryHTTPClient(registryURL, rs.CABundlePath)
 			if err != nil {

--- a/internal/cmd/supply_chain_wrap.go
+++ b/internal/cmd/supply_chain_wrap.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -301,7 +302,7 @@ func runProxyWrap(cmd *cobra.Command, pmName string, pmArgs []string) error {
 
 	warned := proxy.Warned()
 	printWarnThroughSummary(warned, policy)
-	printBlockSummary(proxy.Blocked(), proxy.Allowed(), proxy.Checked(), policy, pmName, installOK, pmArgs, conflicts)
+	printBlockSummary(proxy.Blocked(), proxy.Allowed(), proxy.Checked(), proxy.VerifyFailed(), policy, pmName, installOK, pmArgs, conflicts)
 
 	// WS3 compliance report: written post-install when ARMIS_SUPPLY_CHAIN_REPORT
 	// is set. Best-effort — a report write never changes the install's exit code.
@@ -472,10 +473,27 @@ type pkgFilterResult struct {
 	NewAge     time.Duration  // age of the resolved version, 0 when unknown
 }
 
-func printBlockSummary(blocked []supplychain.BlockedPackage, allowed []supplychain.InstalledPackage, checked int, policy supplychain.Policy, pmName string, installOK bool, pmArgs []string, conflicts []supplychain.ConstraintConflict) {
+func printBlockSummary(blocked []supplychain.BlockedPackage, allowed []supplychain.InstalledPackage, checked, verifyFailed int, policy supplychain.Policy, pmName string, installOK bool, pmArgs []string, conflicts []supplychain.ConstraintConflict) {
 	s := output.GetStyles()
 
 	if len(blocked) == 0 {
+		// verifyFailed packages were counted in `checked` but their age could not
+		// actually be verified (upstream unreachable, untrusted TLS, unreadable
+		// response — the fail-closed paths). A green "N checked, all pass" here
+		// would overstate coverage the org did not get and contradict the TLS/error
+		// lines already on stderr, so report the failures honestly instead. The
+		// install itself fails-closed on those packages (the proxy returned 502),
+		// so this is a reporting-honesty fix, not an enforcement change.
+		if verifyFailed > 0 {
+			verified := checked - verifyFailed
+			fmt.Fprintf(os.Stderr, "%s %s %s %s\n",
+				s.MutedText.Render(scPrefix),
+				s.WarningText.Render("⚠"),
+				s.WarningText.Render(fmt.Sprintf("supply-chain: %s could not be verified against the registry (age not checked); %s",
+					countNoun(verifyFailed, "package"), verifiedClause(verified))),
+				s.MutedText.Render(fmt.Sprintf("(%s policy)", formatPolicyShort(policy.MinReleaseAge))))
+			return
+		}
 		if checked > 0 {
 			fmt.Fprintf(os.Stderr, "%s %s %s %s\n",
 				s.MutedText.Render(scPrefix),
@@ -933,6 +951,16 @@ func groupBlockedByPackage(blocked []supplychain.BlockedPackage, allowedVersions
 	return results
 }
 
+// verifiedClause renders the trailing "N passed" / "no other packages verified"
+// half of the partial-verification warning, so the summary states how many
+// checks did succeed alongside the ones that could not run.
+func verifiedClause(verified int) string {
+	if verified <= 0 {
+		return "no packages could be age-checked"
+	}
+	return fmt.Sprintf("%s passed", countNoun(verified, "package"))
+}
+
 // checkedAllPass renders the "N packages checked, all pass" clause with verb
 // agreement: countNoun inflects the noun ("1 package" vs "N packages") but not
 // the verb, so the singular case collapses "all pass" → "passed" ("all" implies
@@ -1239,10 +1267,39 @@ func runPreInstallBlock(cmd *cobra.Command, pmName string, pmArgs []string) erro
 		fmt.Fprintf(os.Stderr, "  coverage, consider a lockfile plugin (e.g., io.github.chains-project:maven-lockfile)\n")
 	}
 
+	// Resolve the approved registry + credentials for this ecosystem (PPSC-994),
+	// same as runProxyWrap. Without this, the audit path (poetry/pipenv/pdm/
+	// maven/gradle, and any uv invocation that writes uv.lock) always queried
+	// the PUBLIC registry regardless of a configured registries.<eco>, silently
+	// never checking the approved artifactory at all — `check` would report
+	// "all pass" having verified nothing against it. A credential-resolution
+	// error is fatal, matching runProxyWrap's fail-loud contract.
+	rs, err := resolveRegistrySettings(canonicalPM(pmName))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[armis] supply-chain: registry credential error: %v\n", err)
+		os.Exit(1)
+	}
+
+	var registryURL string
+	var registryHTTPClient *http.Client
+	if rs.Configured {
+		if _, verr := supplychain.ValidateRegistryURL(rs.UpstreamURL); verr != nil {
+			fmt.Fprintf(os.Stderr, "[armis] supply-chain: invalid approved registry, checking against the public registry: %v\n", verr)
+		} else {
+			registryURL = rs.UpstreamURL
+			registryHTTPClient, err = supplychain.NewRegistryHTTPClient(registryURL, rs.CABundlePath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "[armis] supply-chain: registry TLS trust error: %v\n", err)
+				os.Exit(1)
+			}
+			maybeWarnOffPolicyRegistry(canonicalPM(pmName), rs.ApprovedURL)
+		}
+	}
+
 	ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
 	defer cancel()
 
-	result, err := check.RunCheck(ctx, policy, lockfilePath, "")
+	result, err := check.RunCheckWithRegistryClient(ctx, policy, lockfilePath, "", registryURL, registryHTTPClient, rs.AuthHeader)
 	if err != nil {
 		// Honor the fail-open policy the same way the proxy path does: with
 		// FailOpen set, a failed audit (e.g. PyPI unreachable, lockfile parse

--- a/internal/cmd/supply_chain_wrap_summary_test.go
+++ b/internal/cmd/supply_chain_wrap_summary_test.go
@@ -65,7 +65,7 @@ func TestPrintBlockSummary_AllPass(t *testing.T) {
 	// uses countNoun (no "(s)").
 	forceNoColor(t)
 	out := captureStderr(t, func() {
-		printBlockSummary(nil, nil, 12, testPolicy(), pmNPM, true, nil, nil)
+		printBlockSummary(nil, nil, 12, 0, testPolicy(), pmNPM, true, nil, nil)
 	})
 	if !strings.Contains(out, "12 packages checked, all pass") {
 		t.Errorf("missing all-pass line; got:\n%s", out)
@@ -85,7 +85,7 @@ func TestPrintBlockSummary_AllPassSingular(t *testing.T) {
 	// ("all" implies more than one).
 	forceNoColor(t)
 	out := captureStderr(t, func() {
-		printBlockSummary(nil, nil, 1, testPolicy(), pmNPM, true, nil, nil)
+		printBlockSummary(nil, nil, 1, 0, testPolicy(), pmNPM, true, nil, nil)
 	})
 	if !strings.Contains(out, "1 package checked, passed") {
 		t.Errorf("singular all-pass line should read \"1 package checked, passed\"; got:\n%s", out)
@@ -95,11 +95,48 @@ func TestPrintBlockSummary_AllPassSingular(t *testing.T) {
 	}
 }
 
+func TestPrintBlockSummary_VerifyFailedNotAllPass(t *testing.T) {
+	// Bug #2b regression: when some checked packages could not be verified against
+	// the registry (e.g. wrong registry-ca-bundle → TLS failure), the summary must
+	// NOT print a green "all pass" — it must warn that N could not be verified.
+	forceNoColor(t)
+	out := captureStderr(t, func() {
+		// 3 checked, all 3 failed to verify.
+		printBlockSummary(nil, nil, 3, 3, testPolicy(), pmNPM, false, []string{"install"}, nil)
+	})
+	if strings.Contains(out, "all pass") || strings.Contains(out, "checked, passed") {
+		t.Errorf("must not claim success when checks failed to verify; got:\n%s", out)
+	}
+	if !strings.Contains(out, "could not be verified") {
+		t.Errorf("expected a 'could not be verified' warning; got:\n%s", out)
+	}
+	if !strings.Contains(out, "no packages could be age-checked") {
+		t.Errorf("with 0 verified, expected 'no packages could be age-checked'; got:\n%s", out)
+	}
+}
+
+func TestPrintBlockSummary_VerifyFailedPartial(t *testing.T) {
+	// Mixed: 5 checked, 2 failed → warn about the 2, credit the 3 that passed.
+	forceNoColor(t)
+	out := captureStderr(t, func() {
+		printBlockSummary(nil, nil, 5, 2, testPolicy(), pmNPM, false, []string{"install"}, nil)
+	})
+	if strings.Contains(out, "all pass") {
+		t.Errorf("partial-verify must not claim 'all pass'; got:\n%s", out)
+	}
+	if !strings.Contains(out, "2 packages could not be verified") {
+		t.Errorf("expected '2 packages could not be verified'; got:\n%s", out)
+	}
+	if !strings.Contains(out, "3 packages passed") {
+		t.Errorf("expected '3 packages passed' credit; got:\n%s", out)
+	}
+}
+
 func TestPrintBlockSummary_AllPassZeroChecked(t *testing.T) {
 	// Nothing checked → nothing printed (e.g. a fully cached install).
 	forceNoColor(t)
 	out := captureStderr(t, func() {
-		printBlockSummary(nil, nil, 0, testPolicy(), pmNPM, true, nil, nil)
+		printBlockSummary(nil, nil, 0, 0, testPolicy(), pmNPM, true, nil, nil)
 	})
 	if out != "" {
 		t.Errorf("expected no output when nothing was checked; got:\n%s", out)
@@ -115,7 +152,7 @@ func TestPrintBlockSummary_SingleResolved(t *testing.T) {
 	allowed := []supplychain.InstalledPackage{{Name: "axios", Version: "1.16.1", Age: 10 * 24 * time.Hour}}
 
 	out := captureStderr(t, func() {
-		printBlockSummary(blocked, allowed, 5, testPolicy(), pmNPM, true, nil, nil)
+		printBlockSummary(blocked, allowed, 5, 0, testPolicy(), pmNPM, true, nil, nil)
 	})
 
 	wantSubstrings := []string{
@@ -164,7 +201,7 @@ func TestPrintBlockSummary_PyPIFilenameNotPrerelease(t *testing.T) {
 	}
 
 	out := captureStderr(t, func() {
-		printBlockSummary(blocked, allowed, 2, testPolicy(), pmUV, true, nil, nil)
+		printBlockSummary(blocked, allowed, 2, 0, testPolicy(), pmUV, true, nil, nil)
 	})
 
 	if strings.Contains(out, "withheld") || strings.Contains(out, "a default install was unaffected") {
@@ -202,7 +239,7 @@ func TestPrintBlockSummary_UnparseableFilenameNotPrerelease(t *testing.T) {
 	allowed := []supplychain.InstalledPackage{{Name: "filelock", Version: "3.29.1", Age: 9 * 24 * time.Hour}}
 
 	out := captureStderr(t, func() {
-		printBlockSummary(blocked, allowed, 1, testPolicy(), pmUV, true, nil, nil)
+		printBlockSummary(blocked, allowed, 1, 0, testPolicy(), pmUV, true, nil, nil)
 	})
 
 	if strings.Contains(out, "withheld") || strings.Contains(out, "a default install was unaffected") {
@@ -224,7 +261,7 @@ func TestPrintBlockSummary_UndatableSkippedOmitsAge(t *testing.T) {
 	allowed := []supplychain.InstalledPackage{{Name: "mystery", Version: "0.9.0", Age: 30 * 24 * time.Hour}}
 
 	out := captureStderr(t, func() {
-		printBlockSummary(blocked, allowed, 1, testPolicy(), pmUV, true, nil, nil)
+		printBlockSummary(blocked, allowed, 1, 0, testPolicy(), pmUV, true, nil, nil)
 	})
 
 	if strings.Contains(out, "0 minutes old") {
@@ -250,7 +287,7 @@ func TestPrintBlockSummary_MixedUnresolved(t *testing.T) {
 	allowed := []supplychain.InstalledPackage{{Name: "axios", Version: "1.16.1"}}
 
 	out := captureStderr(t, func() {
-		printBlockSummary(blocked, allowed, 7, testPolicy(), pmNPM, true, nil, nil)
+		printBlockSummary(blocked, allowed, 7, 0, testPolicy(), pmNPM, true, nil, nil)
 	})
 
 	if !strings.Contains(out, "filtered 2 too-new releases (3-day policy)") {
@@ -279,7 +316,7 @@ func TestPrintBlockSummary_InstallFailed(t *testing.T) {
 	allowed := []supplychain.InstalledPackage{{Name: "axios", Version: "1.16.1"}}
 
 	out := captureStderr(t, func() {
-		printBlockSummary(blocked, allowed, 5, testPolicy(), pmNPM, false, []string{"install"}, nil)
+		printBlockSummary(blocked, allowed, 5, 0, testPolicy(), pmNPM, false, []string{"install"}, nil)
 	})
 
 	if !strings.Contains(out, "install did not complete") {
@@ -320,7 +357,7 @@ func TestPrintBlockSummary_NoFallbackNamesCulprit(t *testing.T) {
 	blocked := []supplychain.BlockedPackage{{Name: "leftpad", Version: "2.0.0", DisplayVersion: "2.0.0", Age: 3 * time.Hour}}
 	// No allowed entry → no safe fallback.
 	out := captureStderr(t, func() {
-		printBlockSummary(blocked, nil, 5, testPolicy(), pmNPM, false, []string{"install"}, nil)
+		printBlockSummary(blocked, nil, 5, 0, testPolicy(), pmNPM, false, []string{"install"}, nil)
 	})
 
 	if !strings.Contains(out, "leftpad@2.0.0") {
@@ -344,7 +381,7 @@ func TestPrintBlockSummary_ConflictNamesDependentAndRange(t *testing.T) {
 	conflicts := []supplychain.ConstraintConflict{{Dep: "scheduler", Range: "^0.24.0", ByPkg: "react-dom"}}
 
 	out := captureStderr(t, func() {
-		printBlockSummary(blocked, allowed, 5, testPolicy(), pmNPM, false, []string{"install"}, conflicts)
+		printBlockSummary(blocked, allowed, 5, 0, testPolicy(), pmNPM, false, []string{"install"}, conflicts)
 	})
 
 	flat := strings.Join(strings.Fields(out), " ")
@@ -363,7 +400,7 @@ func TestPrintFailureCulprits_PipAttributionGap(t *testing.T) {
 	forceNoColor(t)
 	blocked := []supplychain.BlockedPackage{{Name: "requests", Version: "requests-2.99.0.tar.gz", DisplayVersion: "2.99.0", Age: 2 * time.Hour}}
 	out := captureStderr(t, func() {
-		printBlockSummary(blocked, nil, 5, testPolicy(), pmPip, false, []string{"install", "requests"}, nil)
+		printBlockSummary(blocked, nil, 5, 0, testPolicy(), pmPip, false, []string{"install", "requests"}, nil)
 	})
 
 	if !strings.Contains(out, "constraint attribution isn't available for pip/uv") {
@@ -386,7 +423,7 @@ func TestPrintBlockSummary_OnlyPrerelease(t *testing.T) {
 	allowed := []supplychain.InstalledPackage{{Name: "axios", Version: "1.16.1"}}
 
 	out := captureStderr(t, func() {
-		printBlockSummary(blocked, allowed, 5, testPolicy(), pmNPM, true, nil, nil)
+		printBlockSummary(blocked, allowed, 5, 0, testPolicy(), pmNPM, true, nil, nil)
 	})
 
 	if !strings.Contains(out, "withheld 1 prerelease") {
@@ -415,7 +452,7 @@ func TestPrintBlockSummary_StableStillClaimsFilter(t *testing.T) {
 	allowed := []supplychain.InstalledPackage{{Name: "axios", Version: "1.16.1"}}
 
 	out := captureStderr(t, func() {
-		printBlockSummary(blocked, allowed, 5, testPolicy(), pmNPM, true, nil, nil)
+		printBlockSummary(blocked, allowed, 5, 0, testPolicy(), pmNPM, true, nil, nil)
 	})
 
 	if !strings.Contains(out, "installed safe version") {
@@ -467,7 +504,7 @@ func TestPrintBlockSummary_LongListVerbose(t *testing.T) {
 	}
 
 	out := captureStderr(t, func() {
-		printBlockSummary(blocked, allowed, len(names), testPolicy(), pmNPM, true, nil, nil)
+		printBlockSummary(blocked, allowed, len(names), 0, testPolicy(), pmNPM, true, nil, nil)
 	})
 
 	if !strings.Contains(out, "… and 1 more") {

--- a/internal/cmd/supply_chain_wrap_summary_test.go
+++ b/internal/cmd/supply_chain_wrap_summary_test.go
@@ -192,7 +192,7 @@ func TestPrintBlockSummary_UninstallReframesWording(t *testing.T) {
 	allowed := []supplychain.InstalledPackage{{Name: "axios", Version: "1.16.1", Age: 10 * 24 * time.Hour}}
 
 	out := captureStderr(t, func() {
-		printBlockSummary(blocked, allowed, 5, testPolicy(), pmNPM, true, []string{"uninstall", "vercel"}, nil)
+		printBlockSummary(blocked, allowed, 5, 0, testPolicy(), pmNPM, true, []string{"uninstall", "vercel"}, nil)
 	})
 
 	wantSubstrings := []string{
@@ -220,7 +220,7 @@ func TestPrintBlockSummary_UninstallFailureNamesRealVerb(t *testing.T) {
 	blocked := []supplychain.BlockedPackage{{Name: "axios", Version: "1.17.0", DisplayVersion: "1.17.0", Age: 24 * time.Hour}}
 
 	out := captureStderr(t, func() {
-		printBlockSummary(blocked, nil, 5, testPolicy(), pmNPM, false, []string{"remove", "axios"}, nil)
+		printBlockSummary(blocked, nil, 5, 0, testPolicy(), pmNPM, false, []string{"remove", "axios"}, nil)
 	})
 
 	wantSubstrings := []string{
@@ -244,7 +244,7 @@ func TestPrintBlockSummary_FailedUninstallNeverSaysKept(t *testing.T) {
 	allowed := []supplychain.InstalledPackage{{Name: "axios", Version: "1.16.1", Age: 10 * 24 * time.Hour}}
 
 	out := captureStderr(t, func() {
-		printBlockSummary(blocked, allowed, 5, testPolicy(), pmNPM, false, []string{"uninstall", "vercel"}, nil)
+		printBlockSummary(blocked, allowed, 5, 0, testPolicy(), pmNPM, false, []string{"uninstall", "vercel"}, nil)
 	})
 
 	if strings.Contains(out, "kept") {

--- a/internal/cmd/supply_chain_wrap_test.go
+++ b/internal/cmd/supply_chain_wrap_test.go
@@ -428,6 +428,28 @@ func TestRunPreInstallBlock_QueriesConfiguredRegistry(t *testing.T) {
 	// means the server's own default cert (issued for "example.com") will not
 	// validate against that hostname, so this test mints its own self-signed cert
 	// for "nexus.localhost" and serves it directly over tls.Listen.
+	//
+	// Resolving "nexus.localhost" to 127.0.0.1 relies on the OS resolver
+	// special-casing *.localhost subdomains — true on Linux (systemd-resolved)
+	// and macOS (mDNSResponder), but NOT on Windows, which only special-cases
+	// the bare "localhost" name and attempts a real (failing) DNS lookup for any
+	// subdomain of it. Override the dialer so this test doesn't depend on that
+	// OS-specific behavior: redirect only the "nexus.localhost" host to 127.0.0.1
+	// at the TCP layer, while SNI/certificate validation (which reads the
+	// original hostname from the request URL, not the dial target) is untouched.
+	origTransport := http.DefaultTransport.(*http.Transport).Clone()
+	testTransport := origTransport.Clone()
+	testTransport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, portStr, splitErr := net.SplitHostPort(addr)
+		// armis:ignore cwe:918 reason:test-only code (this file has no _test.go build exclusion but is never compiled into the shipped binary); the redirected host is a hardcoded string literal ("nexus.localhost", this test's own fixture hostname), not derived from any request URL or other runtime input, so there is nothing here for an attacker to control
+		if splitErr == nil && host == "nexus.localhost" {
+			addr = net.JoinHostPort("127.0.0.1", portStr)
+		}
+		return (&net.Dialer{}).DialContext(ctx, network, addr)
+	}
+	http.DefaultTransport = testTransport
+	t.Cleanup(func() { http.DefaultTransport = origTransport })
+
 	var hit bool
 	certPEM, server, port := newTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		hit = true

--- a/internal/cmd/supply_chain_wrap_test.go
+++ b/internal/cmd/supply_chain_wrap_test.go
@@ -421,28 +421,25 @@ url = "https://github.com/user/repo.git"
 // host queried, using a fake Simple-API server as the "approved" registry and
 // asserting it (not pypi.org) receives the hit.
 func TestRunPreInstallBlock_QueriesConfiguredRegistry(t *testing.T) {
-	// ValidateRegistryURL (S1) rejects a literal loopback IP as a registry host,
-	// so httptest.NewTLSServer's 127.0.0.1 URL cannot be used directly here (a
-	// deliberate SSRF guard, not a test obstacle to route around) — "nexus.localhost"
-	// resolves to 127.0.0.1 without being a literal IP string, so it passes. That
-	// means the server's own default cert (issued for "example.com") will not
-	// validate against that hostname, so this test mints its own self-signed cert
-	// for "nexus.localhost" and serves it directly over tls.Listen.
-	//
-	// Resolving "nexus.localhost" to 127.0.0.1 relies on the OS resolver
-	// special-casing *.localhost subdomains — true on Linux (systemd-resolved)
-	// and macOS (mDNSResponder), but NOT on Windows, which only special-cases
-	// the bare "localhost" name and attempts a real (failing) DNS lookup for any
-	// subdomain of it. Override the dialer so this test doesn't depend on that
-	// OS-specific behavior: redirect only the "nexus.localhost" host to 127.0.0.1
-	// at the TCP layer, while SNI/certificate validation (which reads the
-	// original hostname from the request URL, not the dial target) is untouched.
+	// ValidateRegistryURL (S1) rejects a literal loopback IP, and (as of the
+	// reserved-name fix below) "localhost"/"*.localhost" by name too, as a
+	// registry host — so httptest.NewTLSServer's 127.0.0.1 URL cannot be used
+	// directly here (a deliberate SSRF guard, not a test obstacle to route
+	// around). "nexus.registry.example" is an IANA-reserved documentation domain
+	// (RFC 2606) that passes validation like any real corporate hostname would,
+	// while making clear it is a fixture, not a real host. It never actually
+	// resolves via DNS; the dialer override below redirects it to 127.0.0.1
+	// directly, so no real lookup happens and no OS-specific resolver behavior
+	// (e.g. *.localhost special-casing, absent on Windows) is depended on. The
+	// server's own default cert (issued for "example.com") would not validate
+	// against this hostname, so this test mints its own self-signed cert for
+	// "nexus.registry.example" and serves it directly over tls.Listen.
 	origTransport := http.DefaultTransport.(*http.Transport).Clone()
 	testTransport := origTransport.Clone()
 	testTransport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		host, portStr, splitErr := net.SplitHostPort(addr)
-		// armis:ignore cwe:918 reason:test-only code (this file has no _test.go build exclusion but is never compiled into the shipped binary); the redirected host is a hardcoded string literal ("nexus.localhost", this test's own fixture hostname), not derived from any request URL or other runtime input, so there is nothing here for an attacker to control
-		if splitErr == nil && host == "nexus.localhost" {
+		// armis:ignore cwe:918 reason:test-only code (this file has no _test.go build exclusion but is never compiled into the shipped binary); the redirected host is a hardcoded string literal ("nexus.registry.example", this test's own fixture hostname), not derived from any request URL or other runtime input, so there is nothing here for an attacker to control
+		if splitErr == nil && host == "nexus.registry.example" {
 			addr = net.JoinHostPort("127.0.0.1", portStr)
 		}
 		return (&net.Dialer{}).DialContext(ctx, network, addr)
@@ -470,7 +467,7 @@ func TestRunPreInstallBlock_QueriesConfiguredRegistry(t *testing.T) {
 	if err := os.WriteFile(caBundlePath, certPEM, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	registryURL := fmt.Sprintf("https://nexus.localhost:%s/simple/", port)
+	registryURL := fmt.Sprintf("https://nexus.registry.example:%s/simple/", port)
 	writeConfig(t, dir, "version: 1\nmin-age: 72h\nregistries:\n  pypi: "+registryURL+"\nregistry-enforcement: warn\nregistry-ca-bundle: "+caBundlePath+"\n")
 
 	lock := `version = 1
@@ -496,11 +493,12 @@ version = "1.0.0"
 }
 
 // newTLSTestServer starts an HTTPS server on 127.0.0.1 with a self-signed cert
-// issued for "nexus.localhost" (which resolves to 127.0.0.1 without being a
-// literal IP string, so it passes ValidateRegistryURL's loopback-IP rejection —
-// httptest.NewTLSServer's own cert, issued for "example.com", would not
-// validate against that hostname). It returns the cert as a PEM block (for
-// registry-ca-bundle) alongside the listening server and its port.
+// issued for "nexus.registry.example" — a hostname string, not a literal IP,
+// so it passes ValidateRegistryURL's loopback/reserved-name checks the way a
+// real corporate hostname would. httptest.NewTLSServer's own cert, issued for
+// "example.com", would not validate against that hostname. It returns the
+// cert as a PEM block (for registry-ca-bundle) alongside the listening server
+// and its port.
 func newTLSTestServer(t *testing.T, handler http.HandlerFunc) ([]byte, *httptest.Server, string) {
 	t.Helper()
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -509,8 +507,8 @@ func newTLSTestServer(t *testing.T, handler http.HandlerFunc) ([]byte, *httptest
 	}
 	tmpl := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: "nexus.localhost"},
-		DNSNames:     []string{"nexus.localhost"},
+		Subject:      pkix.Name{CommonName: "nexus.registry.example"},
+		DNSNames:     []string{"nexus.registry.example"},
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(time.Hour),
 		KeyUsage:     x509.KeyUsageDigitalSignature,

--- a/internal/cmd/supply_chain_wrap_test.go
+++ b/internal/cmd/supply_chain_wrap_test.go
@@ -2,6 +2,18 @@ package cmd
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -397,6 +409,109 @@ url = "https://github.com/user/repo.git"
 	if cap.pm != pmPoetry {
 		t.Errorf("pm = %q, want %q", cap.pm, pmPoetry)
 	}
+}
+
+// TestRunPreInstallBlock_QueriesConfiguredRegistry is the regression guard for
+// the bug where the pre-install audit path (poetry/pipenv/pdm/maven/gradle, and
+// any lockfile-writing uv command) always called check.RunCheck — never
+// RunCheckWithRegistry — so a configured registries.<eco> was silently
+// ignored: every age check queried the PUBLIC registry regardless of policy,
+// and `check` would report "all pass" having verified nothing against the
+// approved artifactory. This pins that a configured registry is actually the
+// host queried, using a fake Simple-API server as the "approved" registry and
+// asserting it (not pypi.org) receives the hit.
+func TestRunPreInstallBlock_QueriesConfiguredRegistry(t *testing.T) {
+	// ValidateRegistryURL (S1) rejects a literal loopback IP as a registry host,
+	// so httptest.NewTLSServer's 127.0.0.1 URL cannot be used directly here (a
+	// deliberate SSRF guard, not a test obstacle to route around) — "nexus.localhost"
+	// resolves to 127.0.0.1 without being a literal IP string, so it passes. That
+	// means the server's own default cert (issued for "example.com") will not
+	// validate against that hostname, so this test mints its own self-signed cert
+	// for "nexus.localhost" and serves it directly over tls.Listen.
+	var hit bool
+	certPEM, server, port := newTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		if r.URL.Path != "/simple/leftpad/" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/vnd.pypi.simple.v1+json")
+		_, _ = w.Write([]byte(`{"files":[{"filename":"leftpad-1.0.0-py3-none-any.whl","upload-time":"2020-01-01T00:00:00Z"}]}`))
+	})
+	defer server.Close()
+
+	dir := chdirTemp(t)
+	t.Setenv(envSCActive, "")
+	t.Setenv(envSCOff, "")
+	t.Setenv(envSCSkip, "")
+
+	caBundlePath := filepath.Join(dir, "test-ca.pem")
+	if err := os.WriteFile(caBundlePath, certPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	registryURL := fmt.Sprintf("https://nexus.localhost:%s/simple/", port)
+	writeConfig(t, dir, "version: 1\nmin-age: 72h\nregistries:\n  pypi: "+registryURL+"\nregistry-enforcement: warn\nregistry-ca-bundle: "+caBundlePath+"\n")
+
+	lock := `version = 1
+
+[[package]]
+name = "leftpad"
+version = "1.0.0"
+`
+	if err := os.WriteFile(filepath.Join(dir, "uv.lock"), []byte(lock), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cap := stubExecPM(t, 0)
+
+	if err := runPreInstallBlock(newWrapTestCmd(), pmUV, []string{"sync"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hit {
+		t.Fatal("the configured registry was never queried — audit path silently used the public registry")
+	}
+	if cap.calls != 1 {
+		t.Errorf("execPMFunc called %d times, want 1", cap.calls)
+	}
+}
+
+// newTLSTestServer starts an HTTPS server on 127.0.0.1 with a self-signed cert
+// issued for "nexus.localhost" (which resolves to 127.0.0.1 without being a
+// literal IP string, so it passes ValidateRegistryURL's loopback-IP rejection —
+// httptest.NewTLSServer's own cert, issued for "example.com", would not
+// validate against that hostname). It returns the cert as a PEM block (for
+// registry-ca-bundle) alongside the listening server and its port.
+func newTLSTestServer(t *testing.T, handler http.HandlerFunc) ([]byte, *httptest.Server, string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "nexus.localhost"},
+		DNSNames:     []string{"nexus.localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewUnstartedServer(handler)
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: priv}},
+		MinVersion:   tls.VersionTLS12,
+	}
+	server.StartTLS()
+
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(server.URL, "https://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return certPEM, server, port
 }
 
 func TestRunSupplyChainWrap_EcosystemScopeExcludesPM(t *testing.T) {

--- a/internal/cmd/supply_chain_wrap_test.go
+++ b/internal/cmd/supply_chain_wrap_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ArmisSecurity/armis-cli/internal/supplychain"
 	"github.com/spf13/cobra"
 )
 
@@ -434,18 +435,24 @@ func TestRunPreInstallBlock_QueriesConfiguredRegistry(t *testing.T) {
 	// server's own default cert (issued for "example.com") would not validate
 	// against this hostname, so this test mints its own self-signed cert for
 	// "nexus.registry.example" and serves it directly over tls.Listen.
-	origTransport := http.DefaultTransport.(*http.Transport).Clone()
-	testTransport := origTransport.Clone()
-	testTransport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		host, portStr, splitErr := net.SplitHostPort(addr)
-		// armis:ignore cwe:918 reason:test-only code (this file has no _test.go build exclusion but is never compiled into the shipped binary); the redirected host is a hardcoded string literal ("nexus.registry.example", this test's own fixture hostname), not derived from any request URL or other runtime input, so there is nothing here for an attacker to control
-		if splitErr == nil && host == "nexus.registry.example" {
-			addr = net.JoinHostPort("127.0.0.1", portStr)
+	// Override supplychain.BaseUpstreamTransport (a package-level test seam,
+	// mirroring execPMFunc) instead of mutating the process-global
+	// http.DefaultTransport — the latter would race against any parallel test
+	// elsewhere in this module that makes its own HTTP request.
+	origBaseTransport := supplychain.BaseUpstreamTransport
+	supplychain.BaseUpstreamTransport = func() *http.Transport {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, portStr, splitErr := net.SplitHostPort(addr)
+			// armis:ignore cwe:918 reason:test-only code (this file has no _test.go build exclusion but is never compiled into the shipped binary); the redirected host is a hardcoded string literal ("nexus.registry.example", this test's own fixture hostname), not derived from any request URL or other runtime input, so there is nothing here for an attacker to control
+			if splitErr == nil && host == "nexus.registry.example" {
+				addr = net.JoinHostPort("127.0.0.1", portStr)
+			}
+			return (&net.Dialer{}).DialContext(ctx, network, addr)
 		}
-		return (&net.Dialer{}).DialContext(ctx, network, addr)
+		return transport
 	}
-	http.DefaultTransport = testTransport
-	t.Cleanup(func() { http.DefaultTransport = origTransport })
+	t.Cleanup(func() { supplychain.BaseUpstreamTransport = origBaseTransport })
 
 	var hit bool
 	certPEM, server, port := newTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/supplychain/check/bun.go
+++ b/internal/supplychain/check/bun.go
@@ -51,12 +51,27 @@ func ParseBunLockfile(path string) ([]PackageEntry, error) {
 		}
 
 		entries = append(entries, PackageEntry{
-			Name:    name,
-			Version: version,
+			Name:     name,
+			Version:  version,
+			Resolved: bunResolvedURL(tuple),
 		})
 	}
 
 	return entries, nil
+}
+
+// bunResolvedURL returns the registry URL recorded for a bun.lock entry (the
+// tuple's second element), or "" when absent. bun records a full tarball URL
+// here for registry packages, which is what the non-approved-registry check
+// compares against the approved host.
+func bunResolvedURL(tuple []interface{}) string {
+	if len(tuple) < 2 {
+		return ""
+	}
+	if resolved, ok := tuple[1].(string); ok {
+		return resolved
+	}
+	return ""
 }
 
 func parseBunPackageKey(key string, tuple []interface{}) (string, string) {

--- a/internal/supplychain/check/check.go
+++ b/internal/supplychain/check/check.go
@@ -4,6 +4,7 @@ package check
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
@@ -24,6 +25,27 @@ type Result struct {
 	Warnings   []string
 	Checked    int
 	Skipped    int
+
+	// RegistryViolations lists npm-family packages whose lockfile-recorded
+	// resolved URL host does not match the approved registry (PPSC-994). It is
+	// populated only when an approved RegistryURL is threaded in and the
+	// ecosystem records a per-package source URL; it is always empty for
+	// ecosystems that do not (poetry/pdm/uv/pip, maven/gradle).
+	RegistryViolations []RegistryViolation
+	// RegistryChecked is the number of packages whose resolved URL could be
+	// compared against the approved registry (those with a parseable host). It
+	// scopes the coverage count ("12 npm packages checked") honestly.
+	RegistryChecked int
+}
+
+// RegistryViolation records a package resolved from a registry host other than
+// the approved one. The host fields are bare hosts (with port) for a compact,
+// actionable message.
+type RegistryViolation struct {
+	Name         string
+	Version      string
+	ResolvedHost string
+	ApprovedHost string
 }
 
 // registryFn resolves publish dates for a set of packages in an ecosystem. It
@@ -33,10 +55,31 @@ type Result struct {
 type registryFn func(ctx context.Context, ecosystem supplychain.Ecosystem, packages []registry.PackageRequest) []registry.QueryResult
 
 func RunCheck(ctx context.Context, policy supplychain.Policy, lockfilePath string, baseLockfilePath string) (*Result, error) {
-	return runCheck(ctx, policy, lockfilePath, baseLockfilePath, queryRegistry)
+	return runCheck(ctx, policy, lockfilePath, baseLockfilePath, queryRegistry, "")
 }
 
-func runCheck(ctx context.Context, policy supplychain.Policy, lockfilePath string, baseLockfilePath string, queryRegistryFn registryFn) (*Result, error) {
+// RunCheckWithRegistry is RunCheck plus an approved registry URL (PPSC-994).
+// When registryURL is non-empty: age checks query THAT registry (not the public
+// one) via queryRegistryWithURL, and npm-family packages whose lockfile resolved
+// URL points at a different host are flagged as RegistryViolations. An empty
+// registryURL is exactly RunCheck. The caller is responsible for having
+// validated registryURL via supplychain.ValidateRegistryURL.
+func RunCheckWithRegistry(ctx context.Context, policy supplychain.Policy, lockfilePath, baseLockfilePath, registryURL string) (*Result, error) {
+	fn := queryRegistry
+	if registryURL != "" {
+		fn = queryRegistryWithURL(registryURL)
+	}
+	return runCheck(ctx, policy, lockfilePath, baseLockfilePath, fn, registryURL)
+}
+
+// runCheck is the testable core. registryURL is variadic so the many existing
+// age-only tests (which pass no URL) keep compiling; only the new
+// registry-divergence tests pass it. At most one value is meaningful.
+func runCheck(ctx context.Context, policy supplychain.Policy, lockfilePath string, baseLockfilePath string, queryRegistryFn registryFn, registryURLArg ...string) (*Result, error) {
+	var registryURL string
+	if len(registryURLArg) > 0 {
+		registryURL = registryURLArg[0]
+	}
 	ecosystem := detectEcosystemFromPath(lockfilePath)
 
 	// armis:ignore cwe:22 cwe:23 cwe:73 reason:local CLI auditing the user's own project; lockfilePath comes from lockfile auto-detection or an explicit --lockfile flag the user controls, not untrusted network input (readLockfile also size-bounds the read)
@@ -64,8 +107,17 @@ func runCheck(ctx context.Context, policy supplychain.Policy, lockfilePath strin
 		toCheck = append(toCheck, registry.PackageRequest{Name: e.Name, Version: e.Version})
 	}
 
+	// Registry-divergence flagging is independent of the age query: it reads the
+	// lockfile's resolved URLs, so it runs even when there are no age violations
+	// (and even when toCheck is empty after exclusions).
+	regViolations, regChecked := detectRegistryDivergence(ecosystem, entries, registryURL)
+
 	if len(toCheck) == 0 {
-		return &Result{Skipped: skipped}, nil
+		return &Result{
+			Skipped:            skipped,
+			RegistryViolations: regViolations,
+			RegistryChecked:    regChecked,
+		}, nil
 	}
 
 	results := queryRegistryFn(ctx, ecosystem, toCheck)
@@ -95,10 +147,12 @@ func runCheck(ctx context.Context, policy supplychain.Policy, lockfilePath strin
 	}
 
 	return &Result{
-		Violations: violations,
-		Warnings:   warnings,
-		Checked:    len(toCheck),
-		Skipped:    skipped,
+		Violations:         violations,
+		Warnings:           warnings,
+		Checked:            len(toCheck),
+		Skipped:            skipped,
+		RegistryViolations: regViolations,
+		RegistryChecked:    regChecked,
 	}, nil
 }
 
@@ -142,6 +196,83 @@ func queryRegistry(ctx context.Context, ecosystem supplychain.Ecosystem, package
 		client := registry.NewClient()
 		return client.GetPublishDates(ctx, packages)
 	}
+}
+
+// queryRegistryWithURL returns a registryFn that resolves publish dates from a
+// configured approved registry instead of the public one (E6). For npm-family
+// ecosystems it points the npm metadata client at registryURL; for PyPI-family
+// it points the PyPI client there. registryURL must already be validated by the
+// caller (supplychain.ValidateRegistryURL). Maven/Gradle stay on the public
+// client — they are audit-path only and not routable in v1.
+func queryRegistryWithURL(registryURL string) registryFn {
+	return func(ctx context.Context, ecosystem supplychain.Ecosystem, packages []registry.PackageRequest) []registry.QueryResult {
+		switch ecosystem {
+		case supplychain.EcosystemPip, supplychain.EcosystemUV:
+			client := registry.NewPyPIClientWithHTTP(nil, registryURL)
+			return client.GetPublishDates(ctx, packages)
+		case supplychain.EcosystemMaven, supplychain.EcosystemGradle,
+			supplychain.EcosystemPoetry, supplychain.EcosystemPipfile, supplychain.EcosystemPDM:
+			// Not routable in v1: fall back to the default public clients.
+			return queryRegistry(ctx, ecosystem, packages)
+		default:
+			client := registry.NewClientWithHTTP(nil, registryURL)
+			return client.GetPublishDates(ctx, packages)
+		}
+	}
+}
+
+// isNPMFamily reports whether an ecosystem records a per-package resolved
+// registry URL in its lockfile and is therefore eligible for the
+// non-approved-registry check. v1 covers exactly the npm-family formats; every
+// other ecosystem (PyPI-family, Maven/Gradle) records no per-package source URL
+// and is explicitly NOT covered.
+func isNPMFamily(eco supplychain.Ecosystem) bool {
+	switch eco {
+	case supplychain.EcosystemNPM, supplychain.EcosystemPNPM, supplychain.EcosystemBun, supplychain.EcosystemYarn:
+		return true
+	default:
+		return false
+	}
+}
+
+// detectRegistryDivergence flags npm-family packages whose lockfile-recorded
+// resolved URL host differs from the approved registry host. It returns the
+// violations and the count of packages it could actually compare (those with a
+// parseable resolved host) — the honest coverage denominator. It is a no-op
+// (nil, 0) when registryURL is empty, the ecosystem is not npm-family, or the
+// approved URL has no parseable host.
+func detectRegistryDivergence(eco supplychain.Ecosystem, entries []PackageEntry, registryURL string) ([]RegistryViolation, int) {
+	if registryURL == "" || !isNPMFamily(eco) {
+		return nil, 0
+	}
+	approvedURL, err := url.Parse(registryURL)
+	if err != nil || approvedURL.Host == "" {
+		return nil, 0
+	}
+	approvedHost := strings.ToLower(approvedURL.Host)
+
+	var violations []RegistryViolation
+	checked := 0
+	for _, e := range entries {
+		if e.Resolved == "" {
+			continue // no recorded source URL → cannot compare (not counted)
+		}
+		ru, err := url.Parse(e.Resolved)
+		if err != nil || ru.Host == "" {
+			continue
+		}
+		checked++
+		host := strings.ToLower(ru.Host)
+		if host != approvedHost {
+			violations = append(violations, RegistryViolation{
+				Name:         e.Name,
+				Version:      e.Version,
+				ResolvedHost: host,
+				ApprovedHost: approvedHost,
+			})
+		}
+	}
+	return violations, checked
 }
 
 // DetectEcosystemFromPath classifies a lockfile path to its ecosystem using the

--- a/internal/supplychain/check/check.go
+++ b/internal/supplychain/check/check.go
@@ -4,6 +4,7 @@ package check
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -65,9 +66,24 @@ func RunCheck(ctx context.Context, policy supplychain.Policy, lockfilePath strin
 // registryURL is exactly RunCheck. The caller is responsible for having
 // validated registryURL via supplychain.ValidateRegistryURL.
 func RunCheckWithRegistry(ctx context.Context, policy supplychain.Policy, lockfilePath, baseLockfilePath, registryURL string) (*Result, error) {
+	return RunCheckWithRegistryClient(ctx, policy, lockfilePath, baseLockfilePath, registryURL, nil, "")
+}
+
+// RunCheckWithRegistryClient is RunCheckWithRegistry plus an explicit HTTP
+// client and Authorization header for the age-query leg (PPSC-994). The client
+// carries the approved registry's private-CA trust (registry-ca-bundle /
+// ARMIS_REGISTRY_CA_BUNDLE) and authHeader carries the developer's registry
+// credential ("Bearer <tok>" / "Basic <b64>" resolved from the native .npmrc /
+// index-url), so `check` can verify ages against a private-CA, auth-gated Nexus
+// exactly as the wrap proxy does. Pass a nil client and empty authHeader to use
+// the registry package's default unauthenticated client (public-registry path).
+// The caller is responsible for having validated registryURL via
+// supplychain.ValidateRegistryURL and for building httpClient/authHeader from
+// that URL's settings.
+func RunCheckWithRegistryClient(ctx context.Context, policy supplychain.Policy, lockfilePath, baseLockfilePath, registryURL string, httpClient *http.Client, authHeader string) (*Result, error) {
 	fn := queryRegistry
 	if registryURL != "" {
-		fn = queryRegistryWithURL(registryURL)
+		fn = queryRegistryWithURL(registryURL, httpClient, authHeader)
 	}
 	return runCheck(ctx, policy, lockfilePath, baseLockfilePath, fn, registryURL)
 }
@@ -202,20 +218,26 @@ func queryRegistry(ctx context.Context, ecosystem supplychain.Ecosystem, package
 // configured approved registry instead of the public one (E6). For npm-family
 // ecosystems it points the npm metadata client at registryURL; for PyPI-family
 // it points the PyPI client there. registryURL must already be validated by the
-// caller (supplychain.ValidateRegistryURL). Maven/Gradle stay on the public
-// client — they are audit-path only and not routable in v1.
-func queryRegistryWithURL(registryURL string) registryFn {
+// caller (supplychain.ValidateRegistryURL). httpClient carries the registry's
+// private-CA trust (or nil to let the registry clients build their own default)
+// and authHeader carries the developer's registry credential (or "" for none);
+// both are passed straight through to the injected-client constructors so a
+// private-CA, auth-gated Nexus is reachable here exactly as it is on the wrap
+// path. Maven/Gradle stay on the public client — they are audit-path only and
+// not routable in v1.
+// armis:ignore cwe:918 reason:registryURL is documented above as already validated by the caller via supplychain.ValidateRegistryURL (https-only, no userinfo, rejects loopback/RFC1918/link-local) before this function is invoked; every production caller (supply_chain_check.go, supply_chain_wrap.go) does so, and tests pass an httptest server URL
+func queryRegistryWithURL(registryURL string, httpClient *http.Client, authHeader string) registryFn {
 	return func(ctx context.Context, ecosystem supplychain.Ecosystem, packages []registry.PackageRequest) []registry.QueryResult {
 		switch ecosystem {
 		case supplychain.EcosystemPip, supplychain.EcosystemUV:
-			client := registry.NewPyPIClientWithHTTP(nil, registryURL)
+			client := registry.NewPyPIClientWithHTTP(httpClient, registryURL).WithAuthHeader(authHeader)
 			return client.GetPublishDates(ctx, packages)
 		case supplychain.EcosystemMaven, supplychain.EcosystemGradle,
 			supplychain.EcosystemPoetry, supplychain.EcosystemPipfile, supplychain.EcosystemPDM:
 			// Not routable in v1: fall back to the default public clients.
 			return queryRegistry(ctx, ecosystem, packages)
 		default:
-			client := registry.NewClientWithHTTP(nil, registryURL)
+			client := registry.NewClientWithHTTP(httpClient, registryURL).WithAuthHeader(authHeader)
 			return client.GetPublishDates(ctx, packages)
 		}
 	}

--- a/internal/supplychain/check/check.go
+++ b/internal/supplychain/check/check.go
@@ -283,6 +283,17 @@ func detectRegistryDivergence(eco supplychain.Ecosystem, entries []PackageEntry,
 		if err != nil || ru.Host == "" {
 			continue
 		}
+		// A resolved URL is only comparable against an approved registry when it
+		// is itself an http(s) registry fetch. Non-registry resolution schemes
+		// (git+https://, git+ssh://, file:, workspace:, link:) still parse with a
+		// non-empty Host (e.g. url.Parse treats "git+https" as the scheme and
+		// "github.com" as the host for a git dependency) but are not registry
+		// resolutions at all, so counting/flagging them would produce false
+		// "non-approved registry" violations for git-based and local/workspace
+		// dependencies that never touch any registry.
+		if ru.Scheme != "http" && ru.Scheme != "https" {
+			continue
+		}
 		checked++
 		host := strings.ToLower(ru.Host)
 		if host != approvedHost {

--- a/internal/supplychain/check/check_registry_test.go
+++ b/internal/supplychain/check/check_registry_test.go
@@ -1,0 +1,139 @@
+package check
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ArmisSecurity/armis-cli/internal/supplychain"
+	"github.com/ArmisSecurity/armis-cli/internal/supplychain/registry"
+)
+
+// TestDetectRegistryDivergence is test-plan case #12: flag npm-family packages
+// resolved from a non-approved registry.
+func TestDetectRegistryDivergence(t *testing.T) {
+	const approved = "https://nexus.corp/repository/npm-group/"
+
+	t.Run("flags off-registry package", func(t *testing.T) {
+		entries := []PackageEntry{
+			{Name: "express", Version: "4.18.2", Resolved: "https://nexus.corp/repository/npm-group/express/-/express-4.18.2.tgz"},
+			{Name: "evil", Version: "1.0.0", Resolved: "https://registry.npmjs.org/evil/-/evil-1.0.0.tgz"},
+		}
+		vios, checked := detectRegistryDivergence(supplychain.EcosystemNPM, entries, approved)
+		if checked != 2 {
+			t.Errorf("checked = %d, want 2", checked)
+		}
+		if len(vios) != 1 {
+			t.Fatalf("expected 1 violation, got %d", len(vios))
+		}
+		if vios[0].Name != "evil" || vios[0].ResolvedHost != "registry.npmjs.org" {
+			t.Errorf("unexpected violation: %+v", vios[0])
+		}
+	})
+
+	t.Run("all approved → no violations", func(t *testing.T) {
+		entries := []PackageEntry{
+			{Name: "express", Version: "4.18.2", Resolved: "https://nexus.corp/repository/npm-group/express/-/express-4.18.2.tgz"},
+		}
+		vios, checked := detectRegistryDivergence(supplychain.EcosystemNPM, entries, approved)
+		if len(vios) != 0 || checked != 1 {
+			t.Errorf("expected 0 violations / 1 checked, got %d / %d", len(vios), checked)
+		}
+	})
+
+	t.Run("packages with no resolved URL are not counted", func(t *testing.T) {
+		entries := []PackageEntry{
+			{Name: "noresolve", Version: "1.0.0", Resolved: ""},
+		}
+		vios, checked := detectRegistryDivergence(supplychain.EcosystemNPM, entries, approved)
+		if len(vios) != 0 || checked != 0 {
+			t.Errorf("a package with no resolved URL must not be counted, got %d / %d", len(vios), checked)
+		}
+	})
+
+	t.Run("non-npm ecosystem is never checked", func(t *testing.T) {
+		entries := []PackageEntry{{Name: "requests", Version: "2.0", Resolved: "https://files.pythonhosted.org/x"}}
+		vios, checked := detectRegistryDivergence(supplychain.EcosystemPip, entries, approved)
+		if vios != nil || checked != 0 {
+			t.Errorf("PyPI must not be registry-checked in v1, got %d / %d", len(vios), checked)
+		}
+	})
+
+	t.Run("empty registryURL is a no-op", func(t *testing.T) {
+		entries := []PackageEntry{{Name: "express", Version: "4.18.2", Resolved: "https://registry.npmjs.org/x"}}
+		vios, checked := detectRegistryDivergence(supplychain.EcosystemNPM, entries, "")
+		if vios != nil || checked != 0 {
+			t.Errorf("no registryURL → no divergence check, got %d / %d", len(vios), checked)
+		}
+	})
+}
+
+// TestRunCheckWithRegistryFlagsDivergence wires the divergence check through
+// RunCheckWithRegistry against a real npm lockfile fixture.
+func TestRunCheckWithRegistryFlagsDivergence(t *testing.T) {
+	// Build a v3 package-lock with one approved and one public-registry package.
+	lock := `{
+  "lockfileVersion": 3,
+  "packages": {
+    "node_modules/approved": {"version": "1.0.0", "resolved": "https://nexus.corp/repository/npm-group/approved/-/approved-1.0.0.tgz"},
+    "node_modules/leaked":   {"version": "2.0.0", "resolved": "https://registry.npmjs.org/leaked/-/leaked-2.0.0.tgz"}
+  }
+}`
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	if err := os.WriteFile(lockPath, []byte(lock), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// A registry server that dates both packages old (so age is not the variable
+	// under test — divergence is).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"time":{"1.0.0":"2020-01-01T00:00:00Z","2.0.0":"2020-01-01T00:00:00Z"}}`) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	policy := supplychain.Policy{MinReleaseAge: 72 * time.Hour}
+	// Use the internal runCheck with an injected resolver + the approved URL so
+	// the test does not depend on the real npmjs.org.
+	resolver := queryRegistryWithURL(server.URL)
+	res, err := runCheck(context.Background(), policy, lockPath, "", resolver, "https://nexus.corp/repository/npm-group/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.RegistryViolations) != 1 {
+		t.Fatalf("expected 1 registry violation, got %d: %+v", len(res.RegistryViolations), res.RegistryViolations)
+	}
+	if res.RegistryViolations[0].Name != "leaked" {
+		t.Errorf("expected 'leaked' flagged, got %q", res.RegistryViolations[0].Name)
+	}
+	if res.RegistryChecked != 2 {
+		t.Errorf("RegistryChecked = %d, want 2", res.RegistryChecked)
+	}
+}
+
+// TestQueryRegistryWithURLHitsConfiguredHost is test-plan case #11: the
+// configured RegistryURL is the host actually queried, not npmjs.org.
+func TestQueryRegistryWithURLHitsConfiguredHost(t *testing.T) {
+	var hit bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"time":{"1.0.0":"2020-01-01T00:00:00Z"}}`) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	fn := queryRegistryWithURL(server.URL)
+	results := fn(context.Background(), supplychain.EcosystemNPM, []registry.PackageRequest{{Name: "leftpad", Version: "1.0.0"}})
+	if !hit {
+		t.Fatal("the configured registry host was not queried")
+	}
+	if len(results) != 1 || results[0].Err != nil {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+}

--- a/internal/supplychain/check/check_registry_test.go
+++ b/internal/supplychain/check/check_registry_test.go
@@ -101,7 +101,7 @@ func TestRunCheckWithRegistryFlagsDivergence(t *testing.T) {
 	policy := supplychain.Policy{MinReleaseAge: 72 * time.Hour}
 	// Use the internal runCheck with an injected resolver + the approved URL so
 	// the test does not depend on the real npmjs.org.
-	resolver := queryRegistryWithURL(server.URL)
+	resolver := queryRegistryWithURL(server.URL, nil, "")
 	res, err := runCheck(context.Background(), policy, lockPath, "", resolver, "https://nexus.corp/repository/npm-group/")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -128,7 +128,7 @@ func TestQueryRegistryWithURLHitsConfiguredHost(t *testing.T) {
 	}))
 	defer server.Close()
 
-	fn := queryRegistryWithURL(server.URL)
+	fn := queryRegistryWithURL(server.URL, nil, "")
 	results := fn(context.Background(), supplychain.EcosystemNPM, []registry.PackageRequest{{Name: "leftpad", Version: "1.0.0"}})
 	if !hit {
 		t.Fatal("the configured registry host was not queried")
@@ -136,4 +136,76 @@ func TestQueryRegistryWithURLHitsConfiguredHost(t *testing.T) {
 	if len(results) != 1 || results[0].Err != nil {
 		t.Fatalf("unexpected results: %+v", results)
 	}
+}
+
+// TestQueryRegistryWithURLUsesInjectedTLSClient is the bug #2a regression guard:
+// `supply-chain check` must reach a private-CA (here: self-signed) registry
+// using the CA-bundle-configured HTTP client. A nil client (the old behavior)
+// cannot verify the self-signed cert and every age check fails; the injected
+// client that trusts the cert succeeds. This proves the client actually flows
+// through queryRegistryWithURL into the registry client rather than being
+// dropped (the original defect, where check always used a default client).
+func TestQueryRegistryWithURLUsesInjectedTLSClient(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"time":{"1.0.0":"2020-01-01T00:00:00Z"}}`) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	pkgs := []registry.PackageRequest{{Name: "leftpad", Version: "1.0.0"}}
+
+	t.Run("nil client fails against self-signed TLS", func(t *testing.T) {
+		fn := queryRegistryWithURL(server.URL, nil, "")
+		results := fn(context.Background(), supplychain.EcosystemNPM, pkgs)
+		if len(results) != 1 || results[0].Err == nil {
+			t.Fatalf("expected a TLS verification error with a nil client, got: %+v", results)
+		}
+	})
+
+	t.Run("injected trusting client succeeds", func(t *testing.T) {
+		// server.Client() trusts the httptest server's self-signed cert — the
+		// stand-in for a client built from registry-ca-bundle.
+		fn := queryRegistryWithURL(server.URL, server.Client(), "")
+		results := fn(context.Background(), supplychain.EcosystemNPM, pkgs)
+		if len(results) != 1 || results[0].Err != nil {
+			t.Fatalf("expected success with the trusting client, got: %+v", results)
+		}
+	})
+}
+
+// TestQueryRegistryWithURLForwardsAuth is the regression guard for the
+// auth-gated-registry fix: `check` must forward the developer's credential on
+// its age queries so an auth-required artifactory answers 200 instead of 401.
+// The server 401s any request without the expected Bearer token; the query
+// succeeds only because queryRegistryWithURL threaded the authHeader into the
+// registry client.
+func TestQueryRegistryWithURLForwardsAuth(t *testing.T) {
+	const token = "Bearer check-forward-tok"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"time":{"1.0.0":"2020-01-01T00:00:00Z"}}`) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	pkgs := []registry.PackageRequest{{Name: "leftpad", Version: "1.0.0"}}
+
+	t.Run("without auth → 401 surfaced as an error", func(t *testing.T) {
+		fn := queryRegistryWithURL(server.URL, nil, "")
+		results := fn(context.Background(), supplychain.EcosystemNPM, pkgs)
+		if len(results) != 1 || results[0].Err == nil {
+			t.Fatalf("expected a 401-derived error without a token, got: %+v", results)
+		}
+	})
+
+	t.Run("with auth → 200", func(t *testing.T) {
+		fn := queryRegistryWithURL(server.URL, nil, token)
+		results := fn(context.Background(), supplychain.EcosystemNPM, pkgs)
+		if len(results) != 1 || results[0].Err != nil {
+			t.Fatalf("expected success with the forwarded token, got: %+v", results)
+		}
+	})
 }

--- a/internal/supplychain/check/check_registry_test.go
+++ b/internal/supplychain/check/check_registry_test.go
@@ -71,6 +71,29 @@ func TestDetectRegistryDivergence(t *testing.T) {
 			t.Errorf("no registryURL → no divergence check, got %d / %d", len(vios), checked)
 		}
 	})
+
+	// Regression guard: url.Parse("git+https://github.com/u/r.git") yields
+	// Scheme="git+https" and a non-empty Host ("github.com") — so a naive
+	// "Host != ''" comparability check would count a git dependency as an
+	// off-registry package and flag it, even though it never touched any
+	// registry. Same reasoning applies to git+ssh, file:, and workspace:
+	// resolutions, which lockfiles use for local/monorepo/VCS dependencies.
+	t.Run("non-registry resolution schemes are not counted or flagged", func(t *testing.T) {
+		entries := []PackageEntry{
+			{Name: "gitdep", Version: "1.0.0", Resolved: "git+https://github.com/user/repo.git"},
+			{Name: "sshdep", Version: "1.0.0", Resolved: "git+ssh://git@github.com/user/repo.git"},
+			{Name: "localdep", Version: "1.0.0", Resolved: "file:../local"},
+			{Name: "workspacedep", Version: "1.0.0", Resolved: "workspace:*"},
+			{Name: "approveddep", Version: "1.0.0", Resolved: "https://nexus.corp/repository/npm-group/approveddep/-/approveddep-1.0.0.tgz"},
+		}
+		vios, checked := detectRegistryDivergence(supplychain.EcosystemNPM, entries, approved)
+		if checked != 1 {
+			t.Errorf("checked = %d, want 1 (only the http(s) registry resolution is comparable)", checked)
+		}
+		if len(vios) != 0 {
+			t.Errorf("expected 0 violations (git/file/workspace resolutions are not registry fetches), got %d: %+v", len(vios), vios)
+		}
+	})
 }
 
 // TestRunCheckWithRegistryFlagsDivergence wires the divergence check through

--- a/internal/supplychain/check/npm.go
+++ b/internal/supplychain/check/npm.go
@@ -9,6 +9,15 @@ import (
 type PackageEntry struct {
 	Name    string
 	Version string
+	// Resolved is the registry URL the lockfile recorded this package was
+	// resolved from, when the format records one (npm `resolved`, pnpm
+	// `resolution.tarball`, yarn classic `resolved`, bun's registry tuple). It
+	// is "" for formats that record no per-package source URL (poetry/pdm/uv/
+	// pip-requirements, yarn-berry's `name@npm:` resolution) — those packages
+	// cannot be checked for registry divergence, which v1 states explicitly
+	// rather than implying coverage. Used only by the non-approved-registry
+	// flag; the age check ignores it.
+	Resolved string
 }
 
 type packageLockFile struct {
@@ -78,8 +87,9 @@ func ParseNPMLockfile(path string) ([]PackageEntry, error) {
 		}
 
 		entries = append(entries, PackageEntry{
-			Name:    name,
-			Version: info.Version,
+			Name:     name,
+			Version:  info.Version,
+			Resolved: info.Resolved,
 		})
 	}
 

--- a/internal/supplychain/check/pnpm.go
+++ b/internal/supplychain/check/pnpm.go
@@ -54,8 +54,9 @@ func ParsePNPMLockfile(path string) ([]PackageEntry, error) {
 		}
 
 		entries = append(entries, PackageEntry{
-			Name:    name,
-			Version: version,
+			Name:     name,
+			Version:  version,
+			Resolved: info.Resolution.Tarball,
 		})
 	}
 

--- a/internal/supplychain/check/yarn.go
+++ b/internal/supplychain/check/yarn.go
@@ -134,6 +134,7 @@ func shouldSkipYarnResolution(resolution string) bool {
 //	  integrity sha512-...
 var yarnV1HeaderRe = regexp.MustCompile(`^"?(@?[^@"]+)@`)
 var yarnV1VersionRe = regexp.MustCompile(`^\s+version\s+"([^"]+)"`)
+var yarnV1ResolvedRe = regexp.MustCompile(`^\s+resolved\s+"([^"]+)"`)
 
 func parseYarnClassic(data []byte) ([]PackageEntry, error) {
 	// bytes.NewReader reads directly from the lockfile slice; converting to a
@@ -142,8 +143,29 @@ func parseYarnClassic(data []byte) ([]PackageEntry, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 
 	var entries []PackageEntry
-	var currentName string
+	var currentName, currentVersion, currentResolved string
 	seen := make(map[string]bool)
+
+	// flush emits the pending entry (if any). Emission is deferred to the next
+	// header / EOF rather than fired on the version line, because the `resolved`
+	// URL appears AFTER `version` in a yarn-classic block and is needed for the
+	// non-approved-registry check.
+	flush := func() {
+		if currentName == "" || currentVersion == "" {
+			currentName, currentVersion, currentResolved = "", "", ""
+			return
+		}
+		key := currentName + "@" + currentVersion
+		if !seen[key] {
+			seen[key] = true
+			entries = append(entries, PackageEntry{
+				Name:     currentName,
+				Version:  currentVersion,
+				Resolved: currentResolved,
+			})
+		}
+		currentName, currentVersion, currentResolved = "", "", ""
+	}
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -155,6 +177,7 @@ func parseYarnClassic(data []byte) ([]PackageEntry, error) {
 
 		// Package header line (no leading whitespace)
 		if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			flush() // close out the previous block before starting a new one
 			name := extractClassicPackageName(line)
 			if name != "" && !shouldSkipClassicProtocol(line) {
 				currentName = name
@@ -164,22 +187,20 @@ func parseYarnClassic(data []byte) ([]PackageEntry, error) {
 			continue
 		}
 
+		if currentName == "" {
+			continue
+		}
 		// Version line (indented)
-		if currentName != "" {
-			if matches := yarnV1VersionRe.FindStringSubmatch(line); matches != nil {
-				version := matches[1]
-				key := currentName + "@" + version
-				if !seen[key] {
-					seen[key] = true
-					entries = append(entries, PackageEntry{
-						Name:    currentName,
-						Version: version,
-					})
-				}
-				currentName = ""
-			}
+		if matches := yarnV1VersionRe.FindStringSubmatch(line); matches != nil {
+			currentVersion = matches[1]
+			continue
+		}
+		// Resolved line (indented) — capture the registry URL for divergence.
+		if matches := yarnV1ResolvedRe.FindStringSubmatch(line); matches != nil {
+			currentResolved = matches[1]
 		}
 	}
+	flush() // emit the final block at EOF
 
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("scanning yarn lockfile: %w", err)

--- a/internal/supplychain/config.go
+++ b/internal/supplychain/config.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -25,7 +26,42 @@ type Config struct {
 	// explicit "warn" opts a young transitive into pass-with-warning. Direct
 	// deps are always blocked regardless. See Config.ToPolicy.
 	TransitivePolicy string `yaml:"transitive-policy,omitempty"`
+
+	// Registries maps an ecosystem name (npm, pypi) to the approved
+	// artifactory/registry URL for that ecosystem (PPSC-994). When set for an
+	// ecosystem, the proxy's upstream points at that URL and the CI check audits
+	// against it. v1 recognizes the "npm" and "pypi" keys (see RegistryURLFor);
+	// other keys are ignored. Each value is validated by ValidateRegistryURL at
+	// config-load — the committed file is a trust boundary, so a non-https or
+	// non-routable URL is a hard error, not a best-effort parse.
+	Registries map[string]string `yaml:"registries,omitempty"`
+
+	// RegistryEnforcement is the routing-enforcement posture, distinct from the
+	// age-policy fail-open. v1 supports only "warn" (and absent, which means
+	// warn-disabled). The value "block" is REJECTED at parse with a hard error
+	// (UC-1): a CISO who writes "block" and deploys it must not be silently
+	// downgraded to a one-line warning, manufacturing false compliance.
+	RegistryEnforcement string `yaml:"registry-enforcement,omitempty"`
+
+	// RegistryCABundle is an optional path to a PEM CA bundle used for the
+	// proxy→upstream TLS leg (S6). It lets a minimal CI container reach a Nexus
+	// fronted by a private/corporate CA without a system trust-store edit. The
+	// env var ARMIS_REGISTRY_CA_BUNDLE overrides it. A TLS failure must surface a
+	// visible, actionable error — never a silent fail-open enforcement bypass.
+	RegistryCABundle string `yaml:"registry-ca-bundle,omitempty"`
 }
+
+// Ecosystem keys recognized inside the "registries" map. v1 wires only the npm
+// family and PyPI; Maven/Gradle stay on the audit path and are intentionally
+// not routable here.
+const (
+	registryKeyNPM  = "npm"
+	registryKeyPyPI = "pypi"
+)
+
+// registryEnforcementWarn is the only routing-enforcement posture v1 accepts
+// (alongside an absent value). See Config.RegistryEnforcement.
+const registryEnforcementWarn = "warn"
 
 // ecosystemAliasPipenv is the user-facing name for the Pipfile/pipenv ecosystem.
 // --help and the generated config call it "pipenv" (the tool name users know),
@@ -99,7 +135,85 @@ func LoadConfig(dir string) (*Config, error) {
 		return nil, fmt.Errorf("parsing %s: %w\n\n  Valid format:\n    version: 1\n    min-age: 72h\n    exclusions:\n      - \"@myorg/*\"\n    fail-open: false", ConfigFileName, err)
 	}
 
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
 	return &cfg, nil
+}
+
+// validate enforces the structural and security invariants on the parsed
+// config that must fail loudly at load time rather than degrade silently
+// later. Three things are checked, all PPSC-994 launch requirements:
+//
+//   - registry-enforcement: only "warn" (or absent) is valid in v1. "block" is
+//     REJECTED with a hard error (UC-1) — never accepted-and-downgraded to warn,
+//     which would manufacture false compliance for a CISO.
+//   - each registries.<ecosystem> URL passes ValidateRegistryURL (S1): https
+//     only, no embedded credentials, no loopback/RFC1918/link-local host. The
+//     committed config is a trust boundary; a bad URL is an SSRF, not a typo.
+//   - a PyPI registry URL must expose the PEP 503 "/simple/" index path (DX4),
+//     caught here rather than as a confusing 404 at install time.
+func (c *Config) validate() error {
+	switch c.RegistryEnforcement {
+	case "", registryEnforcementWarn:
+		// ok: absent or the one supported posture.
+	case "block":
+		return fmt.Errorf("registry-enforcement: 'block' is not supported in this version; use 'warn'")
+	default:
+		return fmt.Errorf("registry-enforcement: %q is not valid; use 'warn' (or omit it)", c.RegistryEnforcement)
+	}
+
+	for eco, raw := range c.Registries {
+		if strings.TrimSpace(raw) == "" {
+			continue // an empty value is treated as "not configured", not an error
+		}
+		u, err := ValidateRegistryURL(raw)
+		if err != nil {
+			return fmt.Errorf("registries.%s: %w", eco, err)
+		}
+		if eco == registryKeyPyPI && !strings.Contains(u.Path, "/simple") {
+			return fmt.Errorf("registries.pypi: %q should point at the PEP 503 Simple API (a URL containing \"/simple/\", e.g. https://nexus.corp/repository/pypi-group/simple/)", raw)
+		}
+	}
+
+	return nil
+}
+
+// RegistryURLFor returns the configured approved registry URL for an ecosystem,
+// or "" when none is set. npm-family ecosystems (npm/pnpm/bun/yarn) all share
+// the single "npm" key since they resolve from the same npm-registry protocol;
+// the PyPI-family proxied ecosystems (pip/uv) share the "pypi" key. Audit-path
+// ecosystems (poetry/pdm/maven/gradle) are not routable in v1 and always return
+// "". A nil config returns "".
+func (c *Config) RegistryURLFor(eco Ecosystem) string {
+	if c == nil || c.Registries == nil {
+		return ""
+	}
+	switch eco {
+	case EcosystemNPM, EcosystemPNPM, EcosystemBun, EcosystemYarn:
+		return strings.TrimSpace(c.Registries[registryKeyNPM])
+	case EcosystemPip, EcosystemUV:
+		return strings.TrimSpace(c.Registries[registryKeyPyPI])
+	default:
+		return ""
+	}
+}
+
+// HasAnyRegistry reports whether the config sets at least one registries entry.
+// It gates the "explicit coverage" honesty rules (E4/DX3): once ANY registry is
+// configured, unconfigured ecosystems must be reported as "not configured
+// (public)" rather than silently implying coverage.
+func (c *Config) HasAnyRegistry() bool {
+	if c == nil {
+		return false
+	}
+	for _, raw := range c.Registries {
+		if strings.TrimSpace(raw) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Config) ToPolicy() (Policy, error) {

--- a/internal/supplychain/config.go
+++ b/internal/supplychain/config.go
@@ -30,10 +30,15 @@ type Config struct {
 	// Registries maps an ecosystem name (npm, pypi) to the approved
 	// artifactory/registry URL for that ecosystem (PPSC-994). When set for an
 	// ecosystem, the proxy's upstream points at that URL and the CI check audits
-	// against it. v1 recognizes the "npm" and "pypi" keys (see RegistryURLFor);
-	// other keys are ignored. Each value is validated by ValidateRegistryURL at
-	// config-load — the committed file is a trust boundary, so a non-https or
-	// non-routable URL is a hard error, not a best-effort parse.
+	// against it. v1 wires only the "npm" and "pypi" keys into actual routing
+	// (see RegistryURLFor) — a key outside that set is never read by any
+	// enforcement path — but validate() checks EVERY key's value regardless,
+	// including unrecognized ones: the committed file is a trust boundary, so
+	// any URL sitting under registries.* must be a syntactically valid, secure
+	// URL, not a best-effort parse. This also catches a value silently doing
+	// nothing today (a typo'd or not-yet-wired key) before it becomes a live
+	// route in a future version. Each value is validated by ValidateRegistryURL
+	// at config-load — a non-https or non-routable URL is a hard error.
 	Registries map[string]string `yaml:"registries,omitempty"`
 
 	// RegistryEnforcement is the routing-enforcement posture, distinct from the

--- a/internal/supplychain/config.go
+++ b/internal/supplychain/config.go
@@ -172,8 +172,9 @@ func (c *Config) validate() error {
 		if err != nil {
 			return fmt.Errorf("registries.%s: %w", eco, err)
 		}
-		if eco == registryKeyPyPI && !strings.Contains(u.Path, "/simple") {
-			return fmt.Errorf("registries.pypi: %q should point at the PEP 503 Simple API (a URL containing \"/simple/\", e.g. https://nexus.corp/repository/pypi-group/simple/)", raw)
+		if eco == registryKeyPyPI && !strings.HasSuffix(strings.TrimSuffix(u.Path, "/"), "/simple") {
+			// armis:ignore cwe:201 reason:raw already passed ValidateRegistryURL a few lines above, which hard-rejects any URL with embedded userinfo (u.User != nil) before reaching here — raw cannot contain credentials by the time this error message includes it
+			return fmt.Errorf("registries.pypi: %q should point at the PEP 503 Simple API (a URL ending in \"/simple\" or \"/simple/\", e.g. https://nexus.corp/repository/pypi-group/simple/)", raw)
 		}
 	}
 

--- a/internal/supplychain/config_registry_test.go
+++ b/internal/supplychain/config_registry_test.go
@@ -1,0 +1,173 @@
+package supplychain
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ConfigFileName), []byte(content), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+	return dir
+}
+
+// TestLoadConfigRegistries covers parsing of the new registries map and the
+// RegistryURLFor / HasAnyRegistry accessors.
+func TestLoadConfigRegistries(t *testing.T) {
+	t.Run("npm and pypi parsed and mapped", func(t *testing.T) {
+		dir := writeConfig(t, `version: 1
+registries:
+  npm: https://nexus.corp/repository/npm-group/
+  pypi: https://nexus.corp/repository/pypi-group/simple/
+registry-enforcement: warn
+`)
+		cfg, err := LoadConfig(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := cfg.RegistryURLFor(EcosystemNPM); got != "https://nexus.corp/repository/npm-group/" {
+			t.Errorf("npm URL = %q", got)
+		}
+		// The whole npm family shares the npm key.
+		if got := cfg.RegistryURLFor(EcosystemPNPM); got == "" {
+			t.Error("pnpm should resolve to the npm registry URL")
+		}
+		if got := cfg.RegistryURLFor(EcosystemPip); !strings.Contains(got, "pypi-group") {
+			t.Errorf("pip URL = %q", got)
+		}
+		if got := cfg.RegistryURLFor(EcosystemUV); !strings.Contains(got, "pypi-group") {
+			t.Errorf("uv URL = %q", got)
+		}
+		// Audit-path ecosystems are not routable in v1.
+		if got := cfg.RegistryURLFor(EcosystemMaven); got != "" {
+			t.Errorf("maven should not be routable, got %q", got)
+		}
+		if !cfg.HasAnyRegistry() {
+			t.Error("HasAnyRegistry should be true")
+		}
+	})
+
+	t.Run("absent registries", func(t *testing.T) {
+		dir := writeConfig(t, "version: 1\nmin-age: 72h\n")
+		cfg, err := LoadConfig(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.HasAnyRegistry() {
+			t.Error("HasAnyRegistry should be false when no registries set")
+		}
+		if cfg.RegistryURLFor(EcosystemNPM) != "" {
+			t.Error("npm URL should be empty when no registries set")
+		}
+	})
+
+	t.Run("nil config accessors are safe", func(t *testing.T) {
+		var cfg *Config
+		if cfg.RegistryURLFor(EcosystemNPM) != "" {
+			t.Error("nil config npm URL should be empty")
+		}
+		if cfg.HasAnyRegistry() {
+			t.Error("nil config HasAnyRegistry should be false")
+		}
+	})
+}
+
+// TestLoadConfigRegistryEnforcement is test-plan case #15 (UC-1): block is
+// rejected at parse with a hard error; warn and absent parse OK.
+func TestLoadConfigRegistryEnforcement(t *testing.T) {
+	t.Run("block rejected at parse", func(t *testing.T) {
+		dir := writeConfig(t, "version: 1\nregistry-enforcement: block\n")
+		_, err := LoadConfig(dir)
+		if err == nil {
+			t.Fatal("expected a hard error for registry-enforcement: block")
+		}
+		if !strings.Contains(err.Error(), "not supported") || !strings.Contains(err.Error(), "warn") {
+			t.Errorf("error should explain block is unsupported and to use warn, got: %v", err)
+		}
+	})
+
+	t.Run("warn accepted", func(t *testing.T) {
+		dir := writeConfig(t, "version: 1\nregistry-enforcement: warn\n")
+		cfg, err := LoadConfig(dir)
+		if err != nil {
+			t.Fatalf("warn should parse OK, got: %v", err)
+		}
+		if cfg.RegistryEnforcement != "warn" {
+			t.Errorf("RegistryEnforcement = %q", cfg.RegistryEnforcement)
+		}
+	})
+
+	t.Run("absent accepted", func(t *testing.T) {
+		dir := writeConfig(t, "version: 1\nmin-age: 72h\n")
+		if _, err := LoadConfig(dir); err != nil {
+			t.Fatalf("absent enforcement should parse OK, got: %v", err)
+		}
+	})
+
+	t.Run("unknown posture rejected", func(t *testing.T) {
+		dir := writeConfig(t, "version: 1\nregistry-enforcement: enforce\n")
+		_, err := LoadConfig(dir)
+		if err == nil {
+			t.Fatal("expected an error for an unknown posture")
+		}
+	})
+}
+
+// TestLoadConfigRegistryURLValidation proves the SSRF guard runs at config-load
+// (S1): a non-https or non-routable registry URL is a hard parse error.
+func TestLoadConfigRegistryURLValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		yaml   string
+		errHas string
+	}{
+		{
+			name:   "http npm rejected",
+			yaml:   "registries:\n  npm: http://nexus.corp/npm/\n",
+			errHas: "https",
+		},
+		{
+			name:   "IMDS npm rejected",
+			yaml:   "registries:\n  npm: https://169.254.169.254/npm/\n",
+			errHas: "link-local",
+		},
+		{ //nolint:gosec // G101: test fixture URL, not a real credential
+			name:   "userinfo rejected",
+			yaml:   "registries:\n  npm: https://user:tok@nexus.corp/npm/\n",
+			errHas: "credentials",
+		},
+		{
+			name:   "pypi without /simple/ rejected",
+			yaml:   "registries:\n  pypi: https://nexus.corp/repository/pypi-group/\n",
+			errHas: "/simple/",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := writeConfig(t, "version: 1\n"+tt.yaml)
+			_, err := LoadConfig(dir)
+			if err == nil {
+				t.Fatalf("expected a parse error for %s", tt.name)
+			}
+			if !strings.Contains(err.Error(), tt.errHas) {
+				t.Errorf("error %q does not mention %q", err.Error(), tt.errHas)
+			}
+		})
+	}
+
+	t.Run("valid https npm + pypi/simple/ accepted", func(t *testing.T) {
+		dir := writeConfig(t, `version: 1
+registries:
+  npm: https://nexus.corp/repository/npm-group/
+  pypi: https://nexus.corp/repository/pypi-group/simple/
+`)
+		if _, err := LoadConfig(dir); err != nil {
+			t.Fatalf("valid registries should parse, got: %v", err)
+		}
+	})
+}

--- a/internal/supplychain/config_registry_test.go
+++ b/internal/supplychain/config_registry_test.go
@@ -146,6 +146,11 @@ func TestLoadConfigRegistryURLValidation(t *testing.T) {
 			yaml:   "registries:\n  pypi: https://nexus.corp/repository/pypi-group/\n",
 			errHas: "/simple/",
 		},
+		{
+			name:   "pypi path merely containing simple as a substring rejected",
+			yaml:   "registries:\n  pypi: https://nexus.corp/repository/pypi-simplex/\n",
+			errHas: "/simple/",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/supplychain/config_registry_test.go
+++ b/internal/supplychain/config_registry_test.go
@@ -151,6 +151,16 @@ func TestLoadConfigRegistryURLValidation(t *testing.T) {
 			yaml:   "registries:\n  pypi: https://nexus.corp/repository/pypi-simplex/\n",
 			errHas: "/simple/",
 		},
+		// v1 only ROUTES the "npm"/"pypi" keys (RegistryURLFor), but validate()
+		// checks every key's value regardless of whether it's wired up — an
+		// unrecognized key with an insecure URL is still a hard error, not
+		// silently ignored, so a typo'd key doesn't sit unnoticed until it
+		// becomes a live route in a future version.
+		{
+			name:   "unrecognized registries key is still validated",
+			yaml:   "registries:\n  docker: http://nexus.corp/docker/\n",
+			errHas: "https",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/supplychain/npmrc.go
+++ b/internal/supplychain/npmrc.go
@@ -1,9 +1,15 @@
 package supplychain
 
 import (
+	"fmt"
+	"net/url"
 	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 )
+
+// ─── npmrc marker management (init --mode npmrc / uninit) ───
 
 // NpmrcFileName is the project-local npm config file that `supply-chain init
 // --mode npmrc` annotates and `supply-chain uninit` cleans.
@@ -123,4 +129,184 @@ func removeNpmrcMarkerLines(content string) string {
 		return ""
 	}
 	return text + "\n"
+}
+
+// ─── npmrc auth-token extraction (custom artifactory, PPSC-994) ───
+
+// tokenCharset is the set of characters a resolved auth token may contain
+// before it is placed in an `Authorization: Bearer <token>` header. npm/Nexus
+// tokens are URL-safe base64-ish strings; this set covers them plus the
+// punctuation real tokens use. A token failing this check is REJECTED, never
+// sanitized (S4/E5): silently stripping a character would forward a corrupted
+// credential (guaranteeing an opaque 401), and the check is what stops a
+// header-injection payload smuggled through a ${VAR} from reaching the header
+// writer. sanitizeHeaderValue only removes CR/LF; this is the positive guard.
+var tokenCharset = regexp.MustCompile(`^[A-Za-z0-9+/=._~-]+$`)
+
+// envVarRef matches a plain ${VAR} reference. v1 supports ONLY this bare form —
+// not ${VAR:-default} or nested expansion — because Nexus's `npm config` output
+// uses the plain form and supporting shell-style defaults would invite the
+// parser to diverge from what npm itself resolves. A name follows the POSIX
+// identifier rule ([A-Za-z_][A-Za-z0-9_]*).
+var envVarRef = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
+
+// authTokenMarker is the .npmrc key suffix that introduces a bearer token. The
+// key has the shape `//<host>[<path>]/:_authToken=<value>`; everything left of
+// the marker is the registry reference the token authenticates.
+//
+// armis:ignore cwe:798 reason:this is the literal .npmrc KEY NAME the parser searches for, not a credential value; no secret is embedded
+const authTokenMarker = ":_authToken=" //nolint:gosec // G101: this is a config key name, not a hardcoded credential
+
+// NpmrcAuthToken extracts the bearer token configured for upstream from one or
+// more .npmrc file contents (project first, then user/global — earlier entries
+// win, matching npm's project-over-home precedence). It looks for the
+// host-AND-path-scoped key first (the form Nexus/Artifactory emit, e.g.
+// `//nexus.corp/repository/npm-group/:_authToken=`) and falls back to the bare
+// host-scoped key (`//nexus.corp/:_authToken=`).
+//
+// Returns:
+//   - (token, true, nil)  — a usable token was found, interpolated, validated.
+//   - ("", false, nil)    — no token is configured for this upstream (no auth).
+//   - ("", false, err)    — a token was found but is unusable: an unset ${VAR}
+//     or a value that fails the safe charset. This is a HARD error the caller
+//     surfaces; it must not fall through to an unauthenticated request that
+//     would 401 with a confusing message.
+func NpmrcAuthToken(contents []string, upstream *url.URL) (string, bool, error) {
+	if upstream == nil {
+		return "", false, nil
+	}
+
+	hostPathKey, hostKey := npmrcKeyCandidates(upstream)
+
+	for _, content := range contents {
+		tokens := parseNpmrcTokens(content)
+		raw, ok := tokens[hostPathKey]
+		if !ok {
+			raw, ok = tokens[hostKey]
+		}
+		if !ok {
+			continue
+		}
+		resolved, err := resolveNpmrcToken(raw)
+		if err != nil {
+			return "", false, err
+		}
+		return resolved, true, nil
+	}
+
+	return "", false, nil
+}
+
+// ReadNpmrcAuthToken is NpmrcAuthToken sourced from the developer's real .npmrc
+// files: the project file in projectDir (highest precedence) then the user file
+// at ~/.npmrc. Missing files are skipped silently — absent native config simply
+// means "no token," which is a valid no-auth state, not an error.
+func ReadNpmrcAuthToken(projectDir string, upstream *url.URL) (string, bool, error) {
+	var contents []string
+	candidates := []string{filepath.Join(projectDir, ".npmrc")}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates, filepath.Join(home, ".npmrc"))
+	}
+	for _, path := range candidates {
+		// armis:ignore cwe:22 cwe:23 cwe:73 reason:reading the developer's own .npmrc from their project dir and home dir to forward their own credential; paths are a fixed ".npmrc" leaf joined to the user-controlled project/home dir, not untrusted input crossing a trust boundary, and the read is size-bounded below
+		data, err := os.ReadFile(path) //nolint:gosec // developer's own .npmrc
+		if err != nil {
+			continue
+		}
+		// Bound the read so a pathological .npmrc cannot exhaust memory.
+		if len(data) > maxConfigSize {
+			data = data[:maxConfigSize]
+		}
+		contents = append(contents, string(data))
+	}
+	return NpmrcAuthToken(contents, upstream)
+}
+
+// npmrcKeyCandidates derives the two .npmrc registry-reference keys to look up
+// for an upstream: the host+path-scoped form and the bare host form. Both are
+// normalized to a trailing slash, matching how npm writes them.
+func npmrcKeyCandidates(upstream *url.URL) (hostPath, host string) {
+	h := upstream.Host
+	p := strings.TrimSuffix(upstream.Path, "/")
+	hostPath = "//" + h + p + "/"
+	host = "//" + h + "/"
+	return hostPath, host
+}
+
+// parseNpmrcTokens scans .npmrc content and returns a map of registry-reference
+// key (e.g. "//host/path/") to the raw, un-interpolated token value. Lines that
+// are blank, comments (# or ;), or not _authToken assignments are ignored. The
+// token value is split on the FIRST "=" after the marker so a base64 token
+// containing "=" padding is preserved intact (E8).
+func parseNpmrcTokens(content string) map[string]string {
+	tokens := make(map[string]string)
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		idx := strings.Index(line, authTokenMarker)
+		if idx < 0 {
+			continue
+		}
+		key := line[:idx]
+		value := line[idx+len(authTokenMarker):]
+		// Strip optional surrounding quotes npm tolerates around the value.
+		value = strings.Trim(strings.TrimSpace(value), `"'`)
+		if key == "" || value == "" {
+			continue
+		}
+		// Normalize the key to a trailing slash so "//host" and "//host/" match.
+		if !strings.HasSuffix(key, "/") {
+			key += "/"
+		}
+		tokens[key] = value
+	}
+	return tokens
+}
+
+// resolveNpmrcToken interpolates any plain ${VAR} references against the
+// environment and then validates the result against the safe charset. An unset
+// referenced variable or a value containing header-hostile characters is a hard
+// error (reject, don't sanitize — S4/E5).
+func resolveNpmrcToken(raw string) (string, error) {
+	var missing string
+	resolved := envVarRef.ReplaceAllStringFunc(raw, func(ref string) string {
+		name := envVarRef.FindStringSubmatch(ref)[1]
+		val, ok := os.LookupEnv(name)
+		if !ok {
+			if missing == "" {
+				missing = name
+			}
+			return ""
+		}
+		return val
+	})
+	if missing != "" {
+		return "", fmt.Errorf("registry auth token references ${%s}, which is not set in the environment", missing)
+	}
+	if !tokenCharset.MatchString(resolved) {
+		return "", fmt.Errorf("registry auth token contains characters outside the allowed set [A-Za-z0-9+/=._~-] and was rejected (it is not sanitized); check the _authToken in your .npmrc")
+	}
+	return resolved, nil
+}
+
+// IndexURLBasicAuth extracts userinfo embedded in a pip/uv index URL
+// (https://user:token@nexus.corp/...) and returns the value for an
+// `Authorization: Basic` header credential (the raw "user:password" string,
+// pre-base64). It returns ("", false, nil) when the URL carries no userinfo,
+// and a hard error when the decoded credential contains header-hostile bytes
+// (CR/LF) — the basic-auth analogue of the token-charset reject.
+func IndexURLBasicAuth(rawIndexURL string) (string, bool, error) {
+	u, err := url.Parse(strings.TrimSpace(rawIndexURL))
+	if err != nil || u.User == nil {
+		return "", false, nil
+	}
+	user := u.User.Username()
+	pass, _ := u.User.Password()
+	cred := user + ":" + pass
+	if strings.ContainsAny(cred, "\r\n") {
+		return "", false, fmt.Errorf("index-url credentials contain invalid characters and were rejected")
+	}
+	return cred, true, nil
 }

--- a/internal/supplychain/npmrc_test.go
+++ b/internal/supplychain/npmrc_test.go
@@ -1,11 +1,15 @@
 package supplychain
 
 import (
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
+
+// ─── npmrc marker management tests ───
 
 func TestHasNpmrcMarker(t *testing.T) {
 	tests := []struct {
@@ -219,4 +223,209 @@ func readFile(t *testing.T, path string) string {
 		t.Fatalf("read %s: %v", path, err)
 	}
 	return string(b)
+}
+
+// ─── npmrc auth-token extraction tests (PPSC-994) ───
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parsing %q: %v", raw, err)
+	}
+	return u
+}
+
+// TestNpmrcAuthToken is test-plan case #6: .npmrc token parsing — embedded "="
+// not truncated, host+path-scoped key preferred, missing file/key → no token,
+// no crash.
+func TestNpmrcAuthToken(t *testing.T) {
+	upstream := mustParseURL(t, "https://nexus.corp/repository/npm-group/")
+
+	t.Run("host+path scoped key", func(t *testing.T) {
+		npmrc := "//nexus.corp/repository/npm-group/:_authToken=abc123\n"
+		tok, ok, err := NpmrcAuthToken([]string{npmrc}, upstream)
+		if err != nil || !ok {
+			t.Fatalf("expected token, got ok=%v err=%v", ok, err)
+		}
+		if tok != "abc123" {
+			t.Errorf("token = %q", tok)
+		}
+	})
+
+	t.Run("bare host-scoped key fallback", func(t *testing.T) {
+		npmrc := "//nexus.corp/:_authToken=hosttok\n"
+		tok, ok, err := NpmrcAuthToken([]string{npmrc}, upstream)
+		if err != nil || !ok {
+			t.Fatalf("expected token, got ok=%v err=%v", ok, err)
+		}
+		if tok != "hosttok" {
+			t.Errorf("token = %q", tok)
+		}
+	})
+
+	t.Run("host+path preferred over bare host", func(t *testing.T) {
+		npmrc := "//nexus.corp/:_authToken=hosttok\n//nexus.corp/repository/npm-group/:_authToken=pathtok\n"
+		tok, _, _ := NpmrcAuthToken([]string{npmrc}, upstream)
+		if tok != "pathtok" {
+			t.Errorf("expected host+path token to win, got %q", tok)
+		}
+	})
+
+	t.Run("base64 token with = padding not truncated", func(t *testing.T) {
+		npmrc := "//nexus.corp/repository/npm-group/:_authToken=YWJjZGVm==\n"
+		tok, ok, err := NpmrcAuthToken([]string{npmrc}, upstream)
+		if err != nil || !ok {
+			t.Fatalf("ok=%v err=%v", ok, err)
+		}
+		if tok != "YWJjZGVm==" {
+			t.Errorf("token truncated: %q", tok)
+		}
+	})
+
+	t.Run("missing key → no token, no error", func(t *testing.T) {
+		npmrc := "//other.host/:_authToken=nope\nregistry=https://nexus.corp/\n"
+		tok, ok, err := NpmrcAuthToken([]string{npmrc}, upstream)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ok || tok != "" {
+			t.Errorf("expected no token, got ok=%v tok=%q", ok, tok)
+		}
+	})
+
+	t.Run("empty contents → no token, no crash", func(t *testing.T) {
+		tok, ok, err := NpmrcAuthToken(nil, upstream)
+		if err != nil || ok || tok != "" {
+			t.Errorf("expected clean no-token, got ok=%v tok=%q err=%v", ok, tok, err)
+		}
+	})
+
+	t.Run("nil upstream → no token", func(t *testing.T) {
+		_, ok, err := NpmrcAuthToken([]string{"//x/:_authToken=y"}, nil)
+		if ok || err != nil {
+			t.Errorf("nil upstream should yield no token, got ok=%v err=%v", ok, err)
+		}
+	})
+
+	t.Run("comments and blank lines ignored", func(t *testing.T) {
+		npmrc := "# a comment\n; another\n\n//nexus.corp/repository/npm-group/:_authToken=realtok\n"
+		tok, ok, _ := NpmrcAuthToken([]string{npmrc}, upstream)
+		if !ok || tok != "realtok" {
+			t.Errorf("token = %q ok=%v", tok, ok)
+		}
+	})
+
+	t.Run("project file wins over user file", func(t *testing.T) {
+		project := "//nexus.corp/repository/npm-group/:_authToken=projecttok\n"
+		user := "//nexus.corp/repository/npm-group/:_authToken=usertok\n"
+		tok, _, _ := NpmrcAuthToken([]string{project, user}, upstream)
+		if tok != "projecttok" {
+			t.Errorf("expected project token to win, got %q", tok)
+		}
+	})
+}
+
+// TestResolveNpmrcToken is test-plan case #5: ${VAR} interpolation resolved;
+// resolved token failing the safe charset → rejected with a clear error.
+func TestResolveNpmrcToken(t *testing.T) {
+	upstream := mustParseURL(t, "https://nexus.corp/npm/")
+
+	t.Run("plain ${VAR} interpolated", func(t *testing.T) {
+		t.Setenv("ARMIS_TEST_NPM_TOKEN", "resolved-secret")
+		npmrc := "//nexus.corp/npm/:_authToken=${ARMIS_TEST_NPM_TOKEN}\n"
+		tok, ok, err := NpmrcAuthToken([]string{npmrc}, upstream)
+		if err != nil || !ok {
+			t.Fatalf("ok=%v err=%v", ok, err)
+		}
+		if tok != "resolved-secret" {
+			t.Errorf("token = %q", tok)
+		}
+	})
+
+	t.Run("unset ${VAR} → hard error", func(t *testing.T) {
+		npmrc := "//nexus.corp/npm/:_authToken=${ARMIS_DEFINITELY_UNSET_VAR}\n"
+		_, _, err := NpmrcAuthToken([]string{npmrc}, upstream)
+		if err == nil {
+			t.Fatal("expected an error for an unset env var")
+		}
+		if !strings.Contains(err.Error(), "ARMIS_DEFINITELY_UNSET_VAR") {
+			t.Errorf("error should name the missing var, got: %v", err)
+		}
+	})
+
+	t.Run("header-hostile resolved token → rejected not sanitized", func(t *testing.T) {
+		// A token carrying a CRLF + injected header must be rejected outright.
+		t.Setenv("ARMIS_TEST_BAD_TOKEN", "good\r\nX-Injected: evil")
+		npmrc := "//nexus.corp/npm/:_authToken=${ARMIS_TEST_BAD_TOKEN}\n"
+		_, _, err := NpmrcAuthToken([]string{npmrc}, upstream)
+		if err == nil {
+			t.Fatal("expected rejection of a header-hostile token")
+		}
+		if !strings.Contains(err.Error(), "rejected") {
+			t.Errorf("error should say rejected, got: %v", err)
+		}
+	})
+
+	t.Run("token with space → rejected", func(t *testing.T) {
+		npmrc := "//nexus.corp/npm/:_authToken=has space\n"
+		_, _, err := NpmrcAuthToken([]string{npmrc}, upstream)
+		if err == nil {
+			t.Fatal("expected rejection of a token with a space")
+		}
+	})
+}
+
+// TestReadNpmrcAuthToken exercises the filesystem-backed reader against a real
+// project .npmrc, covering the project-file path and the missing-file no-op.
+func TestReadNpmrcAuthToken(t *testing.T) {
+	upstream := mustParseURL(t, "https://nexus.corp/repository/npm-group/")
+
+	t.Run("reads project .npmrc", func(t *testing.T) {
+		dir := t.TempDir()
+		npmrc := "//nexus.corp/repository/npm-group/:_authToken=projecttoken\n"
+		if err := os.WriteFile(filepath.Join(dir, ".npmrc"), []byte(npmrc), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		tok, ok, err := ReadNpmrcAuthToken(dir, upstream)
+		if err != nil || !ok {
+			t.Fatalf("ok=%v err=%v", ok, err)
+		}
+		if tok != "projecttoken" {
+			t.Errorf("token = %q", tok)
+		}
+	})
+
+	t.Run("missing project .npmrc → no token from project (home may still apply)", func(t *testing.T) {
+		dir := t.TempDir() // no .npmrc written
+		// Point HOME at an empty dir too so the user-level read also misses,
+		// making the result deterministic regardless of the dev's real ~/.npmrc.
+		t.Setenv("HOME", t.TempDir())
+		tok, ok, err := ReadNpmrcAuthToken(dir, upstream)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ok || tok != "" {
+			t.Errorf("expected no token, got ok=%v tok=%q", ok, tok)
+		}
+	})
+}
+
+func TestIndexURLBasicAuth(t *testing.T) {
+	t.Run("userinfo extracted", func(t *testing.T) {
+		cred, ok, err := IndexURLBasicAuth("https://user:tok@nexus.corp/simple/")
+		if err != nil || !ok {
+			t.Fatalf("ok=%v err=%v", ok, err)
+		}
+		if cred != "user:tok" {
+			t.Errorf("cred = %q", cred)
+		}
+	})
+
+	t.Run("no userinfo → none", func(t *testing.T) {
+		_, ok, err := IndexURLBasicAuth("https://nexus.corp/simple/")
+		if ok || err != nil {
+			t.Errorf("expected no cred, got ok=%v err=%v", ok, err)
+		}
+	})
 }

--- a/internal/supplychain/proxy.go
+++ b/internal/supplychain/proxy.go
@@ -2,7 +2,10 @@ package supplychain
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -113,9 +116,18 @@ type allowedVersion struct {
 }
 
 type Proxy struct {
-	policy       Policy
-	mode         ProxyMode
-	upstreamURL  *url.URL
+	policy      Policy
+	mode        ProxyMode
+	upstreamURL *url.URL
+
+	// customUpstream, authHeader, and the degrade fields are the PPSC-994
+	// custom-artifactory additions. customUpstream gates the WWW-Authenticate
+	// stripping; authHeader is the pre-built "Bearer <tok>"/"Basic <b64>" value
+	// injected on every upstream request (or "" for the public path).
+	customUpstream             bool
+	authHeader                 string // pre-built "Bearer <tok>" / "Basic <b64>" value, or ""
+	degradeOnMissingTimestamps bool
+
 	httpClient   *http.Client
 	revProxy     *httputil.ReverseProxy
 	listener     net.Listener
@@ -127,6 +139,11 @@ type Proxy struct {
 	checked      int
 	checkedMu    sync.Mutex
 	skipPackages map[string]bool
+
+	// degradeWarned guards the one-time missing-timestamp degraded-enforcement
+	// warning emitted when degradeOnMissingTimestamps is set (PPSC-994).
+	degradeWarned bool
+	degradeWarnMu sync.Mutex
 
 	// directSet is the root manifest's direct-dependency names (WS5). It is read
 	// once at wrap start and never mutated afterward, so no lock guards it. A nil
@@ -167,10 +184,32 @@ type ProxyConfig struct {
 	// direct and blocks young versions regardless of the transitive policy
 	// (fail-safe). Only consulted when Policy.TransitivePolicy is warn.
 	DirectDeps []string
+
+	// AuthHeader is the complete Authorization header value to attach to EVERY
+	// forwarded upstream request (metadata AND tarball) — e.g. "Bearer <tok>"
+	// for an npm _authToken or "Basic <base64>" for pip/uv index-url userinfo.
+	// Empty means no auth (the public-registry path). The cmd layer reads the
+	// developer's native config, interpolates/validates, and hands the finished
+	// value here so the proxy itself does no filesystem I/O (testability seam).
+	AuthHeader string
+
+	// DegradeOnMissingTimestamps relaxes the age filter's fail-closed posture
+	// when, and ONLY when, a custom artifactory upstream is configured: an
+	// undatable response passes through with one warning rather than being
+	// removed. It is unset on the default public-registry path, where missing
+	// timestamps stay fail-closed (a public registry always emits them, so a
+	// missing one is suspicious). Lives here, not on Policy, because Policy
+	// threads into check.RunCheck where missing-timestamp semantics differ (E7).
+	DegradeOnMissingTimestamps bool
+
+	// CABundlePath optionally points at a PEM CA bundle for the proxy→upstream
+	// TLS leg (S6), letting a minimal CI container reach a private-CA Nexus.
+	CABundlePath string
 }
 
 func NewProxy(cfg ProxyConfig) (*Proxy, error) {
 	upstream := cfg.UpstreamURL
+	customUpstream := upstream != ""
 	if upstream == "" {
 		// Default the upstream to match the mode so a PyPI proxy constructed with
 		// only a Mode (the common case) still points at pypi.org rather than the
@@ -182,6 +221,15 @@ func NewProxy(cfg ProxyConfig) (*Proxy, error) {
 		}
 	}
 
+	// A configured custom upstream is a trust boundary, but it is validated by
+	// ValidateRegistryURL at config-load (config.go) and again explicitly in
+	// runProxyWrap before this constructor is reached — the same
+	// validate-at-the-caller contract NewClientWithHTTP follows. NewProxy itself
+	// trusts UpstreamURL as a construction-time value so tests (and the
+	// already-validated production path) can pass an httptest/loopback URL; the
+	// cwe:918 suppressions on the forwarding sinks reflect this ("validated at
+	// config-load"). Re-validating here would reject every test's httptest
+	// upstream.
 	upstreamURL, err := url.Parse(upstream)
 	if err != nil {
 		return nil, fmt.Errorf("parsing upstream URL: %w", err)
@@ -205,39 +253,133 @@ func NewProxy(cfg ProxyConfig) (*Proxy, error) {
 		}
 	}
 
+	httpClient, err := newUpstreamHTTPClient(upstreamURL, cfg.CABundlePath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Construct p before the reverse proxy: the Director closure captures p so it
+	// can inject the auth header per request (p.buildAuthHeader). revProxy is
+	// assigned onto p once it is built, below.
+	p := &Proxy{
+		policy:                     cfg.Policy,
+		mode:                       cfg.Mode,
+		upstreamURL:                upstreamURL,
+		customUpstream:             customUpstream,
+		authHeader:                 cfg.AuthHeader,
+		degradeOnMissingTimestamps: cfg.DegradeOnMissingTimestamps,
+		httpClient:                 httpClient,
+		skipPackages:               skipSet,
+		allowed:                    make(map[string]allowedVersion),
+		directSet:                  directSet,
+		requiredRanges:             make(map[string][]requiredRange),
+		keptVersions:               make(map[string][]string),
+		removedVersions:            make(map[string][]string),
+	}
+
 	// NewSingleHostReverseProxy rewrites the request URL's scheme/host but
 	// deliberately does NOT rewrite the Host header (see its doc comment). Left
 	// as-is, tarball passthrough requests reach the upstream registry carrying
 	// the local proxy's Host (e.g. "127.0.0.1:61396"). registry.npmjs.org is
 	// fronted by a CDN that routes on Host, so an unknown value returns 403 —
 	// the metadata check passes but the actual .tgz download fails. Wrap the
-	// Director to point Host at the upstream registry so passthrough works.
-	// upstreamURL is parsed from cfg.UpstreamURL, a startup-configured trusted
-	// host defaulting to registry.npmjs.org/pypi.org — not a per-request
+	// Director to point Host at the upstream registry so passthrough works, and
+	// inject the auth header so private-repo tarballs (a separate request from
+	// metadata — confirmed by the PPSC-994 prototype) authenticate too.
+	// upstreamURL is the default registry.npmjs.org/pypi.org constant or a custom
+	// upstream validated by ValidateRegistryURL at config-load — not a per-request
 	// attacker-controlled value (matches the CWE-918 suppressions in reverseProxy).
-	// armis:ignore cwe:918 reason:upstreamURL is a startup-configured trusted host defaulting to registry.npmjs.org/pypi.org, not a per-request attacker-controlled value
+	// armis:ignore cwe:918 reason:upstreamURL is a startup-configured trusted host (default registry.npmjs.org/pypi.org or a config-load-validated custom upstream), not a per-request attacker-controlled value
 	revProxy := httputil.NewSingleHostReverseProxy(upstreamURL)
 	baseDirector := revProxy.Director
 	revProxy.Director = func(req *http.Request) {
 		baseDirector(req)
 		// armis:ignore cwe:918 reason:upstreamURL.Host is the startup-configured trusted upstream (default registry.npmjs.org/pypi.org); setting the outbound Host to it is required for CDN routing and is not attacker-controlled
 		req.Host = upstreamURL.Host
+		if h := p.buildAuthHeader(); h != "" {
+			req.Header.Set("Authorization", h)
+		}
+	}
+	revProxy.Transport = httpClient.Transport
+	// When a custom upstream is configured, a 4xx from it must NOT carry the
+	// upstream's WWW-Authenticate realm back to the package manager: npm would
+	// honor the realm and re-authenticate DIRECTLY against the upstream host,
+	// bypassing the proxy (and its age filtering) entirely. Strip it and leave a
+	// clean status; the metadata path logs an actionable message (S5/E3).
+	revProxy.ModifyResponse = p.modifyUpstreamResponse
+	p.revProxy = revProxy
+
+	return p, nil
+}
+
+// buildAuthHeader returns the Authorization header value to attach to upstream
+// requests, or "" when no credential is configured. It is the SINGLE seam the
+// design mandates: both handleMetadataFiltering (the explicit forward) and the
+// reverse-proxy Director (tarballs, RPC) call it, so the metadata and tarball
+// legs authenticate identically. The PPSC-994 prototype proved both legs hit a
+// private repo and both need the credential.
+func (p *Proxy) buildAuthHeader() string {
+	return p.authHeader
+}
+
+// modifyUpstreamResponse is the reverse-proxy ModifyResponse hook. On a custom
+// upstream it strips WWW-Authenticate from any 4xx so the PM cannot re-auth
+// directly against the upstream host, bypassing the proxy (S5).
+func (p *Proxy) modifyUpstreamResponse(resp *http.Response) error {
+	if p.customUpstream && resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		resp.Header.Del("WWW-Authenticate")
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			fmt.Fprintf(os.Stderr, "[armis] supply-chain: registry auth failed (%d) for %s — check your credentials (.npmrc _authToken, not _auth) for %s\n",
+				resp.StatusCode, resp.Request.URL.Path, p.upstreamURL.Host)
+		}
+	}
+	return nil
+}
+
+// newUpstreamHTTPClient builds the HTTP client used for the proxy→upstream leg.
+// Two security properties beyond the default client:
+//
+//   - CheckRedirect refuses any cross-host redirect (S2). Go already strips the
+//     Authorization header across hosts, but refusing the redirect outright
+//     means the injected credential provably never even attempts a hop off the
+//     approved host — defense in depth against a 3xx pointed at an attacker.
+//   - an optional CA bundle is loaded into the TLS config (S6) so a minimal CI
+//     container can reach a Nexus fronted by a corporate/private CA. A bad
+//     bundle path is a hard error (a TLS failure must be visible, never a silent
+//     fail-open enforcement bypass).
+func newUpstreamHTTPClient(upstreamURL *url.URL, caBundlePath string) (*http.Client, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+
+	if caBundlePath != "" {
+		// armis:ignore cwe:22 cwe:23 cwe:73 reason:caBundlePath is an operator-supplied path from the committed config / ARMIS_REGISTRY_CA_BUNDLE env (the deploying platform team's own file), read once at proxy startup to trust their corporate CA; not untrusted input crossing a trust boundary
+		pem, err := os.ReadFile(caBundlePath) //nolint:gosec // operator-configured CA bundle
+		if err != nil {
+			return nil, fmt.Errorf("reading registry CA bundle %q: %w", caBundlePath, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("registry CA bundle %q contains no valid PEM certificates", caBundlePath)
+		}
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12} //nolint:gosec // MinVersion set explicitly
+		}
+		transport.TLSClientConfig.RootCAs = pool
 	}
 
-	return &Proxy{
-		policy:      cfg.Policy,
-		mode:        cfg.Mode,
-		upstreamURL: upstreamURL,
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
+	// Compare the full origin (host:port), not just the hostname: a redirect to a
+	// different port on the same host is still a different origin the credential
+	// must not leak to. This is the strict reading of S2 ("off the approved
+	// host") and the safe default for a security control.
+	upstreamOrigin := upstreamURL.Host
+	return &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			if req.URL.Host != upstreamOrigin {
+				return fmt.Errorf("refusing cross-host redirect to %q (credentials must not leave the approved registry origin %q)", req.URL.Host, upstreamOrigin)
+			}
+			return nil
 		},
-		revProxy:        revProxy,
-		skipPackages:    skipSet,
-		allowed:         make(map[string]allowedVersion),
-		directSet:       directSet,
-		requiredRanges:  make(map[string][]requiredRange),
-		keptVersions:    make(map[string][]string),
-		removedVersions: make(map[string][]string),
 	}, nil
 }
 
@@ -390,8 +532,8 @@ func (p *Proxy) handleMetadataFiltering(w http.ResponseWriter, r *http.Request, 
 	// Use RequestURI() (escaped path + raw query) rather than just Path so the
 	// filtered branch is symmetric with the reverse-proxy passthrough: query
 	// params (e.g. ?write=true) and path-escaping nuances reach the upstream.
-	// armis:ignore cwe:918 reason:p.upstreamURL is a startup-configured trusted host (defaults to registry.npmjs.org); r.URL.RequestURI() is the path/query from the local proxy client and cannot change the host
-	upstreamReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, p.upstreamURL.String()+r.URL.RequestURI(), nil) //nolint:gosec // upstream URL is configured at startup, path is from local proxy
+	// armis:ignore cwe:918 reason:p.upstreamURL is the default npmjs.org/pypi.org constant or a custom upstream validated by ValidateRegistryURL at config-load (https-only, no userinfo, rejects loopback/RFC1918/link-local); r.URL.RequestURI() is the path/query from the local proxy client and cannot change the host
+	upstreamReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, p.upstreamURL.String()+r.URL.RequestURI(), nil) //nolint:gosec // upstream URL is a constant default or config-load-validated; path is from the local proxy
 	if err != nil {
 		http.Error(w, fmt.Sprintf("[armis] supply-chain: failed to create request for %s", pkgName), http.StatusBadGateway)
 		return
@@ -403,10 +545,23 @@ func (p *Proxy) handleMetadataFiltering(w http.ResponseWriter, r *http.Request, 
 	} else {
 		upstreamReq.Header.Set("Accept", "application/json")
 	}
+	// Inject the developer's upstream credential on the metadata leg via the
+	// SAME seam the tarball Director uses, so both authenticate identically.
+	if h := p.buildAuthHeader(); h != "" {
+		upstreamReq.Header.Set("Authorization", h)
+	}
 
-	// armis:ignore cwe:918 reason:p.upstreamURL is a startup-configured trusted host (defaults to registry.npmjs.org); the request host is not attacker-controlled
-	resp, err := p.httpClient.Do(upstreamReq) //nolint:gosec // URL constructed from trusted upstream config
+	// armis:ignore cwe:918 reason:p.upstreamURL is the default npmjs.org/pypi.org constant or a custom upstream validated by ValidateRegistryURL at config-load (https-only, no userinfo, rejects loopback/RFC1918/link-local), so the request host is not attacker-controlled
+	resp, err := p.httpClient.Do(upstreamReq) //nolint:gosec // URL is a constant default or config-load-validated upstream
 	if err != nil {
+		// A TLS trust failure to a private-CA artifactory is a common CI gotcha;
+		// name the fix (CA bundle) rather than letting it look like a generic
+		// outage. Critically, this must surface — never silently fail-open into a
+		// direct-to-upstream bypass (S6/E9).
+		if p.customUpstream && isX509Error(err) {
+			fmt.Fprintf(os.Stderr, "[armis] supply-chain: TLS trust error reaching %s for %s: %v\n", p.upstreamURL.Host, pkgName, err)
+			fmt.Fprintf(os.Stderr, "  Set registry-ca-bundle in .armis-supply-chain.yaml (or ARMIS_REGISTRY_CA_BUNDLE) to your corporate CA PEM.\n")
+		}
 		if p.policy.FailOpen {
 			fmt.Fprintf(os.Stderr, "[armis] supply-chain: age check unavailable for %s, allowing (fail-open): %v\n", pkgName, err)
 			p.reverseProxy(w, r)
@@ -419,6 +574,14 @@ func (p *Proxy) handleMetadataFiltering(w http.ResponseWriter, r *http.Request, 
 	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
+		// When a custom upstream returns an auth challenge, strip WWW-Authenticate
+		// so the PM cannot re-auth directly against the upstream host and bypass
+		// the proxy (S5/E3); surface an actionable message instead.
+		if p.customUpstream && (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden) {
+			resp.Header.Del("WWW-Authenticate")
+			fmt.Fprintf(os.Stderr, "[armis] supply-chain: registry auth failed (%d) for %s — check your credentials (.npmrc _authToken, not _auth) for %s\n",
+				resp.StatusCode, pkgName, p.upstreamURL.Host)
+		}
 		// Copy headers value-by-value with CR/LF stripped rather than aliasing the
 		// upstream slices wholesale (w.Header()[k] = v). The verbatim copy both
 		// shared upstream's backing arrays and bypassed the response-splitting
@@ -537,6 +700,33 @@ func sanitizeHeaderValue(v string) string {
 	return strings.NewReplacer("\r", "", "\n", "").Replace(v)
 }
 
+// isX509Error reports whether err is (or wraps) an X.509 certificate trust
+// failure, so the proxy can print the CA-bundle fix rather than a generic
+// "unreachable" message. It checks the typed certificate errors directly
+// (rather than string-matching) so the detection is robust across Go versions.
+func isX509Error(err error) bool {
+	var unknownAuthority x509.UnknownAuthorityError
+	var hostnameErr x509.HostnameError
+	var certInvalid x509.CertificateInvalidError
+	return errors.As(err, &unknownAuthority) || errors.As(err, &hostnameErr) || errors.As(err, &certInvalid)
+}
+
+// warnDegradedEnforcement emits the one-time "age policy could not be enforced"
+// notice when a configured artifactory upstream returns a response with no
+// usable publish timestamps. It fires at most once per proxy (per wrapped
+// install) so a large dependency tree does not repeat it per package. It is
+// only ever called from the degrade path, which is itself gated on
+// degradeOnMissingTimestamps — so the default public path never reaches here.
+func (p *Proxy) warnDegradedEnforcement() {
+	p.degradeWarnMu.Lock()
+	defer p.degradeWarnMu.Unlock()
+	if p.degradeWarned {
+		return
+	}
+	p.degradeWarned = true
+	fmt.Fprintf(os.Stderr, "[armis] supply-chain: age policy could not be enforced against %s (no publish timestamps) — installs pass through; rely on `supply-chain check` in CI for age enforcement\n", p.upstreamURL.Host)
+}
+
 func (p *Proxy) filterMetadata(body []byte, pkgName string) ([]byte, []BlockedPackage) {
 	// body is already bounded to maxProxyResponseSize (20MB) by the io.LimitReader
 	// at the sole production call site; oversize upstream responses are rejected
@@ -550,12 +740,24 @@ func (p *Proxy) filterMetadata(body []byte, pkgName string) ([]byte, []BlockedPa
 
 	timeRaw, ok := metadata["time"]
 	if !ok {
+		// The npm filter has always passed through when the `time` map is absent
+		// (it cannot remove what it cannot date). That pass-through is unchanged;
+		// the only new behavior is that a CONFIGURED artifactory upstream which
+		// strips timestamps now emits the one-time degraded-enforcement notice, so
+		// the gap is visible rather than silent. The default public path (flag
+		// unset) stays silent exactly as before — npmjs.org always sends `time`.
+		if p.degradeOnMissingTimestamps {
+			p.warnDegradedEnforcement()
+		}
 		return body, nil
 	}
 
 	var timeMap map[string]string
 	// armis:ignore cwe:770 reason:timeRaw is a sub-slice of the already size-bounded body (capped at 20MB by io.LimitReader at the caller); unmarshaling it cannot allocate beyond that cap
 	if err := json.Unmarshal(timeRaw, &timeMap); err != nil {
+		if p.degradeOnMissingTimestamps {
+			p.warnDegradedEnforcement()
+		}
 		return body, nil
 	}
 
@@ -901,16 +1103,34 @@ func (p *Proxy) filterPyPISimple(body []byte, pkgName string) ([]byte, []Blocked
 
 	for _, f := range files {
 		filename := jsonString(f["filename"])
-		age, ok := pypiFileAge(f["upload-time"], now)
-		if !ok || age < p.policy.MinReleaseAge {
-			// Undatable or too-young file: remove it. Record an age of 0 for the
-			// undatable case so the summary still names the blocked file.
-			if !ok {
-				age = 0
+		age, dated := pypiFileAge(f["upload-time"], now)
+		if !dated {
+			// Undatable file. Default (public PyPI) posture is fail-CLOSED: remove
+			// it — public PyPI always emits PEP 700 timestamps, so a missing one is
+			// suspicious. But a configured artifactory may legitimately strip all
+			// timestamps; when degradeOnMissingTimestamps is set we KEEP the file and
+			// emit the one-time degraded-enforcement notice rather than blocking
+			// every install. The flag is set only for a configured upstream, so this
+			// never weakens the default public path (regression-guarded by test #9).
+			if p.degradeOnMissingTimestamps {
+				p.warnDegradedEnforcement()
+				kept = append(kept, f)
+				continue
 			}
 			// Version is the filename (what the user sees and what makes the block
 			// actionable); DisplayVersion is the semver parsed from it, used for
 			// prerelease classification and the clean number shown in the summary.
+			blocked = append(blocked, BlockedPackage{
+				Name:           pkgName,
+				Version:        filename,
+				DisplayVersion: pypiVersionFromFilename(filename),
+				Age:            0,
+			})
+			continue
+		}
+		if age < p.policy.MinReleaseAge {
+			// Datable but too young: always removed, regardless of the degrade flag —
+			// the timestamp exists and the file is genuinely within the age window.
 			blocked = append(blocked, BlockedPackage{
 				Name:           pkgName,
 				Version:        filename,

--- a/internal/supplychain/proxy.go
+++ b/internal/supplychain/proxy.go
@@ -128,17 +128,26 @@ type Proxy struct {
 	authHeader                 string // pre-built "Bearer <tok>" / "Basic <b64>" value, or ""
 	degradeOnMissingTimestamps bool
 
-	httpClient   *http.Client
-	revProxy     *httputil.ReverseProxy
-	listener     net.Listener
-	server       *http.Server
-	blocked      []BlockedPackage
-	blockedMu    sync.Mutex
-	allowed      map[string]allowedVersion // package name → resolved safe version
-	allowedMu    sync.Mutex
-	checked      int
-	checkedMu    sync.Mutex
-	skipPackages map[string]bool
+	httpClient *http.Client
+	revProxy   *httputil.ReverseProxy
+	listener   net.Listener
+	server     *http.Server
+	blocked    []BlockedPackage
+	blockedMu  sync.Mutex
+	allowed    map[string]allowedVersion // package name → resolved safe version
+	allowedMu  sync.Mutex
+	checked    int
+	checkedMu  sync.Mutex
+	// verifyFailed counts metadata requests that were counted in `checked` (a real
+	// age check was attempted) but could NOT be verified because the upstream was
+	// unreachable, its TLS could not be trusted, or its response was unreadable —
+	// the fail-closed error paths. It exists so the wrap summary never claims
+	// "N packages checked, all pass" when some checks in fact failed to run (e.g.
+	// a wrong registry-ca-bundle): a green checkmark must never overstate coverage
+	// the org did not actually get. Guarded by verifyFailedMu.
+	verifyFailed   int
+	verifyFailedMu sync.Mutex
+	skipPackages   map[string]bool
 
 	// degradeWarned guards the one-time missing-timestamp degraded-enforcement
 	// warning emitted when degradeOnMissingTimestamps is set (PPSC-994).
@@ -233,6 +242,19 @@ func NewProxy(cfg ProxyConfig) (*Proxy, error) {
 	upstreamURL, err := url.Parse(upstream)
 	if err != nil {
 		return nil, fmt.Errorf("parsing upstream URL: %w", err)
+	}
+
+	// A configured PyPI upstream is validated to end in "/simple" (PEP 503) — see
+	// config.go's registries.pypi check. The local index the proxy exposes to
+	// pip/uv already models that same "/simple/<pkg>/" shape (mirroring the
+	// pypi.org default, whose upstream has no "/simple" suffix of its own), so
+	// joinUpstreamURL's requestURI already carries "/simple/...". Strip the
+	// configured upstream's own "/simple" suffix here so the join produces
+	// ".../pypi-group/simple/<pkg>/" instead of a double
+	// ".../pypi-group/simple/simple/<pkg>/", which 404s into an HTML error page
+	// on real artifactories (Nexus, Artifactory) instead of the PEP 691 JSON.
+	if cfg.Mode == ModePyPI && customUpstream {
+		upstreamURL.Path = strings.TrimSuffix(strings.TrimSuffix(upstreamURL.Path, "/"), "/simple")
 	}
 
 	skipSet := make(map[string]bool, len(cfg.SkipPackages))
@@ -383,6 +405,28 @@ func newUpstreamHTTPClient(upstreamURL *url.URL, caBundlePath string) (*http.Cli
 	}, nil
 }
 
+// NewRegistryHTTPClient builds an HTTP client for talking to a configured
+// approved registry from OUTSIDE the proxy — specifically the `supply-chain
+// check` age-query path (PPSC-994), which reaches the same custom artifactory
+// the wrap proxy does and therefore needs the same private-CA trust. It shares
+// newUpstreamHTTPClient's two guarantees: an optional CA bundle (so a private-CA
+// Nexus is reachable) and a cross-host-redirect refusal. registryURL must have
+// passed ValidateRegistryURL. A nil return with nil error means "no custom
+// trust needed" (empty registryURL and empty caBundlePath) — the caller should
+// fall back to its default client. A bad CA bundle path is a hard error so a
+// TLS misconfiguration surfaces instead of silently failing every age check.
+// armis:ignore cwe:918 reason:registryURL is the config-load-validated registries.<eco> value (supplychain.ValidateRegistryURL: https-only, no userinfo, rejects loopback/RFC1918/link-local) at every call site (supply_chain_check.go, supply_chain_wrap.go); this constructor never receives a per-request or otherwise unvalidated URL
+func NewRegistryHTTPClient(registryURL, caBundlePath string) (*http.Client, error) {
+	if registryURL == "" && caBundlePath == "" {
+		return nil, nil
+	}
+	u, err := url.Parse(registryURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing approved registry URL %q: %w", registryURL, err)
+	}
+	return newUpstreamHTTPClient(u, caBundlePath)
+}
+
 func (p *Proxy) Start(ctx context.Context) (string, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -448,6 +492,28 @@ func (p *Proxy) Checked() int {
 	p.checkedMu.Lock()
 	defer p.checkedMu.Unlock()
 	return p.checked
+}
+
+// VerifyFailed returns the number of packages counted in Checked() whose age
+// could not actually be verified because the upstream errored out on the
+// fail-closed path (unreachable, untrusted TLS, or unreadable response). The
+// wrap summary subtracts this from Checked() so it never reports a package as
+// "checked, passed" when the check itself did not complete.
+func (p *Proxy) VerifyFailed() int {
+	p.verifyFailedMu.Lock()
+	defer p.verifyFailedMu.Unlock()
+	return p.verifyFailed
+}
+
+// markVerifyFailed records that one metadata age check attempted (and counted in
+// Checked) could not be verified against the upstream. Only the fail-closed
+// error paths call it — the fail-open paths pass the package through under an
+// explicit "allowing (fail-open)" notice, which is a deliberate, separately
+// surfaced posture rather than a silently-missed check.
+func (p *Proxy) markVerifyFailed() {
+	p.verifyFailedMu.Lock()
+	p.verifyFailed++
+	p.verifyFailedMu.Unlock()
 }
 
 func (p *Proxy) Allowed() []InstalledPackage {
@@ -528,12 +594,38 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 	p.handleMetadataFiltering(w, r, pkgName)
 }
 
+// joinUpstreamURL concatenates a base upstream URL and a request-URI path,
+// collapsing exactly one slash at the boundary so a trailing slash on the base
+// and a leading slash on the path do not produce a "//" in the result. It
+// mirrors httputil.NewSingleHostReverseProxy's internal singleJoiningSlash so
+// the metadata leg and the tarball (Director) leg build byte-identical upstream
+// URLs. Both inputs are trusted at this point (see handleMetadataFiltering's
+// cwe:918 note); this is a formatting fix, not a security boundary.
+// armis:ignore cwe:628 cwe:22 cwe:73 cwe:918 reason:base is the proxy's own validated upstream URL (constant default or ValidateRegistryURL-checked config); requestURI is the local wrapped-install client's own request path/query (r.URL.RequestURI() at the sole call site in handleMetadataFiltering), which the proxy is intentionally forwarding — this function only collapses a boundary slash, it introduces no new traversal beyond what the client already requested of itself, and httputil's reverse-proxy Director performs the identical unsanitized join for the tarball leg
+func joinUpstreamURL(base, requestURI string) string {
+	baseSlash := strings.HasSuffix(base, "/")
+	uriSlash := strings.HasPrefix(requestURI, "/")
+	switch {
+	case baseSlash && uriSlash:
+		return base + requestURI[1:]
+	case !baseSlash && !uriSlash:
+		return base + "/" + requestURI
+	default:
+		return base + requestURI
+	}
+}
+
 func (p *Proxy) handleMetadataFiltering(w http.ResponseWriter, r *http.Request, pkgName string) {
 	// Use RequestURI() (escaped path + raw query) rather than just Path so the
 	// filtered branch is symmetric with the reverse-proxy passthrough: query
 	// params (e.g. ?write=true) and path-escaping nuances reach the upstream.
-	// armis:ignore cwe:918 reason:p.upstreamURL is the default npmjs.org/pypi.org constant or a custom upstream validated by ValidateRegistryURL at config-load (https-only, no userinfo, rejects loopback/RFC1918/link-local); r.URL.RequestURI() is the path/query from the local proxy client and cannot change the host
-	upstreamReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, p.upstreamURL.String()+r.URL.RequestURI(), nil) //nolint:gosec // upstream URL is a constant default or config-load-validated; path is from the local proxy
+	// joinUpstreamURL collapses the boundary slash so a configured upstream with a
+	// trailing slash (e.g. "https://nexus.corp/") does not produce a "//lodash"
+	// double-slash path that many registries 404 on — the same single-slash join
+	// the reverse-proxy Director (tarball leg) already applies via httputil, so
+	// both legs build identical URLs.
+	// armis:ignore cwe:918 cwe:73 cwe:22 reason:p.upstreamURL is the default npmjs.org/pypi.org constant or a custom upstream validated by ValidateRegistryURL at config-load (https-only, no userinfo, rejects loopback/RFC1918/link-local); r.URL.RequestURI() is the path/query from the local proxy client and cannot change the host — joinUpstreamURL only collapses a boundary slash, it does not accept a caller-chosen path outside that request, so no traversal beyond the client's own request is possible
+	upstreamReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, joinUpstreamURL(p.upstreamURL.String(), r.URL.RequestURI()), nil) //nolint:gosec // upstream URL is a constant default or config-load-validated; path is from the local proxy
 	if err != nil {
 		http.Error(w, fmt.Sprintf("[armis] supply-chain: failed to create request for %s", pkgName), http.StatusBadGateway)
 		return
@@ -567,6 +659,9 @@ func (p *Proxy) handleMetadataFiltering(w http.ResponseWriter, r *http.Request, 
 			p.reverseProxy(w, r)
 			return
 		}
+		// Fail-closed: the age check was attempted (counted in `checked`) but could
+		// not be verified. Record that so the summary does not claim "all pass".
+		p.markVerifyFailed()
 		fmt.Fprintf(os.Stderr, "[armis] supply-chain: registry unreachable for %s: %v\n", pkgName, err)
 		http.Error(w, fmt.Sprintf("[armis] supply-chain: registry unreachable for %s", pkgName), http.StatusBadGateway)
 		return
@@ -610,6 +705,7 @@ func (p *Proxy) handleMetadataFiltering(w http.ResponseWriter, r *http.Request, 
 			p.reverseProxy(w, r)
 			return
 		}
+		p.markVerifyFailed()
 		http.Error(w, fmt.Sprintf("[armis] supply-chain: failed to read upstream response for %s", pkgName), http.StatusBadGateway)
 		return
 	}
@@ -619,6 +715,7 @@ func (p *Proxy) handleMetadataFiltering(w http.ResponseWriter, r *http.Request, 
 			p.reverseProxy(w, r)
 			return
 		}
+		p.markVerifyFailed()
 		http.Error(w, fmt.Sprintf("[armis] supply-chain: upstream response too large for %s", pkgName), http.StatusBadGateway)
 		return
 	}

--- a/internal/supplychain/proxy.go
+++ b/internal/supplychain/proxy.go
@@ -373,12 +373,21 @@ func newUpstreamHTTPClient(upstreamURL *url.URL, caBundlePath string) (*http.Cli
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 
 	if caBundlePath != "" {
-		// armis:ignore cwe:22 cwe:23 cwe:73 reason:caBundlePath is an operator-supplied path from the committed config / ARMIS_REGISTRY_CA_BUNDLE env (the deploying platform team's own file), read once at proxy startup to trust their corporate CA; not untrusted input crossing a trust boundary
+		// armis:ignore cwe:22 cwe:23 cwe:73 cwe:770 reason:caBundlePath is an operator-supplied path from the committed config / ARMIS_REGISTRY_CA_BUNDLE env (the deploying platform team's own file), read once at proxy startup to trust their corporate CA; not untrusted input crossing a trust boundary, and a CA bundle is a small local file the platform team controls, not attacker-sized input
 		pem, err := os.ReadFile(caBundlePath) //nolint:gosec // operator-configured CA bundle
 		if err != nil {
 			return nil, fmt.Errorf("reading registry CA bundle %q: %w", caBundlePath, err)
 		}
-		pool := x509.NewCertPool()
+		// Start from the system trust store rather than an empty pool so the bundle
+		// AUGMENTS trust instead of replacing it — a registry whose chain anchors in
+		// a public CA (fronted by a CDN, e.g.) must keep working alongside a
+		// corporate CA added for an internal Nexus. SystemCertPool() can fail on some
+		// platforms; fall back to an empty pool rather than erroring the whole proxy
+		// startup over an environment quirk.
+		pool, err := x509.SystemCertPool()
+		if err != nil || pool == nil {
+			pool = x509.NewCertPool()
+		}
 		if !pool.AppendCertsFromPEM(pem) {
 			return nil, fmt.Errorf("registry CA bundle %q contains no valid PEM certificates", caBundlePath)
 		}

--- a/internal/supplychain/proxy.go
+++ b/internal/supplychain/proxy.go
@@ -358,6 +358,20 @@ func (p *Proxy) modifyUpstreamResponse(resp *http.Response) error {
 	return nil
 }
 
+// BaseUpstreamTransport returns the *http.Transport newUpstreamHTTPClient
+// clones as its starting point. Production always clones http.DefaultTransport
+// (system proxy settings, standard timeouts); TESTS ONLY may override this var
+// — always saving the previous value and restoring it via t.Cleanup — to inject
+// a custom DialContext (e.g. redirecting a synthetic test hostname to
+// 127.0.0.1) without mutating the process-global http.DefaultTransport, which
+// would otherwise race against any parallel test elsewhere in the module that
+// also makes an HTTP request. Exported (despite the internal/ package) only so
+// internal/cmd's tests can reach it; mirrors the execPMFunc seam used
+// elsewhere in this codebase for the same reason. Not part of any public API.
+var BaseUpstreamTransport = func() *http.Transport {
+	return http.DefaultTransport.(*http.Transport).Clone()
+}
+
 // newUpstreamHTTPClient builds the HTTP client used for the proxy→upstream leg.
 // Two security properties beyond the default client:
 //
@@ -370,10 +384,10 @@ func (p *Proxy) modifyUpstreamResponse(resp *http.Response) error {
 //     bundle path is a hard error (a TLS failure must be visible, never a silent
 //     fail-open enforcement bypass).
 func newUpstreamHTTPClient(upstreamURL *url.URL, caBundlePath string) (*http.Client, error) {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport := BaseUpstreamTransport()
 
 	if caBundlePath != "" {
-		// armis:ignore cwe:22 cwe:23 cwe:73 cwe:770 reason:caBundlePath is an operator-supplied path from the committed config / ARMIS_REGISTRY_CA_BUNDLE env (the deploying platform team's own file), read once at proxy startup to trust their corporate CA; not untrusted input crossing a trust boundary, and a CA bundle is a small local file the platform team controls, not attacker-sized input
+		// armis:ignore cwe:22 cwe:23 cwe:73 cwe:770 cwe:295 reason:caBundlePath is an operator-supplied path from the committed config / ARMIS_REGISTRY_CA_BUNDLE env (the deploying platform team's own file), read once at proxy startup to trust their corporate CA; not untrusted input crossing a trust boundary, and a CA bundle is a small local file the platform team controls, not attacker-sized input. Trusting its contents for TLS is the deliberate purpose of this feature (letting a minimal CI container reach a private-CA-fronted Nexus), not a validation gap — the same operator-controlled trust source already suppressed for cwe:295 at every other newUpstreamHTTPClient/NewRegistryHTTPClient call site
 		pem, err := os.ReadFile(caBundlePath) //nolint:gosec // operator-configured CA bundle
 		if err != nil {
 			return nil, fmt.Errorf("reading registry CA bundle %q: %w", caBundlePath, err)

--- a/internal/supplychain/proxy.go
+++ b/internal/supplychain/proxy.go
@@ -397,17 +397,21 @@ func newUpstreamHTTPClient(upstreamURL *url.URL, caBundlePath string) (*http.Cli
 		transport.TLSClientConfig.RootCAs = pool
 	}
 
-	// Compare the full origin (host:port), not just the hostname: a redirect to a
-	// different port on the same host is still a different origin the credential
-	// must not leak to. This is the strict reading of S2 ("off the approved
-	// host") and the safe default for a security control.
+	// Compare the full origin (scheme + host:port), not just the hostname: a
+	// redirect to a different port on the same host is still a different origin
+	// the credential must not leak to, and a same-host https→http downgrade
+	// would let net/http forward the Authorization header over plaintext (Go
+	// only strips it on a cross-HOST redirect, not a scheme change). This is the
+	// strict reading of S2 ("off the approved host") and the safe default for a
+	// security control.
 	upstreamOrigin := upstreamURL.Host
+	upstreamScheme := upstreamURL.Scheme
 	return &http.Client{
 		Timeout:   30 * time.Second,
 		Transport: transport,
 		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
-			if req.URL.Host != upstreamOrigin {
-				return fmt.Errorf("refusing cross-host redirect to %q (credentials must not leave the approved registry origin %q)", req.URL.Host, upstreamOrigin)
+			if req.URL.Host != upstreamOrigin || req.URL.Scheme != upstreamScheme {
+				return fmt.Errorf("refusing redirect to %q (credentials must not leave the approved registry origin %s://%s)", req.URL, upstreamScheme, upstreamOrigin)
 			}
 			return nil
 		},

--- a/internal/supplychain/proxy_auth_test.go
+++ b/internal/supplychain/proxy_auth_test.go
@@ -1,0 +1,312 @@
+package supplychain
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// startProxy is a test helper that constructs and starts a proxy against a
+// given upstream, returning the proxy's loopback address. It registers cleanup.
+func startProxy(t *testing.T, cfg ProxyConfig) (*Proxy, string) {
+	t.Helper()
+	proxy, err := NewProxy(cfg)
+	if err != nil {
+		t.Fatalf("NewProxy: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	addr, err := proxy.Start(ctx)
+	if err != nil {
+		t.Fatalf("proxy.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = proxy.Close() })
+	return proxy, addr
+}
+
+// npmMetadataWithTime renders a minimal npm metadata doc whose single version
+// is old enough to pass any age policy.
+func npmMetadataWithTime(name, version string) []byte {
+	doc := map[string]any{
+		"name":      name,
+		"dist-tags": map[string]string{"latest": version},
+		"versions": map[string]any{
+			version: map[string]any{"name": name, "version": version},
+		},
+		"time": map[string]string{
+			version: "2020-01-01T00:00:00.000Z",
+		},
+	}
+	b, _ := json.Marshal(doc)
+	return b
+}
+
+// TestProxyInjectsAuthMetadata is test-plan case #2: a metadata request to a
+// custom upstream carries the injected Authorization header; the upstream
+// answers 200 with the token and 401 without.
+func TestProxyInjectsAuthMetadata(t *testing.T) {
+	const token = "Bearer secret-tok"
+
+	t.Run("with auth → 200", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") != token {
+				w.Header().Set("WWW-Authenticate", `Bearer realm="upstream"`)
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(npmMetadataWithTime("express", "4.18.2")) //nolint:errcheck,gosec
+		}))
+		defer upstream.Close()
+
+		_, addr := startProxy(t, ProxyConfig{
+			Policy:      Policy{MinReleaseAge: 72 * time.Hour},
+			UpstreamURL: upstream.URL,
+			AuthHeader:  token,
+		})
+
+		resp := getThrough(t, addr, "/express")
+		defer resp.Body.Close() //nolint:errcheck,gosec
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+	})
+
+	t.Run("without auth → 401 (negative case)", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") != token {
+				w.Header().Set("WWW-Authenticate", `Bearer realm="upstream"`)
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer upstream.Close()
+
+		// No AuthHeader configured → upstream sees no token → 401.
+		_, addr := startProxy(t, ProxyConfig{
+			Policy:      Policy{MinReleaseAge: 72 * time.Hour},
+			UpstreamURL: upstream.URL,
+		})
+
+		resp := getThrough(t, addr, "/express")
+		defer resp.Body.Close() //nolint:errcheck,gosec
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401 without auth", resp.StatusCode)
+		}
+	})
+}
+
+// TestProxyAuthBothLegs is test-plan case #3: buildAuthHeader() is used by BOTH
+// the metadata path AND the reverse-proxy Director (tarball passthrough), so a
+// 401-gated upstream authenticates on both. This is the prototype's headline
+// finding turned into a regression guard.
+func TestProxyAuthBothLegs(t *testing.T) {
+	const token = "Bearer both-legs-tok"
+	var metaAuthed, tarballAuthed atomic.Bool
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authed := r.Header.Get("Authorization") == token
+		isTarball := strings.HasSuffix(r.URL.Path, ".tgz")
+		if !authed {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if isTarball {
+			tarballAuthed.Store(true)
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Write([]byte("tarball-bytes")) //nolint:errcheck,gosec
+			return
+		}
+		metaAuthed.Store(true)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(npmMetadataWithTime("express", "4.18.2")) //nolint:errcheck,gosec
+	}))
+	defer upstream.Close()
+
+	_, addr := startProxy(t, ProxyConfig{
+		Policy:      Policy{MinReleaseAge: 72 * time.Hour},
+		UpstreamURL: upstream.URL,
+		AuthHeader:  token,
+	})
+
+	// Metadata leg.
+	mresp := getThrough(t, addr, "/express")
+	mresp.Body.Close() //nolint:errcheck,gosec
+	if mresp.StatusCode != http.StatusOK {
+		t.Fatalf("metadata status = %d, want 200", mresp.StatusCode)
+	}
+	// Tarball leg (passthrough via Director — contains "/-/").
+	tresp := getThrough(t, addr, "/express/-/express-4.18.2.tgz")
+	body, _ := io.ReadAll(tresp.Body)
+	tresp.Body.Close() //nolint:errcheck,gosec
+	if tresp.StatusCode != http.StatusOK {
+		t.Fatalf("tarball status = %d, want 200 (Director must inject auth too)", tresp.StatusCode)
+	}
+	if string(body) != "tarball-bytes" {
+		t.Errorf("tarball body = %q", body)
+	}
+	if !metaAuthed.Load() || !tarballAuthed.Load() {
+		t.Errorf("both legs must reach upstream authed: meta=%v tarball=%v", metaAuthed.Load(), tarballAuthed.Load())
+	}
+}
+
+// TestProxyRefusesCrossHostRedirect is test-plan case #4 (security): the proxy
+// HTTP client refuses a cross-host redirect so the bearer token is never sent
+// to a redirect target on a different host.
+func TestProxyRefusesCrossHostRedirect(t *testing.T) {
+	const token = "Bearer no-follow-tok"
+	var attackerGotAuth atomic.Bool
+
+	// The attacker host records whether it ever received the Authorization header.
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			attackerGotAuth.Store(true)
+		}
+		w.Write(npmMetadataWithTime("evil", "1.0.0")) //nolint:errcheck,gosec
+	}))
+	defer attacker.Close()
+
+	// The configured upstream 302-redirects to the attacker host.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// armis:ignore cwe:601 reason:test fixture deliberately issuing a cross-host redirect to PROVE the proxy's CheckRedirect refuses to follow it; this is the attacker being simulated, not a vulnerability in product code
+		http.Redirect(w, r, attacker.URL+r.URL.Path, http.StatusFound) //nolint:gosec // G710: intentional cross-host redirect in a security test
+	}))
+	defer upstream.Close()
+
+	_, addr := startProxy(t, ProxyConfig{
+		Policy:      Policy{MinReleaseAge: 72 * time.Hour},
+		UpstreamURL: upstream.URL,
+		AuthHeader:  token,
+	})
+
+	resp := getThrough(t, addr, "/express")
+	resp.Body.Close() //nolint:errcheck,gosec
+	// The redirect must NOT have been followed to the attacker host with the token.
+	if attackerGotAuth.Load() {
+		t.Fatal("SECURITY: bearer token followed a cross-host redirect to the attacker host")
+	}
+	// A refused redirect surfaces as a non-200 (bad gateway / the 302 itself), not a 200.
+	if resp.StatusCode == http.StatusOK {
+		t.Errorf("expected the cross-host redirect to be refused, got 200")
+	}
+}
+
+// TestProxyStripsWWWAuthenticate is test-plan case #10: on a custom upstream, a
+// 401 has its WWW-Authenticate stripped before reaching the PM so npm cannot
+// re-auth directly against the upstream and bypass the proxy.
+func TestProxyStripsWWWAuthenticate(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="https://nexus.corp/"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer upstream.Close()
+
+	t.Run("custom upstream strips realm", func(t *testing.T) {
+		_, addr := startProxy(t, ProxyConfig{
+			Policy:      Policy{MinReleaseAge: 72 * time.Hour},
+			UpstreamURL: upstream.URL,
+			AuthHeader:  "Bearer wrong",
+		})
+		resp := getThrough(t, addr, "/express")
+		resp.Body.Close() //nolint:errcheck,gosec
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		}
+		if got := resp.Header.Get("WWW-Authenticate"); got != "" {
+			t.Errorf("WWW-Authenticate should be stripped on custom upstream, got %q", got)
+		}
+	})
+
+	t.Run("default public path keeps realm", func(t *testing.T) {
+		// No UpstreamURL → not a custom upstream → existing passthrough behavior
+		// (realm forwarded). Point the default-mode proxy at our 401 upstream by
+		// using UpstreamURL but asserting via customUpstream=false is impossible;
+		// instead verify the negative directly: with customUpstream the realm is
+		// gone (above), and the modify hook is gated on customUpstream.
+		p := &Proxy{customUpstream: false, upstreamURL: mustParseURL(t, upstream.URL)}
+		resp := &http.Response{StatusCode: http.StatusUnauthorized, Header: http.Header{}, Request: &http.Request{URL: mustParseURL(t, upstream.URL)}}
+		resp.Header.Set("WWW-Authenticate", `Bearer realm="x"`)
+		if err := p.modifyUpstreamResponse(resp); err != nil {
+			t.Fatalf("modifyUpstreamResponse: %v", err)
+		}
+		if resp.Header.Get("WWW-Authenticate") == "" {
+			t.Error("default (non-custom) path must NOT strip WWW-Authenticate")
+		}
+	})
+}
+
+// TestModifyUpstreamResponse covers the ModifyResponse hook directly across the
+// status/custom-upstream matrix that the end-to-end tests don't all reach.
+func TestModifyUpstreamResponse(t *testing.T) {
+	mk := func(custom bool, status int) *http.Response {
+		resp := &http.Response{
+			StatusCode: status,
+			Header:     http.Header{},
+			Request:    &http.Request{URL: mustParseURL(t, "https://nexus.corp/x")},
+		}
+		resp.Header.Set("WWW-Authenticate", `Bearer realm="x"`)
+		return resp
+	}
+
+	t.Run("custom upstream strips on 401", func(t *testing.T) {
+		p := &Proxy{customUpstream: true, upstreamURL: mustParseURL(t, "https://nexus.corp/")}
+		resp := mk(true, http.StatusUnauthorized)
+		_ = p.modifyUpstreamResponse(resp)
+		if resp.Header.Get("WWW-Authenticate") != "" {
+			t.Error("401 on custom upstream must strip WWW-Authenticate")
+		}
+	})
+
+	t.Run("custom upstream strips on 403", func(t *testing.T) {
+		p := &Proxy{customUpstream: true, upstreamURL: mustParseURL(t, "https://nexus.corp/")}
+		resp := mk(true, http.StatusForbidden)
+		_ = p.modifyUpstreamResponse(resp)
+		if resp.Header.Get("WWW-Authenticate") != "" {
+			t.Error("403 on custom upstream must strip WWW-Authenticate")
+		}
+	})
+
+	t.Run("custom upstream leaves 200 untouched", func(t *testing.T) {
+		p := &Proxy{customUpstream: true, upstreamURL: mustParseURL(t, "https://nexus.corp/")}
+		resp := mk(true, http.StatusOK)
+		_ = p.modifyUpstreamResponse(resp)
+		if resp.Header.Get("WWW-Authenticate") == "" {
+			t.Error("a 200 must not be modified")
+		}
+	})
+
+	t.Run("non-custom upstream never strips", func(t *testing.T) {
+		p := &Proxy{customUpstream: false, upstreamURL: mustParseURL(t, "https://registry.npmjs.org/")}
+		resp := mk(false, http.StatusUnauthorized)
+		_ = p.modifyUpstreamResponse(resp)
+		if resp.Header.Get("WWW-Authenticate") == "" {
+			t.Error("the default public path must not strip WWW-Authenticate")
+		}
+	})
+}
+
+// getThrough issues a GET to the proxy at the given path and returns the
+// response. http.DefaultClient does NOT follow into the proxy's own redirect
+// refusal (the proxy returns the upstream status verbatim), so a plain Get is
+// the right driver here.
+func getThrough(t *testing.T, addr, path string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s%s", addr, path), nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request to proxy: %v", err)
+	}
+	return resp
+}

--- a/internal/supplychain/proxy_auth_test.go
+++ b/internal/supplychain/proxy_auth_test.go
@@ -199,6 +199,25 @@ func TestProxyRefusesCrossHostRedirect(t *testing.T) {
 	}
 }
 
+// TestNewUpstreamHTTPClientRefusesSchemeDowngradeRedirect is the regression
+// guard for a same-host https→http redirect: net/http only strips the
+// Authorization header on a cross-HOST redirect, not a scheme change, so a
+// same-host downgrade would otherwise forward the credential over plaintext.
+// CheckRedirect must compare scheme in addition to host.
+func TestNewUpstreamHTTPClientRefusesSchemeDowngradeRedirect(t *testing.T) {
+	client, err := newUpstreamHTTPClient(mustParseURL(t, "https://nexus.corp/repository/npm-group/"), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodGet, "http://nexus.corp/repository/npm-group/express", nil) //nolint:noctx // test-only request object, never sent
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.CheckRedirect(req, nil); err == nil {
+		t.Fatal("expected a same-host https→http scheme downgrade to be refused, got nil error")
+	}
+}
+
 // TestProxyStripsWWWAuthenticate is test-plan case #10: on a custom upstream, a
 // 401 has its WWW-Authenticate stripped before reaching the PM so npm cannot
 // re-auth directly against the upstream and bypass the proxy.

--- a/internal/supplychain/proxy_cabundle_test.go
+++ b/internal/supplychain/proxy_cabundle_test.go
@@ -1,0 +1,79 @@
+package supplychain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// A throwaway self-signed PEM is enough to prove AppendCertsFromPEM accepts a
+// valid bundle; the bytes are a real, syntactically valid certificate.
+const testCAPEM = `-----BEGIN CERTIFICATE-----
+MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
+DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
+EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
+7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B
+5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr
+BgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1
+NDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l
+Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
+6MF9+Yw1Yy0t
+-----END CERTIFICATE-----
+`
+
+// TestCABundleConfig is test-plan case #18: a CA bundle path is applied to the
+// proxy's TLS config. A valid PEM is accepted; a missing or empty file is a
+// hard error (a TLS misconfig must surface, never silently fail-open).
+func TestCABundleConfig(t *testing.T) {
+	t.Run("valid CA bundle accepted", func(t *testing.T) {
+		dir := t.TempDir()
+		caPath := filepath.Join(dir, "ca.pem")
+		if err := os.WriteFile(caPath, []byte(testCAPEM), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := NewProxy(ProxyConfig{
+			Policy:       Policy{MinReleaseAge: 72 * time.Hour},
+			UpstreamURL:  "https://nexus.corp/repository/npm-group/",
+			CABundlePath: caPath,
+		})
+		if err != nil {
+			t.Fatalf("valid CA bundle should be accepted, got: %v", err)
+		}
+	})
+
+	t.Run("missing CA bundle is a hard error", func(t *testing.T) {
+		_, err := NewProxy(ProxyConfig{
+			Policy:       Policy{MinReleaseAge: 72 * time.Hour},
+			UpstreamURL:  "https://nexus.corp/repository/npm-group/",
+			CABundlePath: "/nonexistent/ca.pem",
+		})
+		if err == nil {
+			t.Fatal("a missing CA bundle must be a hard error, not a silent fallback")
+		}
+	})
+
+	t.Run("garbage CA bundle is a hard error", func(t *testing.T) {
+		dir := t.TempDir()
+		caPath := filepath.Join(dir, "bad.pem")
+		if err := os.WriteFile(caPath, []byte("not a pem"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := NewProxy(ProxyConfig{
+			Policy:       Policy{MinReleaseAge: 72 * time.Hour},
+			UpstreamURL:  "https://nexus.corp/repository/npm-group/",
+			CABundlePath: caPath,
+		})
+		if err == nil {
+			t.Fatal("a CA bundle with no valid certs must be a hard error")
+		}
+	})
+}
+
+// TestIsX509Error sanity-checks the typed-error detection used to print the
+// CA-bundle fix message.
+func TestIsX509Error(t *testing.T) {
+	if isX509Error(os.ErrNotExist) {
+		t.Error("a non-TLS error should not be detected as x509")
+	}
+}

--- a/internal/supplychain/proxy_cabundle_test.go
+++ b/internal/supplychain/proxy_cabundle_test.go
@@ -1,6 +1,8 @@
 package supplychain
 
 import (
+	"crypto/x509"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -75,5 +77,42 @@ func TestCABundleConfig(t *testing.T) {
 func TestIsX509Error(t *testing.T) {
 	if isX509Error(os.ErrNotExist) {
 		t.Error("a non-TLS error should not be detected as x509")
+	}
+}
+
+// TestNewUpstreamHTTPClientAugmentsSystemTrust is the regression guard for the
+// CA-bundle-replaces-system-trust bug: a configured bundle must ADD a corporate
+// CA alongside the system roots, not swap them out — otherwise a registry
+// fronted by a public CA (e.g. a CDN) would stop verifying once any CA bundle
+// is configured. Proven indirectly: appending a syntactically valid PEM to a
+// pool built via SystemCertPool() (this function's actual starting point)
+// leaves that pool non-empty and still able to verify certs chaining to the
+// system roots — an empty NewCertPool() base could not.
+func TestNewUpstreamHTTPClientAugmentsSystemTrust(t *testing.T) {
+	sysPool, err := x509.SystemCertPool()
+	if err != nil || sysPool == nil {
+		t.Skip("no system cert pool available on this platform")
+	}
+	sysSubjects := len(sysPool.Subjects()) //nolint:staticcheck // Subjects() is deprecated but adequate for this count-based assertion
+	if sysSubjects == 0 {
+		t.Skip("system cert pool is empty on this platform")
+	}
+
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.pem")
+	if err := os.WriteFile(caPath, []byte(testCAPEM), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := newUpstreamHTTPClient(mustParseURL(t, "https://nexus.corp/repository/npm-group/"), caPath)
+	if err != nil {
+		t.Fatalf("valid CA bundle should be accepted, got: %v", err)
+	}
+	pool := client.Transport.(*http.Transport).TLSClientConfig.RootCAs
+	if pool == nil {
+		t.Fatal("expected a non-nil RootCAs pool")
+	}
+	if len(pool.Subjects()) <= sysSubjects { //nolint:staticcheck // Subjects() is deprecated but adequate for this count-based assertion
+		t.Errorf("expected the configured bundle's RootCAs to contain the system roots plus the added cert (>%d subjects), got %d — CA bundle appears to have replaced system trust instead of augmenting it", sysSubjects, len(pool.Subjects())) //nolint:staticcheck
 	}
 }

--- a/internal/supplychain/proxy_degrade_test.go
+++ b/internal/supplychain/proxy_degrade_test.go
@@ -1,0 +1,131 @@
+package supplychain
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// pypiDocNoTimestamps renders a PEP 691 Simple API doc whose single file has NO
+// upload-time — the "artifactory stripped timestamps" case.
+func pypiDocNoTimestamps(filename string) []byte {
+	doc := map[string]any{
+		"name":  "requests",
+		"files": []map[string]any{{"filename": filename, "url": "https://x/" + filename}},
+	}
+	b, _ := json.Marshal(doc)
+	return b
+}
+
+// TestDegradeOnMissingTimestampsPyPI is test-plan case #8 (PyPI): with the flag
+// set (configured artifactory), an undatable file PASSES THROUGH rather than
+// being removed, and the file is kept in the filtered body.
+func TestDegradeOnMissingTimestampsPyPI(t *testing.T) {
+	p := &Proxy{
+		policy:                     Policy{MinReleaseAge: 72 * time.Hour},
+		mode:                       ModePyPI,
+		allowed:                    make(map[string]allowedVersion),
+		degradeOnMissingTimestamps: true,
+		upstreamURL:                mustParseURL(t, "https://nexus.corp/repository/pypi-group/simple/"),
+		customUpstream:             true,
+	}
+	body := pypiDocNoTimestamps("requests-2.30.0-py3-none-any.whl")
+	filtered, blocked := p.filterPyPISimple(body, "requests")
+	if len(blocked) != 0 {
+		t.Fatalf("degrade-on: undatable file should NOT be blocked, got %d blocked", len(blocked))
+	}
+	// The file must still be present in the passed-through body.
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(filtered, &doc); err != nil {
+		t.Fatalf("filtered body is not valid JSON: %v", err)
+	}
+	var files []map[string]json.RawMessage
+	json.Unmarshal(doc["files"], &files) //nolint:errcheck,gosec
+	if len(files) != 1 {
+		t.Errorf("expected the undatable file to pass through, got %d files", len(files))
+	}
+}
+
+// TestFailClosedOnMissingTimestampsPyPI is test-plan case #9 — the MANDATORY
+// regression guard. With the flag UNSET (the default public path), an undatable
+// PyPI file is still REMOVED (fail-closed). This proves the new degrade flag did
+// not weaken the default behavior for existing users.
+func TestFailClosedOnMissingTimestampsPyPI(t *testing.T) {
+	p := &Proxy{
+		policy:  Policy{MinReleaseAge: 72 * time.Hour},
+		mode:    ModePyPI,
+		allowed: make(map[string]allowedVersion),
+		// degradeOnMissingTimestamps: false (default)
+	}
+	body := pypiDocNoTimestamps("requests-2.30.0-py3-none-any.whl")
+	filtered, blocked := p.filterPyPISimple(body, "requests")
+	if len(blocked) != 1 {
+		t.Fatalf("fail-closed: undatable file MUST be blocked, got %d blocked", len(blocked))
+	}
+	var doc map[string]json.RawMessage
+	json.Unmarshal(filtered, &doc) //nolint:errcheck,gosec
+	var files []map[string]json.RawMessage
+	json.Unmarshal(doc["files"], &files) //nolint:errcheck,gosec
+	if len(files) != 0 {
+		t.Errorf("fail-closed: undatable file MUST be removed, got %d files kept", len(files))
+	}
+}
+
+// TestDegradeDoesNotAffectDatableFiles proves the degrade flag only governs the
+// UNDATABLE case: a datable-but-too-young file is still removed even with the
+// flag on (the timestamp exists; the file is genuinely too new).
+func TestDegradeDoesNotAffectDatableFiles(t *testing.T) {
+	recent := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	doc := map[string]any{
+		"name": "requests",
+		"files": []map[string]any{
+			{"filename": "requests-9.9.9-py3-none-any.whl", "url": "https://x/r.whl", "upload-time": recent},
+		},
+	}
+	body, _ := json.Marshal(doc)
+
+	p := &Proxy{
+		policy:                     Policy{MinReleaseAge: 72 * time.Hour},
+		mode:                       ModePyPI,
+		allowed:                    make(map[string]allowedVersion),
+		degradeOnMissingTimestamps: true,
+		upstreamURL:                mustParseURL(t, "https://nexus.corp/simple/"),
+		customUpstream:             true,
+	}
+	_, blocked := p.filterPyPISimple(body, "requests")
+	if len(blocked) != 1 {
+		t.Errorf("a datable too-young file must still be blocked even under degrade, got %d", len(blocked))
+	}
+}
+
+// TestDegradeNPMMissingTimeMap covers the npm side: with the flag set and the
+// `time` map absent, the body passes through unchanged (npm already did this)
+// and the one-time warning is allowed to fire without panic.
+func TestDegradeNPMMissingTimeMap(t *testing.T) {
+	doc := map[string]any{
+		"name":      "leftpad",
+		"dist-tags": map[string]string{"latest": "1.0.0"},
+		"versions":  map[string]any{"1.0.0": map[string]any{"name": "leftpad", "version": "1.0.0"}},
+		// no "time" key
+	}
+	body, _ := json.Marshal(doc)
+
+	p := &Proxy{
+		policy:                     Policy{MinReleaseAge: 72 * time.Hour},
+		mode:                       ModeNPM,
+		allowed:                    make(map[string]allowedVersion),
+		degradeOnMissingTimestamps: true,
+		upstreamURL:                mustParseURL(t, "https://nexus.corp/repository/npm-group/"),
+		customUpstream:             true,
+	}
+	filtered, blocked := p.filterMetadata(body, "leftpad")
+	if len(blocked) != 0 {
+		t.Errorf("npm missing time map should not block, got %d", len(blocked))
+	}
+	if string(filtered) != string(body) {
+		t.Errorf("npm body should pass through unchanged when time map absent")
+	}
+	if !p.degradeWarned {
+		t.Error("expected the degraded-enforcement warning to have fired")
+	}
+}

--- a/internal/supplychain/proxy_trailing_slash_test.go
+++ b/internal/supplychain/proxy_trailing_slash_test.go
@@ -1,0 +1,153 @@
+package supplychain
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestJoinUpstreamURL verifies the boundary-slash collapse used by the metadata
+// leg so a trailing slash on the configured upstream never produces a "//" path
+// (the PPSC-994 double-slash bug: `registries.npm: https://host/` made every
+// install 404 with GET //<pkg>).
+func TestJoinUpstreamURL(t *testing.T) {
+	cases := []struct {
+		name       string
+		base       string
+		requestURI string
+		want       string
+	}{
+		{"trailing slash + leading slash", "https://nexus.corp/", "/lodash", "https://nexus.corp/lodash"},
+		{"no trailing slash + leading slash", "https://nexus.corp", "/lodash", "https://nexus.corp/lodash"},
+		{"trailing slash + no leading slash", "https://nexus.corp/", "lodash", "https://nexus.corp/lodash"},
+		{"no slash on either side", "https://nexus.corp", "lodash", "https://nexus.corp/lodash"},
+		{"base path with trailing slash", "https://nexus.corp/repository/npm/", "/lodash", "https://nexus.corp/repository/npm/lodash"},
+		{"base path no trailing slash", "https://nexus.corp/repository/npm", "/lodash", "https://nexus.corp/repository/npm/lodash"},
+		{"query preserved", "https://nexus.corp/", "/lodash?write=true", "https://nexus.corp/lodash?write=true"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := joinUpstreamURL(tc.base, tc.requestURI); got != tc.want {
+				t.Errorf("joinUpstreamURL(%q, %q) = %q, want %q", tc.base, tc.requestURI, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestProxyMetadataTrailingSlashUpstream is the end-to-end regression guard for
+// the double-slash bug: with an upstream configured WITH a trailing slash (the
+// exact shape of the committed example config), a metadata request must reach
+// the upstream at "/express", not "//express", and resolve 200.
+func TestProxyMetadataTrailingSlashUpstream(t *testing.T) {
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(npmMetadataWithTime("express", "4.18.2")) //nolint:errcheck,gosec
+	}))
+	defer upstream.Close()
+
+	// httptest URLs have no trailing slash; append one to reproduce the config
+	// shape that triggered the bug.
+	_, addr := startProxy(t, ProxyConfig{
+		Policy:      Policy{MinReleaseAge: 72 * time.Hour},
+		UpstreamURL: upstream.URL + "/",
+	})
+
+	resp := getThrough(t, addr, "/express")
+	defer resp.Body.Close() //nolint:errcheck,gosec
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (trailing-slash upstream should resolve)", resp.StatusCode)
+	}
+	if gotPath != "/express" {
+		t.Errorf("upstream saw path %q, want %q (double-slash regression)", gotPath, "/express")
+	}
+}
+
+// TestProxyVerifyFailedCounter is the bug #2b regression guard: when the
+// age-check request fails on the fail-closed path (unreachable/untrusted
+// upstream), the package is counted in Checked() but ALSO in VerifyFailed(), so
+// the wrap summary can distinguish "checked and passed" from "check could not
+// run". Without this the summary printed a green "N packages checked, all pass"
+// while every check had in fact errored out (e.g. a wrong registry-ca-bundle).
+func TestProxyVerifyFailedCounter(t *testing.T) {
+	t.Run("fail-closed increments VerifyFailed", func(t *testing.T) {
+		proxy := newUnreachableProxy(t, false)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		addr, _ := proxy.Start(ctx)
+		defer proxy.Close() //nolint:errcheck,gosec
+
+		req, _ := http.NewRequest(http.MethodGet, "http://"+addr+"/express", nil)
+		req.Header.Set("Accept", "application/json")
+		resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704: local test proxy on 127.0.0.1
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		resp.Body.Close() //nolint:errcheck,gosec
+
+		if got := proxy.Checked(); got != 1 {
+			t.Errorf("Checked() = %d, want 1 (the age check was attempted)", got)
+		}
+		if got := proxy.VerifyFailed(); got != 1 {
+			t.Errorf("VerifyFailed() = %d, want 1 (the check could not be verified)", got)
+		}
+	})
+
+	t.Run("fail-open does NOT increment VerifyFailed", func(t *testing.T) {
+		// Under fail-open the package is deliberately passed through with an explicit
+		// "allowing (fail-open)" notice, which is a separate, surfaced posture — not
+		// a silently-missed check — so it must not count as a verify failure.
+		proxy := newUnreachableProxy(t, true)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		addr, _ := proxy.Start(ctx)
+		defer proxy.Close() //nolint:errcheck,gosec
+
+		req, _ := http.NewRequest(http.MethodGet, "http://"+addr+"/express", nil)
+		req.Header.Set("Accept", "application/json")
+		resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704: local test proxy on 127.0.0.1
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		resp.Body.Close() //nolint:errcheck,gosec
+
+		if got := proxy.VerifyFailed(); got != 0 {
+			t.Errorf("VerifyFailed() = %d, want 0 under fail-open", got)
+		}
+	})
+}
+
+// TestNewRegistryHTTPClient covers the bug #2a helper that gives `supply-chain
+// check` the same private-CA trust the wrap proxy uses.
+func TestNewRegistryHTTPClient(t *testing.T) {
+	t.Run("no url and no bundle → nil client (use default)", func(t *testing.T) {
+		c, err := NewRegistryHTTPClient("", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c != nil {
+			t.Errorf("expected nil client when no custom trust is needed, got %+v", c)
+		}
+	})
+
+	t.Run("valid url, no bundle → non-nil client", func(t *testing.T) {
+		c, err := NewRegistryHTTPClient("https://nexus.corp/", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c == nil {
+			t.Error("expected a non-nil client (cross-host redirect guard applies even without a bundle)")
+		}
+	})
+
+	t.Run("bad bundle path → hard error, not silent fallback", func(t *testing.T) {
+		_, err := NewRegistryHTTPClient("https://nexus.corp/", "/no/such/ca-bundle.pem")
+		if err == nil {
+			t.Fatal("expected a hard error for an unreadable CA bundle (must never fail open)")
+		}
+	})
+}

--- a/internal/supplychain/registry/npm.go
+++ b/internal/supplychain/registry/npm.go
@@ -78,13 +78,23 @@ func NewClient() *Client {
 }
 
 // NewClientWithHTTP builds a Client with an injected HTTP client and registry
-// URL. It exists for tests that point the client at an httptest server; the
-// registryURL is therefore a trusted construction-time value, not request- or
-// network-derived input. Production code uses NewClient, which hardcodes the
-// npmjs.org HTTPS endpoint.
+// URL. Two callers use it: tests pointing at an httptest server, and the CI
+// `check` path pointing at a configured corporate artifactory (PPSC-994). In
+// both cases registryURL is a construction-time value the caller controls — for
+// the artifactory case it MUST have passed supplychain.ValidateRegistryURL
+// (https-only, no userinfo, no loopback/RFC1918/link-local host) at config-load
+// before reaching here, which is what keeps the cwe:918 suppressions in
+// fetchMetadata sound now that the URL is configurable. Production age checks
+// against the public registry use NewClient, which hardcodes npmjs.org.
 func NewClientWithHTTP(httpClient *http.Client, registryURL string) *Client {
 	if registryURL == "" {
 		registryURL = defaultRegistryURL
+	}
+	// Guard against a nil client (the production CI-check path passes nil to mean
+	// "use a default client"); without this, c.httpClient.Do panics. Mirrors the
+	// nil-guard in NewPyPIClientWithHTTP.
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
 	}
 	return &Client{
 		httpClient:  httpClient,
@@ -159,18 +169,18 @@ func (c *Client) fetchMetadata(ctx context.Context, name string) (*registryRespo
 	}
 
 	encodedName := url.PathEscape(name)
-	// armis:ignore cwe:918 reason:registryURL is a trusted construction-time config value (production NewClient hardcodes the npmjs.org HTTPS constant; the URL-accepting NewClientWithHTTP is test-only); name is regex-validated above and PathEscaped, so it cannot alter the host
-	// armis:ignore cwe:918 reason:reqURL is built from the trusted registryURL constant (production NewClient hardcodes the npmjs.org HTTPS constant) + a PathEscaped, regex-validated package name, so the host is not attacker-controlled
+	// armis:ignore cwe:918 reason:registryURL is either the hardcoded npmjs.org HTTPS constant (NewClient) or a custom upstream validated at config-load by supplychain.ValidateRegistryURL (https-only, no userinfo, rejects loopback/RFC1918/link-local) before NewClientWithHTTP is called; name is regex-validated above and PathEscaped, so neither can alter the host
+	// armis:ignore cwe:918 reason:reqURL is built from registryURL (npmjs.org constant or a config-load-validated custom upstream) + a PathEscaped, regex-validated package name, so the host is not attacker-controlled
 	reqURL := fmt.Sprintf("%s/%s", c.registryURL, encodedName)
-	// armis:ignore cwe:918 reason:reqURL is built from the trusted registryURL constant + a PathEscaped, regex-validated package name, so the host is not attacker-controlled
+	// armis:ignore cwe:918 reason:reqURL is built from registryURL (npmjs.org constant or a config-load-validated custom upstream) + a PathEscaped, regex-validated package name, so the host is not attacker-controlled
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request for %s: %w", name, err)
 	}
 	req.Header.Set("Accept", "application/json")
 
-	// armis:ignore cwe:918 reason:c.registryURL is a trusted construction-time config value (production NewClient hardcodes the npmjs.org HTTPS constant; the URL-accepting NewClientWithHTTP is test-only), so the request host is not attacker-controlled; the package name is regex-validated and PathEscaped
-	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: reqURL is a constant/configured registry host + regex-validated, PathEscaped package name
+	// armis:ignore cwe:918 reason:c.registryURL is either the hardcoded npmjs.org HTTPS constant (NewClient) or a custom upstream validated at config-load by supplychain.ValidateRegistryURL (https-only, no userinfo, rejects loopback/RFC1918/link-local), so the request host is not attacker-controlled; the package name is regex-validated and PathEscaped
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: reqURL is a constant/config-load-validated registry host + regex-validated, PathEscaped package name
 	if err != nil {
 		return nil, fmt.Errorf("fetching metadata for %s: %w", name, err)
 	}

--- a/internal/supplychain/registry/npm.go
+++ b/internal/supplychain/registry/npm.go
@@ -108,9 +108,11 @@ func NewClientWithHTTP(httpClient *http.Client, registryURL string) *Client {
 	registryURL = strings.TrimRight(registryURL, "/")
 	// Guard against a nil client (the production CI-check path passes nil to mean
 	// "use a default client"); without this, c.httpClient.Do panics. Mirrors the
-	// nil-guard in NewPyPIClientWithHTTP.
+	// nil-guard in NewPyPIClientWithHTTP. Use the same proxy-aware transport as
+	// NewClient so this fallback also honors WinINET/PAC on Windows instead of
+	// silently dropping proxy support for the injected-client path.
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 30 * time.Second}
+		httpClient = &http.Client{Timeout: 30 * time.Second, Transport: httpclient.ProxyAwareTransport()}
 	}
 	return &Client{
 		httpClient:  httpClient,

--- a/internal/supplychain/registry/npm.go
+++ b/internal/supplychain/registry/npm.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -33,8 +34,15 @@ var validPackageName = regexp.MustCompile(`^(@[a-z0-9\-~][a-z0-9\-._~]*/)?[a-z0-
 type Client struct {
 	httpClient  *http.Client
 	registryURL string
-	cache       sync.Map // map[string]*registryResponse
-	cacheLen    atomic.Int64
+	// authHeader is an optional pre-built Authorization value ("Bearer <tok>")
+	// attached to every metadata request. It lets `supply-chain check` query an
+	// auth-gated artifactory with the developer's .npmrc credential, exactly as
+	// the wrap proxy does — an auth-required registry returns 401 without it, so
+	// the age check would otherwise silently degrade to a warning. Empty on the
+	// public path (npmjs.org needs no credential to read metadata).
+	authHeader string
+	cache      sync.Map // map[string]*registryResponse
+	cacheLen   atomic.Int64
 }
 
 // registryResponse models the subset of npm package metadata we need. The npm
@@ -86,10 +94,18 @@ func NewClient() *Client {
 // before reaching here, which is what keeps the cwe:918 suppressions in
 // fetchMetadata sound now that the URL is configurable. Production age checks
 // against the public registry use NewClient, which hardcodes npmjs.org.
+// armis:ignore cwe:918 reason:registryURL is either "" (defaults to the hardcoded npmjs.org constant below) or the config-load-validated registries.npm value (supplychain.ValidateRegistryURL: https-only, no userinfo, rejects loopback/RFC1918/link-local) per the doc comment above; not a per-request attacker-controlled value
 func NewClientWithHTTP(httpClient *http.Client, registryURL string) *Client {
-	if registryURL == "" {
+	if registryURL == "" { // armis:ignore cwe:918 reason:registryURL is either empty here (defaulted to the hardcoded npmjs.org constant) or config-load-validated by ValidateRegistryURL before this constructor runs, per the doc comment above
 		registryURL = defaultRegistryURL
 	}
+	// Trim a trailing slash so fetchMetadata's "%s/%s" join never yields a
+	// "//<pkg>" path: a configured artifactory URL commonly carries one (e.g.
+	// "https://nexus.corp/repository/npm-group/"), and many registries 404 on the
+	// resulting double slash. Same normalization the proxy's joinUpstreamURL does
+	// for the wrap path.
+	// armis:ignore cwe:918 reason:registryURL is either "" (defaults to the hardcoded npmjs.org constant above) or the config-load-validated registries.npm value (supplychain.ValidateRegistryURL: https-only, no userinfo, rejects loopback/RFC1918/link-local) per the NewClientWithHTTP doc comment; trimming a trailing slash does not widen what hosts are reachable
+	registryURL = strings.TrimRight(registryURL, "/")
 	// Guard against a nil client (the production CI-check path passes nil to mean
 	// "use a default client"); without this, c.httpClient.Do panics. Mirrors the
 	// nil-guard in NewPyPIClientWithHTTP.
@@ -100,6 +116,17 @@ func NewClientWithHTTP(httpClient *http.Client, registryURL string) *Client {
 		httpClient:  httpClient,
 		registryURL: registryURL,
 	}
+}
+
+// WithAuthHeader sets the Authorization header value ("Bearer <tok>") sent on
+// every metadata request and returns the client for chaining. The caller (the
+// `check` path) resolves it from the developer's native .npmrc; an empty value
+// is a no-op, keeping the public-registry path unauthenticated. It must be set
+// before any concurrent GetPublishDates call, which is how the check flow uses
+// it (set once at construction, then queried).
+func (c *Client) WithAuthHeader(authHeader string) *Client {
+	c.authHeader = authHeader
+	return c
 }
 
 func (c *Client) GetPublishDate(ctx context.Context, name, version string) (time.Time, error) {
@@ -178,6 +205,11 @@ func (c *Client) fetchMetadata(ctx context.Context, name string) (*registryRespo
 		return nil, fmt.Errorf("creating request for %s: %w", name, err)
 	}
 	req.Header.Set("Accept", "application/json")
+	// Forward the developer's registry credential when configured so an
+	// auth-gated artifactory answers 200 instead of 401 (the `check` path).
+	if c.authHeader != "" {
+		req.Header.Set("Authorization", c.authHeader)
+	}
 
 	// armis:ignore cwe:918 reason:c.registryURL is either the hardcoded npmjs.org HTTPS constant (NewClient) or a custom upstream validated at config-load by supplychain.ValidateRegistryURL (https-only, no userinfo, rejects loopback/RFC1918/link-local), so the request host is not attacker-controlled; the package name is regex-validated and PathEscaped
 	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: reqURL is a constant/config-load-validated registry host + regex-validated, PathEscaped package name

--- a/internal/supplychain/registry/npm_test.go
+++ b/internal/supplychain/registry/npm_test.go
@@ -333,3 +333,16 @@ func TestCacheCountsDistinctEntries(t *testing.T) {
 		t.Errorf("cacheLen = %d, want 3 (one per distinct package, no double-count)", got)
 	}
 }
+
+// TestNewClientWithHTTPNilClientUsesProxyAwareTransport is the regression
+// guard for the nil-client fallback losing proxy-awareness: a caller passing
+// nil (the production `check` path, when no injected client is needed) must
+// still get WinINET/PAC support on Windows, same as NewClient(). A bare
+// &http.Client{Timeout: ...} (the pre-fix code) leaves Transport nil.
+func TestNewClientWithHTTPNilClientUsesProxyAwareTransport(t *testing.T) {
+	client := NewClientWithHTTP(nil, "")
+	transport, ok := client.httpClient.Transport.(*http.Transport)
+	if !ok || transport.Proxy == nil {
+		t.Error("expected the defaulted client to carry ProxyAwareTransport (non-nil *http.Transport with a Proxy func), got a plain/nil transport")
+	}
+}

--- a/internal/supplychain/registry/npm_test.go
+++ b/internal/supplychain/registry/npm_test.go
@@ -33,6 +33,68 @@ func TestGetPublishDate(t *testing.T) {
 		}
 	})
 
+	t.Run("registry URL with trailing slash does not double-slash", func(t *testing.T) {
+		// Bug #1 (check path): a configured artifactory URL commonly ends in "/".
+		// The metadata request must reach "/express", not "//express".
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/express" {
+				t.Errorf("path = %q, want /express (double-slash regression)", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"time":{"4.18.2":"2022-10-08T14:21:24.484Z"}}`))
+		}))
+		defer server.Close()
+
+		client := NewClientWithHTTP(server.Client(), server.URL+"/")
+		if _, err := client.GetPublishDate(context.Background(), "express", "4.18.2"); err != nil {
+			t.Fatalf("unexpected error with trailing-slash registry URL: %v", err)
+		}
+	})
+
+	t.Run("auth header forwarded to auth-gated registry", func(t *testing.T) {
+		// Bug: `check` against an auth-required artifactory 401'd because no
+		// credential was sent. With WithAuthHeader the metadata request carries the
+		// Bearer token and the registry answers 200.
+		const token = "Bearer check-tok"
+		var gotAuth string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			if gotAuth != token {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"time":{"4.18.2":"2022-10-08T14:21:24.484Z"}}`))
+		}))
+		defer server.Close()
+
+		client := NewClientWithHTTP(server.Client(), server.URL).WithAuthHeader(token)
+		if _, err := client.GetPublishDate(context.Background(), "express", "4.18.2"); err != nil {
+			t.Fatalf("expected success with forwarded auth, got: %v", err)
+		}
+		if gotAuth != token {
+			t.Errorf("Authorization = %q, want %q", gotAuth, token)
+		}
+	})
+
+	t.Run("no auth header when unset (public path)", func(t *testing.T) {
+		var gotAuth string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"time":{"4.18.2":"2022-10-08T14:21:24.484Z"}}`))
+		}))
+		defer server.Close()
+
+		client := NewClientWithHTTP(server.Client(), server.URL)
+		if _, err := client.GetPublishDate(context.Background(), "express", "4.18.2"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gotAuth != "" {
+			t.Errorf("no Authorization header expected on public path, got %q", gotAuth)
+		}
+	})
+
 	t.Run("scoped package URL encoding", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// url.PathEscape encodes @types/node as %40types%2Fnode

--- a/internal/supplychain/registry/pypi.go
+++ b/internal/supplychain/registry/pypi.go
@@ -54,10 +54,14 @@ func NewPyPIClient() *PyPIClient {
 }
 
 // NewPyPIClientWithHTTP builds a PyPIClient with an injected HTTP client and
-// base URL. It exists for tests that point the client at an httptest server;
-// the baseURL is therefore a trusted construction-time value, not request- or
-// network-derived input. Production code uses NewPyPIClient, which hardcodes
-// the pypi.org HTTPS endpoint.
+// base URL. Two callers use it: tests pointing at an httptest server, and the
+// CI `check` path pointing at a configured corporate artifactory (PPSC-994). In
+// both cases baseURL is a construction-time value the caller controls — for the
+// artifactory case it MUST have passed supplychain.ValidateRegistryURL
+// (https-only, no userinfo, no loopback/RFC1918/link-local host) at config-load
+// before reaching here, which keeps the cwe:918 suppressions in fetchReleases
+// sound now that the URL is configurable. Production age checks against public
+// PyPI use NewPyPIClient, which hardcodes pypi.org.
 func NewPyPIClientWithHTTP(httpClient *http.Client, baseURL string) *PyPIClient {
 	if baseURL == "" {
 		baseURL = defaultPyPIURL
@@ -159,17 +163,17 @@ func (c *PyPIClient) fetchReleases(ctx context.Context, name string) (map[string
 	}
 
 	encodedName := url.PathEscape(name)
-	// armis:ignore cwe:918 reason:baseURL is a trusted construction-time config value (production NewPyPIClient hardcodes the pypi.org HTTPS constant; the URL-accepting NewPyPIClientWithHTTP is test-only); name is regex-validated above and PathEscaped, so it cannot alter the host
+	// armis:ignore cwe:918 reason:baseURL is either the hardcoded pypi.org HTTPS constant (NewPyPIClient) or a custom upstream validated at config-load by supplychain.ValidateRegistryURL (https-only, no userinfo, rejects loopback/RFC1918/link-local) before NewPyPIClientWithHTTP is called; name is regex-validated above and PathEscaped, so neither can alter the host
 	reqURL := fmt.Sprintf("%s/pypi/%s/json", c.baseURL, encodedName)
-	// armis:ignore cwe:918 reason:reqURL is built from the trusted baseURL constant + a PathEscaped, regex-validated package name, so the host is not attacker-controlled
+	// armis:ignore cwe:918 reason:reqURL is built from baseURL (pypi.org constant or a config-load-validated custom upstream) + a PathEscaped, regex-validated package name, so the host is not attacker-controlled
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request for %s: %w", name, err)
 	}
 	req.Header.Set("Accept", "application/json")
 
-	// armis:ignore cwe:918 reason:c.baseURL is a trusted construction-time config value (production NewPyPIClient hardcodes the pypi.org HTTPS constant; the URL-accepting NewPyPIClientWithHTTP is test-only), so the request host is not attacker-controlled; the package name is regex-validated and PathEscaped
-	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: reqURL is a constant/configured registry host + regex-validated, PathEscaped package name
+	// armis:ignore cwe:918 reason:c.baseURL is either the hardcoded pypi.org HTTPS constant (NewPyPIClient) or a custom upstream validated at config-load by supplychain.ValidateRegistryURL (https-only, no userinfo, rejects loopback/RFC1918/link-local), so the request host is not attacker-controlled; the package name is regex-validated and PathEscaped
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: reqURL is a constant/config-load-validated registry host + regex-validated, PathEscaped package name
 	if err != nil {
 		return nil, fmt.Errorf("fetching PyPI metadata for %s: %w", name, err)
 	}

--- a/internal/supplychain/registry/pypi.go
+++ b/internal/supplychain/registry/pypi.go
@@ -118,9 +118,11 @@ func NewPyPIClientWithHTTP(httpClient *http.Client, baseURL string) *PyPIClient 
 	baseURL = strings.TrimRight(baseURL, "/")
 	// Guard the exported constructor against a nil client: callers that pass nil
 	// would otherwise hit a nil-pointer panic at c.httpClient.Do(). Default to
-	// the same timeout-configured client NewPyPIClient uses.
+	// the same proxy-aware, timeout-configured client NewPyPIClient uses, so this
+	// fallback also honors WinINET/PAC on Windows instead of silently dropping
+	// proxy support for the injected-client path.
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 30 * time.Second}
+		httpClient = &http.Client{Timeout: 30 * time.Second, Transport: httpclient.ProxyAwareTransport()}
 	}
 	return &PyPIClient{
 		httpClient: httpClient,

--- a/internal/supplychain/registry/pypi.go
+++ b/internal/supplychain/registry/pypi.go
@@ -18,6 +18,11 @@ import (
 
 const (
 	defaultPyPIURL = "https://pypi.org"
+
+	// pypiSimpleJSONAccept is the PEP 691 content type for the PyPI Simple API
+	// JSON representation, which carries PEP 700 per-file "upload-time" fields.
+	// Mirrors the constant the wrap proxy requests (supplychain.pypiSimpleJSONAccept).
+	pypiSimpleJSONAccept = "application/vnd.pypi.simple.v1+json"
 )
 
 var validPyPIPackageName = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$`)
@@ -34,6 +39,21 @@ var pypiSeparatorRun = regexp.MustCompile(`[-_.]+`)
 type PyPIClient struct {
 	httpClient *http.Client
 	baseURL    string
+	// simpleAPI selects the PEP 691 Simple API ("<baseURL>/<name>/") instead of
+	// PyPI's own legacy JSON API ("<baseURL>/pypi/<name>/json"). Set true only
+	// for a configured custom upstream (NewPyPIClientWithHTTP with a non-default
+	// baseURL): the legacy endpoint is a PyPI-proprietary API that no
+	// artifactory (Nexus, JFrog Artifactory) implements — a custom upstream 404s
+	// on it — while every PEP 503-compliant mirror serves the Simple API. The
+	// default public path keeps using the legacy API, which returns every
+	// version's files in one response instead of requiring the version to
+	// already be known.
+	simpleAPI bool
+	// authHeader is an optional pre-built Authorization value ("Basic <b64>")
+	// attached to every release-metadata request, so `supply-chain check` can
+	// query an auth-gated PyPI index with the developer's index-url credential.
+	// Empty on the public path (pypi.org needs no credential).
+	authHeader string
 	cache      sync.Map // map[string]map[string][]pypiRelease
 	cacheLen   atomic.Int64
 }
@@ -44,6 +64,19 @@ type pypiResponse struct {
 
 type pypiRelease struct {
 	UploadTime string `json:"upload_time_iso_8601"`
+}
+
+// pypiSimpleFile is one entry in a PEP 691 Simple API "files" array. Only the
+// fields the age check needs are decoded; hashes/requires-python/etc. are
+// dropped, mirroring the wrap proxy's map[string]json.RawMessage approach but
+// with a fixed struct since this client never re-serializes the document.
+type pypiSimpleFile struct {
+	Filename   string `json:"filename"`
+	UploadTime string `json:"upload-time"`
+}
+
+type pypiSimpleResponse struct {
+	Files []pypiSimpleFile `json:"files"`
 }
 
 func NewPyPIClient() *PyPIClient {
@@ -62,10 +95,27 @@ func NewPyPIClient() *PyPIClient {
 // before reaching here, which keeps the cwe:918 suppressions in fetchReleases
 // sound now that the URL is configurable. Production age checks against public
 // PyPI use NewPyPIClient, which hardcodes pypi.org.
+//
+// A non-default, non-empty baseURL is assumed to be a custom artifactory and
+// switches fetchReleases to the PEP 691 Simple API (see simpleAPI) — the
+// legacy "/pypi/<name>/json" endpoint this client otherwise uses is a
+// PyPI-proprietary API no artifactory implements.
+// armis:ignore cwe:918 reason:baseURL is either "" (defaults to the hardcoded pypi.org constant below) or the config-load-validated registries.pypi value (supplychain.ValidateRegistryURL: https-only, no userinfo, rejects loopback/RFC1918/link-local) per the doc comment above; not a per-request attacker-controlled value
 func NewPyPIClientWithHTTP(httpClient *http.Client, baseURL string) *PyPIClient {
+	custom := baseURL != "" && baseURL != defaultPyPIURL
 	if baseURL == "" {
 		baseURL = defaultPyPIURL
 	}
+	// Trim a trailing slash so fetchReleases' URL join never yields a "//" at
+	// the boundary — a configured index URL commonly ends in one. Same
+	// normalization as the npm client. A configured registries.pypi URL is
+	// required (config.go) to already end in "/simple" (PEP 503); unlike the
+	// wrap proxy (which forwards the client's own "/simple/<pkg>/" request path
+	// onto the upstream and so must avoid re-adding it), fetchReleasesSimple
+	// builds "<baseURL>/<name>/" directly with no separate "/simple" segment of
+	// its own, so baseURL keeping its "/simple" suffix is exactly the path PEP
+	// 503 artifactories expect — nothing to strip here.
+	baseURL = strings.TrimRight(baseURL, "/")
 	// Guard the exported constructor against a nil client: callers that pass nil
 	// would otherwise hit a nil-pointer panic at c.httpClient.Do(). Default to
 	// the same timeout-configured client NewPyPIClient uses.
@@ -75,7 +125,17 @@ func NewPyPIClientWithHTTP(httpClient *http.Client, baseURL string) *PyPIClient 
 	return &PyPIClient{
 		httpClient: httpClient,
 		baseURL:    baseURL,
+		simpleAPI:  custom,
 	}
+}
+
+// WithAuthHeader sets the Authorization header value ("Basic <b64>") sent on
+// every release-metadata request and returns the client for chaining. Mirrors
+// the npm client's setter; an empty value is a no-op (public path). Set before
+// any concurrent GetPublishDates call.
+func (c *PyPIClient) WithAuthHeader(authHeader string) *PyPIClient {
+	c.authHeader = authHeader
+	return c
 }
 
 func (c *PyPIClient) GetPublishDate(ctx context.Context, name, version string) (time.Time, error) {
@@ -157,11 +217,40 @@ func (c *PyPIClient) GetPublishDates(ctx context.Context, packages []PackageRequ
 	return results
 }
 
+// fetchReleases resolves a package's per-version release files. It dispatches
+// to the legacy PyPI JSON API (public pypi.org) or the PEP 691 Simple API (any
+// configured custom artifactory) based on c.simpleAPI — see NewPyPIClientWithHTTP.
 func (c *PyPIClient) fetchReleases(ctx context.Context, name string) (map[string][]pypiRelease, error) {
 	if cached, ok := c.cache.Load(name); ok {
 		return cached.(map[string][]pypiRelease), nil
 	}
 
+	var releases map[string][]pypiRelease
+	var err error
+	if c.simpleAPI {
+		releases, err = c.fetchReleasesSimple(ctx, name)
+	} else {
+		releases, err = c.fetchReleasesLegacy(ctx, name)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Memoize, but stop inserting once the cache reaches maxCacheEntries so it
+	// cannot grow without bound (CWE-770). LoadOrStore keeps the length count
+	// race-free under the concurrent GetPublishDates fan-out.
+	if c.cacheLen.Load() < maxCacheEntries {
+		if _, loaded := c.cache.LoadOrStore(name, releases); !loaded {
+			c.cacheLen.Add(1)
+		}
+	}
+	return releases, nil
+}
+
+// fetchReleasesLegacy queries PyPI's own "/pypi/<name>/json" API. This is a
+// PyPI-proprietary endpoint no third-party artifactory implements, so it is
+// used only for the default public pypi.org path (c.simpleAPI is false).
+func (c *PyPIClient) fetchReleasesLegacy(ctx context.Context, name string) (map[string][]pypiRelease, error) {
 	encodedName := url.PathEscape(name)
 	// armis:ignore cwe:918 reason:baseURL is either the hardcoded pypi.org HTTPS constant (NewPyPIClient) or a custom upstream validated at config-load by supplychain.ValidateRegistryURL (https-only, no userinfo, rejects loopback/RFC1918/link-local) before NewPyPIClientWithHTTP is called; name is regex-validated above and PathEscaped, so neither can alter the host
 	reqURL := fmt.Sprintf("%s/pypi/%s/json", c.baseURL, encodedName)
@@ -171,6 +260,11 @@ func (c *PyPIClient) fetchReleases(ctx context.Context, name string) (map[string
 		return nil, fmt.Errorf("creating request for %s: %w", name, err)
 	}
 	req.Header.Set("Accept", "application/json")
+	// Forward the developer's index credential when configured so an auth-gated
+	// PyPI index answers 200 instead of 401 (the `check` path).
+	if c.authHeader != "" {
+		req.Header.Set("Authorization", c.authHeader)
+	}
 
 	// armis:ignore cwe:918 reason:c.baseURL is either the hardcoded pypi.org HTTPS constant (NewPyPIClient) or a custom upstream validated at config-load by supplychain.ValidateRegistryURL (https-only, no userinfo, rejects loopback/RFC1918/link-local), so the request host is not attacker-controlled; the package name is regex-validated and PathEscaped
 	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: reqURL is a constant/config-load-validated registry host + regex-validated, PathEscaped package name
@@ -202,16 +296,109 @@ func (c *PyPIClient) fetchReleases(ctx context.Context, name string) (map[string
 	if err := json.Unmarshal(body, &result); err != nil {
 		return nil, fmt.Errorf("parsing PyPI response for %s: %w", name, err)
 	}
+	return result.Releases, nil
+}
 
-	// Memoize, but stop inserting once the cache reaches maxCacheEntries so it
-	// cannot grow without bound (CWE-770). LoadOrStore keeps the length count
-	// race-free under the concurrent GetPublishDates fan-out.
-	if c.cacheLen.Load() < maxCacheEntries {
-		if _, loaded := c.cache.LoadOrStore(name, result.Releases); !loaded {
-			c.cacheLen.Add(1)
+// fetchReleasesSimple queries the PEP 691 Simple API ("<baseURL>/<name>/") and
+// regroups its flat per-file list by version (parsed from each filename) so
+// the result matches fetchReleasesLegacy's shape and GetPublishDate's existing
+// version-lookup logic needs no changes. Used for any configured custom
+// upstream (c.simpleAPI is true) — every PEP 503-compliant artifactory
+// (Nexus, JFrog Artifactory) serves this API, unlike PyPI's proprietary legacy
+// JSON endpoint.
+func (c *PyPIClient) fetchReleasesSimple(ctx context.Context, name string) (map[string][]pypiRelease, error) {
+	encodedName := url.PathEscape(name)
+	// armis:ignore cwe:918 reason:baseURL is a custom upstream validated at config-load by supplychain.ValidateRegistryURL (https-only, no userinfo, rejects loopback/RFC1918/link-local) before NewPyPIClientWithHTTP is called; name is regex-validated above and PathEscaped, so neither can alter the host
+	reqURL := fmt.Sprintf("%s/%s/", c.baseURL, encodedName)
+	// armis:ignore cwe:918 reason:reqURL is built from baseURL (a config-load-validated custom upstream) + a PathEscaped, regex-validated package name, so the host is not attacker-controlled
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request for %s: %w", name, err)
+	}
+	// Request the PEP 691 JSON form so the response carries PEP 700 per-file
+	// upload-time fields; the default Simple API HTML has no timestamps. Mirrors
+	// the wrap proxy's handleMetadataFiltering.
+	req.Header.Set("Accept", pypiSimpleJSONAccept)
+	if c.authHeader != "" {
+		req.Header.Set("Authorization", c.authHeader)
+	}
+
+	// armis:ignore cwe:918 reason:c.baseURL is a custom upstream validated at config-load by supplychain.ValidateRegistryURL (https-only, no userinfo, rejects loopback/RFC1918/link-local), so the request host is not attacker-controlled; the package name is regex-validated and PathEscaped
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: reqURL is a config-load-validated registry host + regex-validated, PathEscaped package name
+	if err != nil {
+		return nil, fmt.Errorf("fetching PyPI Simple API metadata for %s: %w", name, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort close on read path
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("package %q not found on configured registry", name)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("configured registry returned %d for %s", resp.StatusCode, name)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading registry response for %s: %w", name, err)
+	}
+	if int64(len(body)) > maxResponseSize {
+		return nil, fmt.Errorf("registry response for %s too large (max %d bytes)", name, maxResponseSize)
+	}
+
+	var simple pypiSimpleResponse
+	if err := json.Unmarshal(body, &simple); err != nil {
+		return nil, fmt.Errorf("parsing registry Simple API response for %s: %w", name, err)
+	}
+
+	releases := make(map[string][]pypiRelease, len(simple.Files))
+	for _, f := range simple.Files {
+		ver := pypiVersionFromFilename(f.Filename)
+		if ver == "" {
+			continue
+		}
+		releases[ver] = append(releases[ver], pypiRelease{UploadTime: f.UploadTime})
+	}
+	return releases, nil
+}
+
+// pypiVersionFromFilename extracts the version component from a wheel or sdist
+// filename. Wheels and sdists use different grammars, so they are parsed
+// separately. Returns "" if the pattern does not match. Duplicated from the
+// wrap proxy's identical helper (supplychain.pypiVersionFromFilename, package-
+// private there) rather than exported across the package boundary for one
+// small pure function.
+func pypiVersionFromFilename(filename string) string {
+	// Wheels (and the legacy egg format) carry trailing build/interpreter/
+	// platform tags after the version, e.g.
+	// "{name}-{version}-{python}-{abi}-{platform}.whl". PEP 427 normalizes the
+	// distribution so it never contains '-' (runs of [-_.] collapse to '_'), so
+	// the version is reliably the second '-'-delimited field.
+	if strings.HasSuffix(filename, ".whl") || strings.HasSuffix(filename, ".egg") {
+		base := filename[:strings.LastIndex(filename, ".")]
+		parts := strings.SplitN(base, "-", 3)
+		if len(parts) < 2 {
+			return ""
+		}
+		return parts[1]
+	}
+
+	// sdists are "{name}-{version}{ext}" with no trailing tags. Unlike wheels the
+	// project name is NOT normalized, so it may legitimately contain '-' (e.g.
+	// "zope-interface-6.0.tar.gz"). PEP 440 versions never contain '-', so the
+	// version is everything after the FINAL '-'. Splitting on the first '-' (as a
+	// single shared parser would) misreads such names — yielding "interface".
+	name := filename
+	for _, ext := range []string{".tar.gz", ".tar.bz2", ".zip"} {
+		if strings.HasSuffix(name, ext) {
+			name = name[:len(name)-len(ext)]
+			break
 		}
 	}
-	return result.Releases, nil
+	idx := strings.LastIndex(name, "-")
+	if idx <= 0 || idx == len(name)-1 {
+		return ""
+	}
+	return name[idx+1:]
 }
 
 // NormalizePyPIName applies PEP 503 name normalization: lowercase the name and

--- a/internal/supplychain/registry/pypi.go
+++ b/internal/supplychain/registry/pypi.go
@@ -102,7 +102,6 @@ func NewPyPIClient() *PyPIClient {
 // PyPI-proprietary API no artifactory implements.
 // armis:ignore cwe:918 reason:baseURL is either "" (defaults to the hardcoded pypi.org constant below) or the config-load-validated registries.pypi value (supplychain.ValidateRegistryURL: https-only, no userinfo, rejects loopback/RFC1918/link-local) per the doc comment above; not a per-request attacker-controlled value
 func NewPyPIClientWithHTTP(httpClient *http.Client, baseURL string) *PyPIClient {
-	custom := baseURL != "" && baseURL != defaultPyPIURL
 	if baseURL == "" {
 		baseURL = defaultPyPIURL
 	}
@@ -116,6 +115,11 @@ func NewPyPIClientWithHTTP(httpClient *http.Client, baseURL string) *PyPIClient 
 	// its own, so baseURL keeping its "/simple" suffix is exactly the path PEP
 	// 503 artifactories expect — nothing to strip here.
 	baseURL = strings.TrimRight(baseURL, "/")
+	// Compute custom AFTER normalization: "https://pypi.org/" (trailing slash)
+	// must be treated as the default public host, not as a custom artifactory —
+	// computing this before TrimRight would make an equivalent default URL take
+	// the wrong (Simple API) code path purely due to a cosmetic trailing slash.
+	custom := baseURL != strings.TrimRight(defaultPyPIURL, "/")
 	// Guard the exported constructor against a nil client: callers that pass nil
 	// would otherwise hit a nil-pointer panic at c.httpClient.Do(). Default to
 	// the same proxy-aware, timeout-configured client NewPyPIClient uses, so this

--- a/internal/supplychain/registry/pypi_test.go
+++ b/internal/supplychain/registry/pypi_test.go
@@ -143,6 +143,16 @@ func TestPyPIGetPublishDate(t *testing.T) {
 		if client.baseURL != defaultPyPIURL {
 			t.Errorf("expected baseURL to default to %q, got %q", defaultPyPIURL, client.baseURL)
 		}
+		// Regression guard: the defaulted client must use the same proxy-aware
+		// transport as NewClient(), so this fallback still honors WinINET/PAC on
+		// Windows instead of silently dropping proxy support. A bare
+		// &http.Client{Timeout: ...} (the pre-fix code) leaves Transport nil; the
+		// fix sets it to httpclient.ProxyAwareTransport(), whose .Proxy field is
+		// always non-nil (the OS proxy resolver).
+		transport, ok := client.httpClient.Transport.(*http.Transport)
+		if !ok || transport.Proxy == nil {
+			t.Error("expected the defaulted client to carry ProxyAwareTransport (non-nil *http.Transport with a Proxy func), got a plain/nil transport")
+		}
 	})
 
 	t.Run("caches responses", func(t *testing.T) {

--- a/internal/supplychain/registry/pypi_test.go
+++ b/internal/supplychain/registry/pypi_test.go
@@ -233,6 +233,21 @@ func TestPyPIGetPublishDate(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+
+	// Regression guard: the default public URL with a trailing slash
+	// ("https://pypi.org/") must be treated as the default host (legacy JSON
+	// API), not as a "custom" artifactory — custom-detection used to run BEFORE
+	// trailing-slash normalization, so this equivalent-to-default URL took the
+	// wrong (Simple API) code path purely because of a cosmetic trailing slash.
+	t.Run("default public URL with trailing slash is still treated as default", func(t *testing.T) {
+		client := NewPyPIClientWithHTTP(nil, defaultPyPIURL+"/")
+		if client.simpleAPI {
+			t.Errorf("expected simpleAPI=false for a trailing-slash default URL, got true (treated as custom)")
+		}
+		if client.baseURL != defaultPyPIURL {
+			t.Errorf("baseURL = %q, want %q", client.baseURL, defaultPyPIURL)
+		}
+	})
 }
 
 func TestPyPIGetPublishDates(t *testing.T) {

--- a/internal/supplychain/registry/pypi_test.go
+++ b/internal/supplychain/registry/pypi_test.go
@@ -8,19 +8,34 @@ import (
 	"time"
 )
 
+// simplePyPIBody builds a minimal PEP 691 Simple API JSON body from
+// filename→upload-time pairs, the shape a configured custom registry
+// (NewPyPIClientWithHTTP with a non-default baseURL) is queried with.
+func simplePyPIBody(files map[string]string) string {
+	body := `{"files":[`
+	first := true
+	for filename, uploadTime := range files {
+		if !first {
+			body += ","
+		}
+		first = false
+		body += `{"filename":"` + filename + `","upload-time":"` + uploadTime + `"}`
+	}
+	body += `]}`
+	return body
+}
+
 func TestPyPIGetPublishDate(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path != "/pypi/flask/json" {
+			if r.URL.Path != "/flask/" {
 				t.Errorf("unexpected path: %s", r.URL.Path)
 			}
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{
-				"releases": {
-					"3.0.0": [{"upload_time_iso_8601": "2023-09-30T12:00:00Z"}],
-					"2.3.3": [{"upload_time_iso_8601": "2023-08-15T10:00:00Z"}]
-				}
-			}`))
+			w.Header().Set("Content-Type", "application/vnd.pypi.simple.v1+json")
+			_, _ = w.Write([]byte(simplePyPIBody(map[string]string{
+				"flask-3.0.0-py3-none-any.whl": "2023-09-30T12:00:00Z",
+				"flask-2.3.3-py3-none-any.whl": "2023-08-15T10:00:00Z",
+			})))
 		}))
 		defer server.Close()
 
@@ -51,8 +66,10 @@ func TestPyPIGetPublishDate(t *testing.T) {
 
 	t.Run("version not found", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"releases": {"1.0.0": [{"upload_time_iso_8601": "2023-01-01T00:00:00Z"}]}}`))
+			w.Header().Set("Content-Type", "application/vnd.pypi.simple.v1+json")
+			_, _ = w.Write([]byte(simplePyPIBody(map[string]string{
+				"flask-1.0.0-py3-none-any.whl": "2023-01-01T00:00:00Z",
+			})))
 		}))
 		defer server.Close()
 
@@ -73,12 +90,14 @@ func TestPyPIGetPublishDate(t *testing.T) {
 
 	t.Run("name normalization", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Normalized: Flask -> flask, my_package -> my-package
-			if r.URL.Path != "/pypi/my-package/json" {
+			// Normalized: My_Package -> my-package
+			if r.URL.Path != "/my-package/" {
 				t.Errorf("unexpected path: %s (expected normalized name)", r.URL.Path)
 			}
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"releases": {"1.0.0": [{"upload_time_iso_8601": "2023-01-01T00:00:00Z"}]}}`))
+			w.Header().Set("Content-Type", "application/vnd.pypi.simple.v1+json")
+			_, _ = w.Write([]byte(simplePyPIBody(map[string]string{
+				"my_package-1.0.0-py3-none-any.whl": "2023-01-01T00:00:00Z",
+			})))
 		}))
 		defer server.Close()
 
@@ -90,12 +109,14 @@ func TestPyPIGetPublishDate(t *testing.T) {
 	})
 
 	t.Run("matches version under PEP 440 normalization", func(t *testing.T) {
-		// Lockfile pins "2.0" but PyPI keys the release as "2.0.0" — the lookup
-		// must still resolve via normalized comparison rather than reporting the
+		// Lockfile pins "2.0" but the filename embeds "2.0.0" — the lookup must
+		// still resolve via normalized comparison rather than reporting the
 		// version as missing.
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"releases": {"2.0.0": [{"upload_time_iso_8601": "2023-01-01T00:00:00Z"}]}}`))
+			w.Header().Set("Content-Type", "application/vnd.pypi.simple.v1+json")
+			_, _ = w.Write([]byte(simplePyPIBody(map[string]string{
+				"flask-2.0.0-py3-none-any.whl": "2023-01-01T00:00:00Z",
+			})))
 		}))
 		defer server.Close()
 
@@ -128,8 +149,11 @@ func TestPyPIGetPublishDate(t *testing.T) {
 		calls := 0
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			calls++
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"releases": {"3.0.0": [{"upload_time_iso_8601": "2023-09-30T12:00:00Z"}], "2.3.3": [{"upload_time_iso_8601": "2023-08-15T10:00:00Z"}]}}`))
+			w.Header().Set("Content-Type", "application/vnd.pypi.simple.v1+json")
+			_, _ = w.Write([]byte(simplePyPIBody(map[string]string{
+				"flask-3.0.0-py3-none-any.whl": "2023-09-30T12:00:00Z",
+				"flask-2.3.3-py3-none-any.whl": "2023-08-15T10:00:00Z",
+			})))
 		}))
 		defer server.Close()
 
@@ -149,6 +173,56 @@ func TestPyPIGetPublishDate(t *testing.T) {
 			t.Errorf("expected 1 HTTP call (cached), got %d", calls)
 		}
 	})
+
+	t.Run("default public URL uses the legacy PyPI JSON API", func(t *testing.T) {
+		// NewPyPIClient() (no injected baseURL) must keep querying PyPI's own
+		// "/pypi/<name>/json" API, not the Simple API — this is the production
+		// path against the real pypi.org and is a regression guard distinguishing
+		// it from the custom-upstream Simple API path exercised by every other
+		// subtest in this file.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/pypi/flask/json" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"releases": {"3.0.0": [{"upload_time_iso_8601": "2023-09-30T12:00:00Z"}]}}`))
+		}))
+		defer server.Close()
+
+		client := &PyPIClient{httpClient: server.Client(), baseURL: server.URL, simpleAPI: false}
+		publishTime, err := client.GetPublishDate(context.Background(), "flask", "3.0.0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		expected := time.Date(2023, 9, 30, 12, 0, 0, 0, time.UTC)
+		if !publishTime.Equal(expected) {
+			t.Errorf("expected %v, got %v", expected, publishTime)
+		}
+	})
+
+	t.Run("custom upstream keeps its configured /simple suffix", func(t *testing.T) {
+		// registries.pypi is required (config.go) to end in "/simple" (PEP 503),
+		// and fetchReleasesSimple builds "<baseURL>/<name>/" directly with no
+		// separate "/simple" segment of its own — so the configured suffix must
+		// be preserved, not stripped, or the request 404s on
+		// ".../pypi-group/<name>/" instead of ".../pypi-group/simple/<name>/".
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/repository/pypi-group/simple/flask/" {
+				t.Errorf("unexpected path: %s (expected the /simple suffix preserved)", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/vnd.pypi.simple.v1+json")
+			_, _ = w.Write([]byte(simplePyPIBody(map[string]string{
+				"flask-3.0.0-py3-none-any.whl": "2023-09-30T12:00:00Z",
+			})))
+		}))
+		defer server.Close()
+
+		client := NewPyPIClientWithHTTP(server.Client(), server.URL+"/repository/pypi-group/simple/")
+		_, err := client.GetPublishDate(context.Background(), "flask", "3.0.0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestPyPIGetPublishDates(t *testing.T) {
@@ -156,12 +230,16 @@ func TestPyPIGetPublishDates(t *testing.T) {
 	// else, so one server backs every batch sub-case.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/pypi/flask/json":
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"releases": {"3.0.0": [{"upload_time_iso_8601": "2023-09-30T12:00:00Z"}]}}`))
-		case "/pypi/requests/json":
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"releases": {"2.31.0": [{"upload_time_iso_8601": "2023-05-22T15:12:00Z"}]}}`))
+		case "/flask/":
+			w.Header().Set("Content-Type", "application/vnd.pypi.simple.v1+json")
+			_, _ = w.Write([]byte(simplePyPIBody(map[string]string{
+				"flask-3.0.0-py3-none-any.whl": "2023-09-30T12:00:00Z",
+			})))
+		case "/requests/":
+			w.Header().Set("Content-Type", "application/vnd.pypi.simple.v1+json")
+			_, _ = w.Write([]byte(simplePyPIBody(map[string]string{
+				"requests-2.31.0-py3-none-any.whl": "2023-05-22T15:12:00Z",
+			})))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/internal/supplychain/registry_url.go
+++ b/internal/supplychain/registry_url.go
@@ -1,0 +1,110 @@
+package supplychain
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// ValidateRegistryURL validates a registry/artifactory URL read from
+// .armis-supply-chain.yaml before it is used as the proxy's upstream or as the
+// CI check's registry client.
+//
+// This is a SECURITY BOUNDARY, not a cosmetic check. Once registries.<ecosystem>
+// is configurable, the committed config file becomes a trust boundary: a
+// malicious PR could repoint the proxy at http://169.254.169.254/ (cloud IMDS)
+// or an attacker-controlled host, and the proxy would faithfully forward the
+// developer's injected credentials there (SSRF + credential exfiltration). The
+// old "hardcoded trusted host" reasoning behind the cwe:918 suppressions in
+// proxy.go and registry/*.go is FALSE the moment the upstream is configurable —
+// this function is what restores that reasoning to "validated at config-load."
+//
+// Rules (all must hold):
+//   - scheme must be https (no http, file, gopher, etc.) — credentials must
+//     never traverse a plaintext hop, and non-http schemes are not registries.
+//   - no embedded userinfo (https://user:pass@host) — credentials belong in the
+//     PM's native config, never in the committed policy file, and userinfo here
+//     would leak into lockfiles via NormalizeArtifact (see S3).
+//   - the host must resolve to a routable public address: reject loopback,
+//     RFC1918 private ranges, link-local (including 169.254.0.0/16, the cloud
+//     metadata range), unique-local IPv6 (fc00::/7), and the unspecified
+//     address. A literal IP is checked directly; a hostname's literal-IP forms
+//     are rejected, but a DNS name is allowed (we cannot resolve it safely at
+//     config-load without a TOCTOU window — the CheckRedirect and https
+//     guarantees bound the residual risk, and an internal corporate registry
+//     legitimately uses a private DNS name).
+func ValidateRegistryURL(raw string) (*url.URL, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, fmt.Errorf("registry URL is empty")
+	}
+
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("invalid registry URL %q: %w", raw, err)
+	}
+
+	if u.Scheme != "https" {
+		return nil, fmt.Errorf("registry URL %q must use https:// (got %q) — credentials must not traverse a plaintext connection", raw, u.Scheme)
+	}
+
+	if u.User != nil {
+		return nil, fmt.Errorf("registry URL %q must not embed credentials (user:pass@host) — put the token in your .npmrc/pip.conf, not the committed policy file", raw)
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		return nil, fmt.Errorf("registry URL %q has no host", raw)
+	}
+
+	// A literal IP is validated directly. A DNS name is allowed through (an
+	// internal registry commonly uses a private name); we deliberately do not
+	// resolve it here to avoid a TOCTOU between validation and use.
+	// armis:ignore cwe:918 reason:the registry URL is read from the committed .armis-supply-chain.yaml (a code-review trust boundary, not runtime user input); literal non-routable IPs are rejected here, and a DNS name is allowed BY DESIGN because internal corporate registries legitimately run on private hostnames — resolving-and-rejecting-private-IPs would break that required use case and only open a TOCTOU window. Residual rebinding risk is bounded by the https requirement and the proxy's CheckRedirect (refuses any cross-host hop, S2).
+	if ip := net.ParseIP(host); ip != nil {
+		if err := rejectNonRoutableIP(ip); err != nil {
+			return nil, fmt.Errorf("registry URL %q: %w", raw, err)
+		}
+	}
+
+	return u, nil
+}
+
+// StripURLUserinfo returns origin with any embedded userinfo
+// (https://user:tok@host) removed, preserving scheme, host, port, and path.
+// It is applied to the upstream origin BEFORE it is handed to
+// normalizeProxyResidue/NormalizeArtifact (S3): a `https://user:token@nexus/`
+// config (rejected for registries.<eco>, but possible via an index-url-derived
+// origin) must never be written into a lockfile as the rewrite target. On any
+// parse failure it returns the input unchanged — the residue rewrite is
+// best-effort and must not panic on a malformed origin.
+func StripURLUserinfo(origin string) string {
+	u, err := url.Parse(origin)
+	if err != nil || u.User == nil {
+		return origin
+	}
+	u.User = nil
+	return u.String()
+}
+
+// rejectNonRoutableIP returns an error when ip is in a range the registry
+// upstream must never point at — loopback, private, link-local (cloud IMDS),
+// unique-local, or unspecified. Centralized so the literal-IP path and any
+// future resolved-IP path share one policy.
+func rejectNonRoutableIP(ip net.IP) error {
+	switch {
+	case ip.IsLoopback():
+		return fmt.Errorf("loopback addresses (%s) are not allowed as a registry host", ip)
+	case ip.IsUnspecified():
+		return fmt.Errorf("the unspecified address (%s) is not allowed as a registry host", ip)
+	case ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast():
+		// 169.254.0.0/16 (and fe80::/10) — includes the cloud metadata endpoint
+		// 169.254.169.254, the canonical SSRF target.
+		return fmt.Errorf("link-local addresses (%s) are not allowed as a registry host (cloud metadata SSRF range)", ip)
+	case ip.IsPrivate():
+		// RFC1918 (10/8, 172.16/12, 192.168/16) and IPv6 unique-local (fc00::/7).
+		return fmt.Errorf("private addresses (%s) are not allowed as a registry host", ip)
+	}
+	return nil
+}

--- a/internal/supplychain/registry_url.go
+++ b/internal/supplychain/registry_url.go
@@ -58,6 +58,18 @@ func ValidateRegistryURL(raw string) (*url.URL, error) {
 		return nil, fmt.Errorf("registry URL %q has no host", raw)
 	}
 
+	// "localhost" and any "*.localhost" name are reserved (RFC 6761) and resolve
+	// to loopback on every major OS/browser/resolver by convention, even though
+	// they are not literal IPs — so the literal-IP check below would miss them
+	// entirely. Reject them by name for the same reason a literal 127.0.0.1 is
+	// rejected: a registry pointed at the proxy's own host would let the proxy
+	// forward the developer's injected credential back to a process on the local
+	// machine.
+	lowerHost := strings.ToLower(host)
+	if lowerHost == "localhost" || strings.HasSuffix(lowerHost, ".localhost") {
+		return nil, fmt.Errorf("registry URL %q: %q is a reserved loopback name (RFC 6761) and is not allowed as a registry host", raw, host)
+	}
+
 	// A literal IP is validated directly. A DNS name is allowed through (an
 	// internal registry commonly uses a private name); we deliberately do not
 	// resolve it here to avoid a TOCTOU between validation and use.

--- a/internal/supplychain/registry_url_test.go
+++ b/internal/supplychain/registry_url_test.go
@@ -1,0 +1,93 @@
+package supplychain
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStripURLUserinfo is part of test-plan case #7 (credential-leak
+// prevention): a userinfo-bearing origin must be stripped before it can be
+// written into a lockfile as the residue rewrite target.
+func TestStripURLUserinfo(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "user:pass stripped", in: "https://user:tok@nexus.corp/npm", want: "https://nexus.corp/npm"}, //nolint:gosec // G101: test fixture URL, not a real credential
+		{name: "user only stripped", in: "https://user@nexus.corp/npm", want: "https://nexus.corp/npm"},
+		{name: "no userinfo unchanged", in: "https://nexus.corp/npm", want: "https://nexus.corp/npm"},
+		{name: "preserves port and path", in: "https://u:p@nexus.corp:8443/repository/npm", want: "https://nexus.corp:8443/repository/npm"}, //nolint:gosec // G101: test fixture URL, not a real credential
+		{name: "malformed returned unchanged", in: "://bad", want: "://bad"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StripURLUserinfo(tt.in); got != tt.want {
+				t.Errorf("StripURLUserinfo(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+			if strings.Contains(StripURLUserinfo(tt.in), "tok") {
+				t.Errorf("token leaked through StripURLUserinfo(%q)", tt.in)
+			}
+		})
+	}
+}
+
+// TestValidateRegistryURL is test-plan case #1 (P1, security). Each row pairs a
+// positive (accepted) or negative (rejected) expectation; the negative cases
+// ARE the SSRF security guarantee, so they are exhaustive over the threat
+// ranges called out in the design's Security Requirements.
+func TestValidateRegistryURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr bool
+		errHas  string // substring the rejection message should contain
+	}{
+		// --- accepted ---
+		{name: "https public host", raw: "https://nexus.corp/repository/npm-group/"},
+		{name: "https with port", raw: "https://nexus.corp:8443/repository/npm/"},
+		{name: "https private DNS name (internal registry)", raw: "https://artifactory.internal/npm/"},
+		{name: "https public IP literal", raw: "https://8.8.8.8/npm/"},
+
+		// --- rejected: scheme ---
+		{name: "http scheme", raw: "http://nexus.corp/npm/", wantErr: true, errHas: "https"},
+		{name: "file scheme", raw: "file:///etc/passwd", wantErr: true, errHas: "https"},
+		{name: "empty", raw: "", wantErr: true},
+		{name: "whitespace only", raw: "   ", wantErr: true},
+
+		// --- rejected: embedded credentials (S3 / leak prevention) ---
+		{name: "userinfo user:pass", raw: "https://user:token@nexus.corp/npm/", wantErr: true, errHas: "credentials"}, //nolint:gosec // G101: test fixture URL, not a real credential
+		{name: "userinfo user only", raw: "https://user@nexus.corp/npm/", wantErr: true, errHas: "credentials"},
+
+		// --- rejected: non-routable IPs (SSRF) ---
+		{name: "loopback v4", raw: "https://127.0.0.1/npm/", wantErr: true, errHas: "loopback"},
+		{name: "loopback v6", raw: "https://[::1]/npm/", wantErr: true, errHas: "loopback"},
+		{name: "IMDS link-local", raw: "https://169.254.169.254/latest/meta-data/", wantErr: true, errHas: "link-local"},
+		{name: "RFC1918 10/8", raw: "https://10.0.0.5/npm/", wantErr: true, errHas: "private"},
+		{name: "RFC1918 172.16/12", raw: "https://172.16.0.1/npm/", wantErr: true, errHas: "private"},
+		{name: "RFC1918 192.168/16", raw: "https://192.168.1.1/npm/", wantErr: true, errHas: "private"},
+		{name: "IPv6 unique-local", raw: "https://[fc00::1]/npm/", wantErr: true, errHas: "private"},
+		{name: "unspecified v4", raw: "https://0.0.0.0/npm/", wantErr: true, errHas: "unspecified"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := ValidateRegistryURL(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ValidateRegistryURL(%q) = nil error, want rejection", tt.raw)
+				}
+				if tt.errHas != "" && !strings.Contains(err.Error(), tt.errHas) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errHas)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateRegistryURL(%q) unexpected error: %v", tt.raw, err)
+			}
+			if u == nil {
+				t.Fatalf("ValidateRegistryURL(%q) returned nil URL with no error", tt.raw)
+			}
+		})
+	}
+}

--- a/internal/supplychain/registry_url_test.go
+++ b/internal/supplychain/registry_url_test.go
@@ -68,6 +68,14 @@ func TestValidateRegistryURL(t *testing.T) {
 		{name: "RFC1918 192.168/16", raw: "https://192.168.1.1/npm/", wantErr: true, errHas: "private"},
 		{name: "IPv6 unique-local", raw: "https://[fc00::1]/npm/", wantErr: true, errHas: "private"},
 		{name: "unspecified v4", raw: "https://0.0.0.0/npm/", wantErr: true, errHas: "unspecified"},
+
+		// --- rejected: reserved loopback names (SSRF) -- a literal-IP-only check
+		// would miss these, since localhost/*.localhost are hostnames, not literal
+		// IPs, yet resolve to loopback by OS/resolver convention (RFC 6761).
+		{name: "reserved name localhost", raw: "https://localhost/npm/", wantErr: true, errHas: "reserved loopback name"},
+		{name: "reserved name subdomain of localhost", raw: "https://nexus.localhost/npm/", wantErr: true, errHas: "reserved loopback name"},
+		{name: "reserved name case-insensitive", raw: "https://LocalHost/npm/", wantErr: true, errHas: "reserved loopback name"},
+		{name: "hostname merely containing localhost as substring accepted", raw: "https://nexus-localhost-mirror.corp/npm/"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Related Issue

* [PPSC-994](https://armis.atlassian.net/browse/PPSC-994)

## Type of Change

* [x] New feature (non-breaking change which adds functionality)
* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

Supply-chain enforcement (`wrap`/`check`) only ever queried the public npm/PyPI registries for package-age data, so orgs running a private artifactory (Nexus, JFrog) with a corporate CA and/or auth-gated access got no real coverage — installs resolved through the artifactory but ages were checked against a registry the org may not even use.

## Solution

Adds a `registries.<eco>` config (npm, pypi) with `registry-ca-bundle` and `registry-enforcement`, validated at load time (https-only, no userinfo, rejects loopback/RFC1918/link-local). The wrap proxy and `check` audit both resolve the developer's native credential (.npmrc `_authToken` / index-url userinfo) and route age queries through the configured upstream with the right TLS trust and Authorization header. Also fixes bugs found while wiring this up: a trailing-slash-configured upstream produced a double-slash path that 404s on real artifactories, PyPI custom upstreams needed the PEP 691 Simple API (the legacy PyPI JSON API isn't implemented by artifactories), and the wrap summary could report "N checked, all pass" even when TLS/auth failures meant no check actually ran — it now reports partial-verification failures honestly.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [x] All tests passing locally

### Manual Testing

Validated the custom-artifactory flow end-to-end against a real npm registry proxy during prototyping (auth injection + TLS trust confirmed working).

## Reviewer Notes

Four commits on top of the two already-merged PPSC-994 commits (config/URL/auth core, registry clients + CLI): this PR's own commits close gaps found afterward — double-slash join, `check` never getting TLS/auth, and the "all pass" reporting bug. Maven/Gradle stay on the public registry client for age checks (not routable in v1, called out in code comments).

[PPSC-994]: https://armis-security.atlassian.net/browse/PPSC-994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ