### PR TITLE
PPSC-1043: IT Admin SSO setup guide + streamlined auth setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,7 +1001,7 @@ When using client credentials, the tenant ID is automatically extracted from the
 
 You can also sign in explicitly at any time with `armis-cli auth login`; setting `ARMIS_DEFAULT_AUTH_METHOD=SSO` just triggers that sign-in automatically on the first command that needs credentials.
 
-Before users can sign in with SSO, an IT admin registers the tenant's identity provider once with `armis-cli auth setup` (see below).
+Before users can sign in with SSO, an IT admin registers the tenant's identity provider once with `armis-cli auth setup`. See the **[SSO Setup Guide](docs/SSO-SETUP.md)** for the full end-to-end walkthrough (IdP registration for Okta / Entra ID / Keycloak, group-to-role mapping, and MDM deployment).
 
 **Basic Authentication (Legacy):**
 
@@ -1019,41 +1019,6 @@ Before users can sign in with SSO, an IT admin registers the tenant's identity p
 | `ARMIS_THEME` | Terminal background theme: auto, dark, light (default: auto) |
 | `ARMIS_NO_UPDATE_CHECK` | Disable automatic update checking |
 
-### Registering an identity provider (IT admins)
-
-Before your users can sign in with SSO, register your tenant's identity provider once with `armis-cli auth setup`. Run it after you register `armis-cli` as an OIDC application in your IdP (Okta, Entra ID, Keycloak, …); it posts the resulting configuration to the Armis admin API. Authentication uses your existing Armis admin credentials (resolved the same way as the scan commands).
-
-```bash
-# Interactive — the CLI walks you through each value
-armis-cli auth setup
-
-# Non-interactive, from a JSON file (for MDM / CI)
-armis-cli auth setup --config idp.json --yes
-
-# Update an existing configuration (rotate the secret, change mappings)
-armis-cli auth setup --config idp.json --update
-```
-
-`--config` accepts a file path, `-` to read stdin, or an inline JSON string:
-
-```json
-{
-  "tenant_id": "acme",
-  "idp_type": "okta",
-  "issuer": "https://acme.okta.com",
-  "oidc_client_id": "0oa1b2c3d4",
-  "oidc_client_secret": "…",
-  "group_claim": "groups",
-  "group_mapping": {
-    "admin": ["eng-admins"],
-    "developer": ["core-developers", "contract-developers"]
-  }
-}
-```
-
-`group_mapping` maps each Armis role to the IdP groups that grant it, so several groups can share a role. Only the two recognized roles — `admin` and `developer` — are accepted, and a group may appear under only one role. In interactive mode the same is entered as a comma-separated list of groups per role. The command shows a review summary (with the client secret masked) and confirms before sending; the secret is transmitted only in the registration request and is never stored or printed.
-
-If a configuration already exists for your tenant, running `armis-cli auth setup` interactively lets you edit it: the form is pre-filled with the current values, and you can update just what you need — for example, change a group mapping without re-entering the client secret. To update from a JSON document non-interactively, use `--config … --update`.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Documentation: an SSO Setup Guide for IT admins (`docs/SSO-SETUP.md`) covering the end-to-end workflow — registering `armis-cli` as an OIDC app in IdP, and deploying to developer machines via MDM.
+
 ### Changed
+
+- `auth setup`: now auto-detects your tenant ID and region from your Armis credentials — the detected tenant seeds the interactive prompt, and the region routes the registration request to the correct regional host. On success the command prints the exact environment variables to deploy to developer machines.
 
 ### Deprecated
 

--- a/docs/SSO-SETUP.md
+++ b/docs/SSO-SETUP.md
@@ -1,0 +1,130 @@
+# SSO Setup Guide for IT Administrators
+
+Configure Single Sign-On so your developers authenticate the Armis developer
+tools (`armis-cli` and the Armis MCP plugins) with your organization's existing
+identity provider (IdP) — Okta, Microsoft Entra ID, Keycloak, or any other
+OIDC-compliant IdP.
+
+With SSO, there are **no per-user secrets to distribute**: developers sign in
+through your IdP in the browser, governed by your existing MFA and
+conditional-access policies, and access follows their IdP state.
+
+> Client credentials (`ARMIS_CLIENT_ID` / `ARMIS_CLIENT_SECRET`) remain
+> supported for CI/CD and service accounts. SSO is for interactive use on
+> developer machines.
+
+## Overview
+
+Three one-time steps by IT, then a one-time browser sign-in per developer:
+
+1. **Register `armis-cli` as an OIDC app in your IdP** (Step 1).
+2. **Register your IdP with Armis** and map IdP groups to Armis roles, using
+   `armis-cli auth setup` (Step 2).
+3. **Deploy `armis-cli` to developer machines via MDM** with two environment
+   variables and no secrets (Step 3).
+
+## Prerequisites
+
+- **`armis-cli` installed on your admin machine**, to run the setup command. See
+  the [`armis-cli` repository](https://github.com/ArmisSecurity/armis-cli).
+- **Armis API credentials.** In VIPR, open `<base_VIPR_URL>/settings/api-access`
+  and copy a `client_id` and `client_secret`.
+- **Admin access to your IdP**, to create an application and configure claims.
+
+You do **not** need to look up your `tenant_id` or region — `armis-cli auth
+setup` reads both from your API credentials and prints the environment variables
+to deploy in Step 3.
+
+> **Regions.** The one place you must know your region is the **redirect URI** in
+> Step 1. Armis currently has two regions: **default** (`https://moose.armis.com`)
+> and **EU** (`https://eu.moose.armis.com`). Use the host that matches your
+> deployment; if unsure, ask your Armis contact.
+
+## Step 1 — Register `armis-cli` in your IdP
+
+Create a **confidential OIDC / OAuth2 web application** in your IdP and configure:
+
+- **Redirect URI:** `<your-region-host>/oauth2/device/callback`
+  (e.g. `https://moose.armis.com/oauth2/device/callback`, or the `eu.` host for EU).
+- **Grant type:** Authorization Code.
+- **Scopes:** `openid`, `email`, `profile`, `groups`.
+- **Groups claim:** include the user's group memberships in the token under a
+  claim (commonly `groups`). Armis uses this to assign each user's role.
+
+Then collect these values for Step 2: **Issuer** (OIDC issuer URL), **Client ID**,
+**Client secret**, the **group claim name**, and the **IdP groups** that should
+become Armis admins and developers.
+
+Provider-specific notes (follow your IdP's own docs for the current UI):
+
+- **Okta** — Applications → Create App Integration → OIDC / Web Application. Issuer
+  is your org URL (`https://<org>.okta.com`). Add a `groups` claim to the ID token
+  and assign the relevant groups to the app.
+- **Microsoft Entra ID** — App registrations → New registration (platform: Web).
+  Issuer is `https://login.microsoftonline.com/<tenant-guid>/v2.0`. Add a groups
+  claim under Token configuration — Entra emits **group object IDs**, so use those
+  IDs as the group values in Step 2.
+- **Keycloak** — Clients → Create client (OpenID Connect), enable Client
+  authentication + Standard flow. Issuer is `https://<host>/realms/<realm>`. Add a
+  *Group Membership* mapper so groups appear under the `groups` claim.
+
+## Step 2 — Register your IdP with Armis
+
+From your admin machine, run:
+
+```bash
+armis-cli auth setup \
+  --client-id "$ARMIS_CLIENT_ID" \
+  --client-secret "$ARMIS_CLIENT_SECRET"
+```
+
+The command auto-detects your region and tenant from your credentials, 
+then walks you through the values from Step 1: IdP type,
+issuer, client ID, client secret, and group claim.
+
+For the role mapping, it asks which IdP groups become **admins** (full
+administrative access) and which become **developers** (day-to-day scanning). List
+several groups per role if needed; each group maps to exactly one role.
+
+It shows a review summary (client secret masked) for confirmation. The secret is
+sent only in this one request — never printed, stored locally, or returned by the
+API.
+
+On success it prints the environment variables to deploy in Step 3.
+
+## Step 3 — Deploy the tools to developer machines (MDM)
+
+Roll `armis-cli` out through your MDM (see the
+[repository](https://github.com/ArmisSecurity/armis-cli) for installers), then set
+the environment variables from Step 2's output via MDM policy:
+
+```bash
+export ARMIS_TENANT_ID="acme"
+export ARMIS_DEFAULT_AUTH_METHOD="SSO"
+# Non-default regions only
+export ARMIS_REGION="eu1"
+```
+
+The first Armis command a developer runs then opens the browser for sign-in
+(they can also run `armis-cli auth login`). The session is shared across
+`armis-cli` and the Armis MCP plugins, and tokens refresh silently.
+
+## Verifying and updating
+
+Re-running `armis-cli auth setup` fetches the existing configuration, shows the
+current values (secrets excluded) and lets you **edit it in place** — for example 
+to rotate the secret or change a group mapping. 
+This both verifies the registration and is how you update it later.
+
+For an end-to-end check, have a developer run `armis-cli auth login` and confirm
+sign-in completes with the expected role.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| ------- | --- |
+| Setup rejected as unauthorized | Wrong/expired API credentials. Re-copy them from `<base_VIPR_URL>/settings/api-access`. |
+| Developer sign-in fails with "access denied" | The user isn't in any mapped group. Add their IdP group under `admin` or `developer` (Step 2). |
+| Redirect / callback error during sign-in | The redirect URI in your IdP doesn't match your region host (Step 1). |
+
+

--- a/internal/cmd/auth_flow_test.go
+++ b/internal/cmd/auth_flow_test.go
@@ -355,5 +355,23 @@ func TestMain(m *testing.M) {
 	// Ensure no test accidentally spawns a real browser: stub the opener to a
 	// no-op (success) for the whole cmd test binary.
 	auth.SetBrowserOpener(func(string) error { return nil })
+
+	// Clear ambient Armis configuration so a developer's shell (e.g. an exported
+	// ARMIS_DEFAULT_AUTH_METHOD=SSO or ARMIS_API_TOKEN for local work) cannot
+	// change test outcomes. Tests that need these set them explicitly via
+	// t.Setenv. Without this, running the suite from a configured shell/IDE makes
+	// credential-resolution tests non-hermetic.
+	for _, k := range []string{
+		"ARMIS_DEFAULT_AUTH_METHOD",
+		"ARMIS_CLIENT_ID",
+		"ARMIS_CLIENT_SECRET",
+		"ARMIS_API_TOKEN",
+		"ARMIS_TENANT_ID",
+		"ARMIS_REGION",
+		"ARMIS_API_URL",
+	} {
+		_ = os.Unsetenv(k)
+	}
+
 	os.Exit(m.Run())
 }

--- a/internal/cmd/auth_setup.go
+++ b/internal/cmd/auth_setup.go
@@ -41,6 +41,10 @@ var (
 	setupConfigInput string // --config: file path, "-" for stdin, or inline JSON
 	setupUpdate      bool   // --update: force the PUT (update) path
 	setupYes         bool   // --yes: skip the review confirmation
+
+	// setupDetectedRegion is the region resolved from the admin's credentials (or
+	// an explicit --region), surfaced in the post-setup hint. Empty means default.
+	setupDetectedRegion string
 )
 
 var authSetupCmd = &cobra.Command{
@@ -96,16 +100,27 @@ func runAuthSetup(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	client, err := auth.NewIdpConfigClient(getAPIBaseURL(), provider, debug)
-	if err != nil {
-		return err
-	}
-
 	// Pass the command's context through; each network call applies its own
 	// per-request timeout (see withRequestTimeout). We must NOT wrap a single
 	// deadline around the whole flow — the interactive forms can take minutes and
 	// would otherwise consume the budget before the request is even sent.
 	ctx := cmd.Context()
+
+	// The tenant seeds the interactive prompt; the region feeds the post-setup
+	// hint. An explicit --region/ARMIS_REGION wins over the detected region.
+	detectedTenant, detectedRegion := detectIdentity(ctx, provider)
+	if region != "" {
+		detectedRegion = region
+	}
+	setupDetectedRegion = detectedRegion
+
+	// Route the admin API through the region-aware resolver (the same one the scan
+	// data plane uses) so a non-default region is auto-detected from the JWT and
+	// the admin need not pass --region. Explicit config still wins.
+	client, err := auth.NewIdpConfigClient(resolveDataPlaneURL(ctx, provider), provider, debug)
+	if err != nil {
+		return err
+	}
 
 	// The --config path is for scripting (MDM, CI): the caller supplies the whole
 	// configuration as one document, so we don't pre-flight or prompt.
@@ -115,7 +130,22 @@ func runAuthSetup(cmd *cobra.Command, _ []string) error {
 	if !cli.IsInteractive() {
 		return fmt.Errorf("no configuration provided: pass --config (a file, '-' for stdin, or inline JSON), or run in an interactive terminal")
 	}
-	return runInteractiveSetup(ctx, client)
+	return runInteractiveSetup(ctx, client, detectedTenant)
+}
+
+// detectIdentity resolves the tenant and region the active credentials imply.
+// Best-effort: a resolution failure is left for the first admin-API call to
+// surface, so it returns empty strings rather than erroring here.
+func detectIdentity(ctx context.Context, provider *auth.AuthProvider) (tenant, region string) {
+	reqCtx, cancel := withRequestTimeout(ctx)
+	defer cancel()
+
+	tenant, err := provider.GetTenantID(reqCtx)
+	if err != nil {
+		return "", ""
+	}
+	region, _ = provider.GetRegion(reqCtx)
+	return strings.TrimSpace(tenant), strings.TrimSpace(region)
 }
 
 // idpRequestTimeout bounds a single admin-API request. It is applied per call so
@@ -170,8 +200,14 @@ func runConfigFileSetup(ctx context.Context, client *auth.IdpConfigClient) error
 // with the current values and sends only the fields the admin edited — so an admin
 // can, say, tweak a group mapping without re-entering the client secret (which the
 // form leaves blank). Otherwise it collects a full configuration and creates it.
-func runInteractiveSetup(ctx context.Context, client *auth.IdpConfigClient) error {
-	tenant, err := promptSetupTenantID(strings.TrimSpace(tenantID))
+func runInteractiveSetup(ctx context.Context, client *auth.IdpConfigClient, detectedTenant string) error {
+	// Prefer an explicit --tenant-id/ARMIS_TENANT_ID; otherwise fall back to the
+	// tenant detected from the credentials so the admin isn't asked to retype it.
+	known := strings.TrimSpace(tenantID)
+	if known == "" {
+		known = strings.TrimSpace(detectedTenant)
+	}
+	tenant, err := promptSetupTenantID(known)
 	if err != nil {
 		return err
 	}
@@ -359,9 +395,24 @@ func detailOr(ce *auth.IdpConfigError, fallback string) string {
 	return fallback
 }
 
-// printPostSetupHint points the admin at the next step once a config exists.
+// printPostSetupHint points the admin at the next step once a config exists:
+// the environment variables to deploy to developer machines (via MDM). It prints
+// ARMIS_REGION only for a non-default region, matching the deployment guide.
 func printPostSetupHint(tenantID string) {
-	fmt.Fprintf(os.Stderr, "  Users can now sign in with: armis-cli auth login --tenant-id %s\n", tenantID)
+	fmt.Fprintln(os.Stderr, "  Deploy these environment variables to developer machines (e.g. via MDM):")
+	fmt.Fprintf(os.Stderr, "    ARMIS_TENANT_ID=%s\n", tenantID)
+	fmt.Fprintln(os.Stderr, "    ARMIS_DEFAULT_AUTH_METHOD=SSO")
+	if isNonDefaultRegion(setupDetectedRegion) {
+		fmt.Fprintf(os.Stderr, "    ARMIS_REGION=%s\n", setupDetectedRegion)
+	}
+	fmt.Fprintf(os.Stderr, "  Users can then sign in with: armis-cli auth login\n")
+}
+
+// isNonDefaultRegion reports whether a region code routes to a dedicated
+// (non-primary) data plane and therefore must be set on developer machines.
+// Codes that fall back to the primary host (us1, au1, "") need no ARMIS_REGION.
+func isNonDefaultRegion(region string) bool {
+	return region != "" && auth.RegionalBaseURL(region) != auth.ProductionBaseURL
 }
 
 // -- Interactive prompting ---------------------------------------------------

--- a/internal/cmd/auth_setup_test.go
+++ b/internal/cmd/auth_setup_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -340,4 +342,79 @@ func TestAuthSetupConfigFromFile(t *testing.T) {
 	if gotMethod != http.MethodPost {
 		t.Errorf("method = %q, want POST", gotMethod)
 	}
+}
+
+// detectIdentity should pull the tenant (customer_id) and region claim straight
+// from the client-credentials JWT, so `auth setup` can seed the tenant prompt
+// and the post-setup hint without the admin supplying either.
+func TestDetectIdentity(t *testing.T) {
+	region = ""
+	t.Setenv("ARMIS_API_URL", "")
+	p := newRegionAuthProvider(t, "eu1")
+
+	tenant, reg := detectIdentity(context.Background(), p)
+	if tenant != "customer-123" {
+		t.Errorf("tenant = %q, want customer-123", tenant)
+	}
+	if reg != "eu1" {
+		t.Errorf("region = %q, want eu1", reg)
+	}
+}
+
+func TestIsNonDefaultRegion(t *testing.T) {
+	cases := map[string]bool{
+		"":    false, // default host
+		"us1": false, // primary data plane
+		"au1": false, // no dedicated data plane yet — falls back to primary
+		"eu1": true,  // dedicated EU data plane
+	}
+	for region, want := range cases {
+		if got := isNonDefaultRegion(region); got != want {
+			t.Errorf("isNonDefaultRegion(%q) = %v, want %v", region, got, want)
+		}
+	}
+}
+
+// The post-setup hint tells the admin which env vars to deploy. ARMIS_REGION is
+// emitted only for a non-default region; the default region omits it.
+func TestPrintPostSetupHint(t *testing.T) {
+	capture := func(f func()) string {
+		old := os.Stderr
+		r, w, _ := os.Pipe()
+		os.Stderr = w
+		f()
+		_ = w.Close()
+		os.Stderr = old
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		return buf.String()
+	}
+
+	t.Run("default region omits ARMIS_REGION", func(t *testing.T) {
+		orig := setupDetectedRegion
+		t.Cleanup(func() { setupDetectedRegion = orig })
+		setupDetectedRegion = ""
+
+		out := capture(func() { printPostSetupHint("acme") })
+		if !strings.Contains(out, "ARMIS_TENANT_ID=acme") {
+			t.Errorf("missing tenant env var: %q", out)
+		}
+		if !strings.Contains(out, "ARMIS_DEFAULT_AUTH_METHOD=SSO") {
+			t.Errorf("missing auth-method env var: %q", out)
+		}
+		if strings.Contains(out, "ARMIS_REGION") {
+			t.Errorf("default region should not emit ARMIS_REGION: %q", out)
+		}
+	})
+
+	t.Run("non-default region emits ARMIS_REGION", func(t *testing.T) {
+		orig := setupDetectedRegion
+		t.Cleanup(func() { setupDetectedRegion = orig })
+		setupDetectedRegion = "eu1"
+
+		out := capture(func() { printPostSetupHint("acme") })
+		if !strings.Contains(out, "ARMIS_REGION=eu1") {
+			t.Errorf("missing ARMIS_REGION=eu1: %q", out)
+		}
+	})
 }


### PR DESCRIPTION
## Related Issue

* [PPSC-1043](https://armis-security.atlassian.net/browse/PPSC-1043)

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] Documentation update
* [ ] Refactoring (no functional changes)
* [ ] Performance improvement

## Problem

IT administrators had no clear path to enable SSO for the Armis developer tools (`armis-cli` and the Armis MCP plugins). Beyond the missing guide, `armis-cli auth setup` pushed avoidable work onto the admin:

- The admin had to look up and type their `tenant_id`, even though it is already carried in their API credentials.
- On the client-credentials path, `auth setup` always targeted the primary US host. A non-default-region admin (e.g. EU) had to pass `--region` explicitly, or the registration request would hit the wrong regional host — a silent trap, since the scan flow with the same credentials already auto-detects the region.

## Solution

**Guided `armis-cli auth setup` experience** (`internal/cmd/auth_setup.go`):

- Detects the tenant and region from the admin's credentials (`detectIdentity`). The detected tenant seeds the interactive prompt so it needn't be retyped.
- Routes the admin API through `resolveDataPlaneURL` — the same region-aware resolver the scan data plane uses — so a non-default region is auto-detected from the JWT and `--region` is no longer required. Explicit config (`ARMIS_API_URL` > `--dev` > `--region`/`ARMIS_REGION` > JWT region) still wins.
- On success, `printPostSetupHint` prints the exact environment variables to deploy in Step 3 (`ARMIS_TENANT_ID`, `ARMIS_DEFAULT_AUTH_METHOD=SSO`, and `ARMIS_REGION` only for a non-default region).

**Documentation** (`docs/SSO-SETUP.md`): a concise IT-admin guide covering the three one-time steps — register `armis-cli` as an OIDC app (Okta / Entra ID / Keycloak notes), register the IdP with Armis and map groups to roles, and deploy to developer machines via MDM.

**Test hermeticity fix** (`internal/cmd/auth_flow_test.go`): `TestMain` now clears ambient `ARMIS_*` env vars so a developer's shell/IDE (e.g. an exported `ARMIS_DEFAULT_AUTH_METHOD=SSO`) can't change credential-resolution test outcomes.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [ ] Integration tests added/updated
* [x] All tests passing locally

Added `TestDetectIdentity` (tenant + region pulled from the JWT), `TestIsNonDefaultRegion`, and `TestPrintPostSetupHint` (ARMIS_REGION emitted only for non-default regions). Region routing itself is covered by the existing `TestResolveDataPlaneURL`.

### Manual Testing

Verified `go build ./...`, `go test ./...`, and the setup tests under `-race`. Confirmed the previously IDE-only failure (`TestNoCredentialsErrorMentionsLogin`) now passes with `ARMIS_DEFAULT_AUTH_METHOD=SSO` and `ARMIS_API_TOKEN` exported in the environment.

## Reviewer Notes

- The region-routing change reuses the existing `resolveDataPlaneURL`; no new region logic. Only the `auth setup` client construction moved from `getAPIBaseURL()` to the region-aware resolver.
- The `TestMain` env-var clearing is safe: no test reads ambient `ARMIS_*` values — they all set what they need via `t.Setenv`.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] Documentation updated (if needed)
* [ ] Breaking changes documented (if applicable)
* [x] No new warnings generated

[PPSC-1043]: https://armis-security.atlassian.net/browse/PPSC-1043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ