### PR TITLE
chore(ci): pin third-party GitHub Actions to commit SHAs (PPSC-1111)

### DIFF
--- a/.github/workflows/armis-cli-marketplace-sample.yml
+++ b/.github/workflows/armis-cli-marketplace-sample.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Run Armis CLI Action from Marketplace
         uses: ArmisSecurity/armis-cli@v1
         with:
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Run Armis CLI Action from Marketplace
         uses: ArmisSecurity/armis-cli@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.25"
           cache: true
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: matrix.race == true
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage
           path: |
@@ -78,13 +78,13 @@ jobs:
       pull-requests: write
     steps:
       - name: Download Linux coverage
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: coverage
           path: coverage
 
       - name: Post PR comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           retries: 3
           script: |

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -21,13 +21,13 @@ jobs:
       any_changed: ${{ steps.changed-files.outputs.any_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           separator: ','
           # Exclude test files from security scan - they contain intentional

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -20,28 +20,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.25"
           cache: true
 
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0.24.0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Run GoReleaser (Snapshot)
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser
           version: latest
           args: release --snapshot --clean --skip=sign
 
       - name: Upload snapshot artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: snapshot-artifacts
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.25"
           cache: true
@@ -59,7 +59,7 @@ jobs:
       hashes: ${{ steps.hash.outputs.hashes }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
@@ -67,19 +67,19 @@ jobs:
         run: git fetch --force --tags
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.25"
           cache: true
 
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0.24.0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser
           version: "~> v2.15"
@@ -114,7 +114,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: release-artifacts
@@ -131,6 +131,16 @@ jobs:
       actions: read
       id-token: write
       contents: write
+    # NB: the SLSA generator MUST be referenced by a full semantic version tag
+    # (@vX.Y.Z), NOT a commit SHA and not a short @vX tag — the build fails
+    # otherwise. Reason is a GitHub Actions platform limitation: when a reusable
+    # workflow is called by digest, GitHub does not expose the calling `ref`, so
+    # the generator can't determine which version of itself is running (needed to
+    # embed in the provenance it produces and for slsa-verifier to later verify
+    # the trusted builder). Tracked upstream as slsa-verifier issue #12; see the
+    # slsa-github-generator README "Referencing SLSA builders and generators".
+    # This is the one action ref intentionally left unpinned — CWE-1357 here is a
+    # justified, documented exception, not an oversight.
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
@@ -145,7 +155,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.25"
           cache: true
@@ -37,7 +37,7 @@ jobs:
         run: go vet ./...
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: v2.12.2
           args: --timeout=5m

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
@@ -119,7 +119,7 @@ jobs:
 
       - name: Post PR Comment with Results
         if: always() && inputs.pr-comment && github.event_name == 'pull_request'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require('fs');
@@ -313,7 +313,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Code Scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         continue-on-error: true
         with:
           sarif_file: armis-results.sarif
@@ -321,7 +321,7 @@ jobs:
 
       - name: Upload SARIF as Artifact
         if: always() && inputs.upload-artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: armis-security-results
           path: armis-results.sarif


### PR DESCRIPTION
## Summary

Pins every **third-party** GitHub Actions `uses:` ref across the workflow files to a 40-char commit SHA (with a trailing `# vX` version comment) instead of a mutable tag. Clears the **33 open CWE-1357 "high" alerts** on the [code-scanning page](https://github.com/ArmisSecurity/armis-cli/security/code-scanning) that come from our own Armis Security Scanner dogfooding this repo.

**Why it matters:** a version tag like `actions/checkout@v7` is mutable — whoever controls the action's repo can repoint the tag to malicious code, and PR-triggered workflows are internet-reachable. A SHA is immutable, so the supply-chain foothold closes. This isn't hypothetical: `tj-actions/changed-files` (one of the actions pinned here) was [compromised in March 2025](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) exactly this way — tags v1.0.0–v44.5.1 were retroactively repointed to secret-dumping code; SHA-pinned consumers were unaffected.

## Standard this follows

SHA-pinning is the documented recommendation of [GitHub's own hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions) ("the most secure option… the only way to use an action as an immutable release"), is enforced by the [OpenSSF Scorecard Pinned-Dependencies check](https://github.com/ossf/scorecard/blob/main/docs/checks.md), and GitHub now ships org/repo-level policy enforcement for it. It is a **graded, cost-aware** best practice (GitHub still permits tag-pinning for trusted creators; some advocates recommend tiering by trust) — for our 11 flat third-party refs with Dependabot already configured, blanket pinning is low-cost and clearly correct.

## What changed

Pinned across 7 workflow files (SHAs resolved via the GitHub API and independently re-verified against each tag through a second API path):

| Action | Pinned |
|---|---|
| `actions/checkout` | `9c091bb` # v7 |
| `actions/setup-go` | `924ae3a` # v6 |
| `actions/upload-artifact` | `043fb46` # v7 |
| `actions/download-artifact` | `3e5f45b` # v8 |
| `actions/github-script` | `3a2844b` # v9 |
| `tj-actions/changed-files` | `24d32ff` # v47 |
| `anchore/sbom-action` | `e22c389` # v0.24.0 |
| `goreleaser/goreleaser-action` | `f06c13b` # v7 |
| `sigstore/cosign-installer` | `6f9f177` # v4.1.2 |
| `github/codeql-action` | `54f647b` # v4 |
| `golangci/golangci-lint-action` | `ba0d7d2` # v9 |

## Intentionally left unpinned

- **First-party refs** (`ArmisSecurity/armis-cli@main` / `@v1`) and **local reusable workflows** (`./.github/...`) — not third-party supply-chain surface.
- **`slsa-framework/slsa-github-generator@v2.1.0`** — must be called by a full semver tag; the build fails when it's called by SHA. This is a GitHub Actions platform limitation (a reusable workflow called by digest doesn't get its calling `ref` exposed, so the generator can't identify which version of itself is running for provenance/verification) — tracked upstream as slsa-verifier issue #12. Documented inline; this one CWE-1357 alert is a justified dismissal.

## Known limitation (stated honestly)

Pinning a `uses:` line to a SHA makes only that action's **top-level repo** immutable. It does **not** pin the action's *own* internal dependencies — a composite action can still call other actions by mutable tag or pull `docker:latest`. [Palo Alto Unit42](https://unit42.paloaltonetworks.com/github-actions-worm-supply-chain/) found ~32% of top Marketplace actions are "unpinnable" this way. No mainstream tool (Dependabot, Scorecard, zizmor) recurses into a dependency's own `action.yml`, so this PR does not — and cannot automatically — close that gap. Closing it requires manual vetting per action and/or runtime egress monitoring (defense-in-depth); out of scope here.

## Dependabot

The repo's Dependabot config already tracks the `github-actions` ecosystem and understands SHA pins with `# vX` comments, so it keeps these bumped automatically — no config change needed. (Note: GitHub's Dependabot *vulnerability alerts* only fire for semver-referenced actions, not SHA-pinned ones — the `# vX` comment + version-update job is the mitigation, and it's in place.)

## Out of scope (not in this PR)

- `docs/ci-examples/*` samples (2 CWE-1357 + 1 CWE-78 `curl | bash`) — customer-facing *sample* workflows. Open question on PPSC-1111 whether to pin them too (customers copy them) or dismiss as documentation.
- ~6 code-level findings in `internal/` (CWE-522/253/770/822) — confirmed false positives already carrying `armis:ignore` suppressions; need repo-level alert dismissal, not code changes.

Ticket: PPSC-1111