### PR TITLE
[PPSC-1123] fix(supply-chain): raise yarn buffer cap; suppress FPs

### DIFF
--- a/internal/output/syntax.go
+++ b/internal/output/syntax.go
@@ -66,6 +66,7 @@ func HighlightCode(code, filename string) []string {
 
 	// Format all tokens
 	var buf bytes.Buffer
+	// armis:ignore cwe:822 reason:formatters.Get() never returns nil (falls back to the registered NoOp formatter on a registry miss); nil-check would be dead code
 	err = formatter.Format(&buf, style, iterator)
 	if err != nil {
 		return strings.Split(code, "\n")

--- a/internal/supplychain/check/yarn.go
+++ b/internal/supplychain/check/yarn.go
@@ -141,6 +141,13 @@ func parseYarnClassic(data []byte) ([]PackageEntry, error) {
 	// string first (strings.NewReader(string(data))) would copy up to the 64MB
 	// readLockfile cap into a second buffer for no benefit.
 	scanner := bufio.NewScanner(bytes.NewReader(data))
+	// A single yarn.lock line can carry a long resolved URL or integrity hash
+	// and exceed bufio.Scanner's default 64KB token limit, which would otherwise
+	// surface as scanner.Err() = "token too long" and turn a valid lockfile into
+	// a hard failure. Allow one line to grow up to the same maxLockfileSize cap
+	// readLockfile already enforces, matching pip.go/gradle.go.
+	// armis:ignore cwe:770 reason:data is already size-bounded by readLockfile's maxLockfileSize cap; this only raises the per-line token limit to that same bound, matching pip.go/gradle.go
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxLockfileSize)
 
 	var entries []PackageEntry
 	var currentName, currentVersion, currentResolved string

--- a/internal/supplychain/check/yarn_test.go
+++ b/internal/supplychain/check/yarn_test.go
@@ -1,8 +1,11 @@
 package check
 
 import (
+	"bufio"
+	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -69,6 +72,37 @@ func TestParseYarnClassicLockfile(t *testing.T) {
 		_, err := ParseYarnLockfile("testdata/nonexistent.lock")
 		if err == nil {
 			t.Fatal("expected error for nonexistent file")
+		}
+	})
+
+	t.Run("parses lines longer than the default scanner token", func(t *testing.T) {
+		// A resolved URL or integrity hash can exceed bufio.Scanner's default
+		// 64KB token limit. Build a line well past that to assert the raised
+		// buffer keeps such a lockfile parseable instead of failing "token too long".
+		var sb strings.Builder
+		sb.WriteString(`  resolved "https://registry.yarnpkg.com/big/-/big-1.0.0.tgz?`)
+		for i := 0; i < 2000; i++ {
+			sb.WriteString("0000000000000000000000000000000000000000000000000000000000000000")
+		}
+		sb.WriteString(`"`)
+		if sb.Len() <= bufio.MaxScanTokenSize {
+			t.Fatalf("test line is %d bytes, expected > %d to exercise the raised buffer", sb.Len(), bufio.MaxScanTokenSize)
+		}
+
+		lockfile := "big@^1.0.0:\n  version \"1.0.0\"\n" + sb.String() + "\n"
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "yarn.lock")
+		if err := os.WriteFile(path, []byte(lockfile), 0o600); err != nil {
+			t.Fatalf("writing fixture: %v", err)
+		}
+
+		entries, err := ParseYarnLockfile(path)
+		if err != nil {
+			t.Fatalf("unexpected error on long line: %v", err)
+		}
+		if len(entries) != 1 || entries[0].Name != "big" || entries[0].Version != "1.0.0" {
+			t.Errorf("expected [big@1.0.0], got %v", entries)
 		}
 	})
 }


### PR DESCRIPTION
## Related Issue

* [PPSC-1123](https://armis.atlassian.net/browse/PPSC-1123)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

`parseYarnClassic` used `bufio.Scanner`'s default 64KB token limit, so a `yarn.lock` line with a very long resolved URL or integrity hash would fail parsing with a `token too long` error on an otherwise valid lockfile. Separately, code-scanning flagged a CWE-822 (untrusted pointer dereference) false positive in `syntax.go` around `formatter.Format`.

## Solution

- `internal/supplychain/check/yarn.go`: raise the scanner's per-line buffer cap to `maxLockfileSize` (matching the existing pattern in `pip.go`/`gradle.go`), with an inline `armis:ignore cwe:770` documenting that the input is already size-bounded upstream by `readLockfile`.
- `internal/output/syntax.go`: add an `armis:ignore cwe:822` at the `formatter.Format` call, documenting that `formatters.Get()` never returns nil (falls back to the registered NoOp formatter), so the flagged nil-check would be dead code.

## Testing

### Automated Tests

* [x] All tests passing locally (3160 passed, 3 pre-existing/platform skips, 72.1% coverage)

### Manual Testing

Ran `make lint`, `make test`, `make build`, `gofmt -l .`, and `go mod tidy` — all clean. Verified via security scanner that both findings are suppressed with correct CWE tags at the correct sink lines.

## Reviewer Notes

Both changes are FP suppressions / minor robustness fixes tracked under the PPSC-1123 code-scanning triage effort — no behavior change for the common case.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed

[PPSC-1123]: https://armis-security.atlassian.net/browse/PPSC-1123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ