### PR TITLE
feat: add scan sbom command for SBOM-to-VEX generation (PPSC-971)

### DIFF
--- a/internal/cmd/scan_sbom.go
+++ b/internal/cmd/scan_sbom.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/ArmisSecurity/armis-cli/internal/api"
+	"github.com/ArmisSecurity/armis-cli/internal/cli"
+	"github.com/ArmisSecurity/armis-cli/internal/cmd/cmdutil"
+	"github.com/ArmisSecurity/armis-cli/internal/output"
+	"github.com/ArmisSecurity/armis-cli/internal/scan/sbom"
+	"github.com/spf13/cobra"
+)
+
+var scanSBOMCmd = &cobra.Command{
+	Use:   "sbom [path]",
+	Short: "Generate a VEX document from a pre-existing SBOM",
+	Long: `Upload a pre-existing SBOM file and download the OpenVEX document the Armis
+backend generates from it.
+
+The <path> may be a single SBOM file (.json/.xml), a directory of SBOMs, or an
+already-built .tar/.tar.gz/.tgz. An SBOM scan produces no findings — the result
+is the generated VEX document (default: .armis/<artifact>-vex.json).`,
+	Example: `  $ armis-cli scan sbom sbom.json
+  $ armis-cli scan sbom ./sboms/
+  $ armis-cli scan sbom sbom.json --vex-output out/vex.json`,
+	// Path is optional and defaults to the current directory, matching scan repo.
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sbomPath := "."
+		if len(args) > 0 {
+			sbomPath = args[0]
+		}
+
+		// --sbom / --sbom-output are meaningless here: you can't generate an SBOM
+		// from an SBOM. Warn (consistent with scan.PersistentPreRunE's style) and
+		// ignore. --vex is always implied by this command.
+		if generateSBOM {
+			cli.PrintWarning("--sbom is ignored for `scan sbom` (the SBOM is the input, not the output)")
+		}
+		if sbomOutput != "" {
+			cli.PrintWarning("--sbom-output is ignored for `scan sbom`")
+		}
+
+		// Validate path exists before making network calls. A directory, a
+		// single SBOM file, and a pre-built tarball are all valid inputs, so we
+		// only check existence here (the scanner classifies the path).
+		// armis:ignore cwe:22 reason:os.Stat is read-only existence check; path is from direct CLI arg, sanitized again in scanner
+		if _, err := os.Stat(sbomPath); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("path does not exist: %s", sbomPath)
+			}
+			return fmt.Errorf("cannot access path %s: %w", sbomPath, err)
+		}
+
+		authProvider, err := getAuthProvider(cmd.Context())
+		if err != nil {
+			return err
+		}
+		if authProvider == nil {
+			return fmt.Errorf("internal error: nil auth provider")
+		}
+
+		tid, err := authProvider.GetTenantID(cmd.Context())
+		if err != nil {
+			return err
+		}
+
+		failOnSeverities, err := cmdutil.GetFailOn(failOn)
+		if err != nil {
+			return err
+		}
+
+		baseURL := resolveDataPlaneURL(cmd.Context(), authProvider)
+		client, err := api.NewClient(baseURL, authProvider, debug, time.Duration(uploadTimeout)*time.Minute,
+			clientOptionsForBaseURL(baseURL)...)
+		if err != nil {
+			return fmt.Errorf("failed to create API client: %w", err)
+		}
+
+		scanTimeoutDuration := time.Duration(scanTimeout) * time.Minute
+		scanner := sbom.NewScanner(client, noProgress, tid, scanTimeoutDuration).
+			WithVEXOutput(vexOutput)
+
+		ctx, cancel := NewSignalContext()
+		defer cancel()
+
+		// armis:ignore cwe:22 reason:sbomPath is from direct CLI argument; sanitized via util.SanitizePath in scanner.Scan
+		result, err := scanner.Scan(ctx, sbomPath)
+		if err != nil {
+			return handleScanError(ctx, err)
+		}
+
+		// Resolve output destination and format (handles file creation, format auto-detection, colors)
+		outputCfg, err := cmdutil.ResolveOutput(cmd, outputFile, format, colorFlag)
+		if err != nil {
+			return err
+		}
+		defer outputCfg.Cleanup()
+
+		formatter, err := output.GetFormatter(outputCfg.Format)
+		if err != nil {
+			return err
+		}
+
+		opts := output.FormatOptions{
+			GroupBy:          groupBy,
+			Debug:            debug,
+			SummaryTop:       summaryTop,
+			FailOnSeverities: failOnSeverities,
+		}
+
+		if err := formatter.FormatWithOptions(result, outputCfg.Writer, opts); err != nil {
+			return fmt.Errorf("failed to format output: %w", err)
+		}
+
+		// An SBOM scan produces no findings, so CheckExit never trips --fail-on;
+		// call it anyway for symmetry with the other scan subcommands.
+		return output.CheckExit(result, failOnSeverities, exitCode)
+	},
+}
+
+func init() {
+	scanCmd.AddCommand(scanSBOMCmd)
+}

--- a/internal/cmd/scan_sbom_test.go
+++ b/internal/cmd/scan_sbom_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ArmisSecurity/armis-cli/internal/testutil"
+)
+
+// TestScanSBOMRunE_SuccessfulScan drives `scan sbom <file>` end to end against
+// the mock API, verifying the command uploads the SBOM and writes the VEX
+// document without erroring on the empty findings set.
+func TestScanSBOMRunE_SuccessfulScan(t *testing.T) {
+	const vex = `{"@context":"https://openvex.dev/ns/v0.2.0","statements":[{"vulnerability":{"name":"GHSA-1"}}]}`
+	serverURL := testutil.GetMockServerURLWithConfig(t, testutil.MockAPIConfig{
+		ScanID:     "sbom-scan-cmd",
+		VEXContent: vex,
+	})
+
+	tmpDir := t.TempDir()
+	sbomPath := filepath.Join(tmpDir, "sbom.json")
+	if err := os.WriteFile(sbomPath, []byte(`{"bomFormat":"CycloneDX"}`), 0600); err != nil {
+		t.Fatalf("write sbom: %v", err)
+	}
+	vexOut := filepath.Join(tmpDir, "result-vex.json")
+
+	originalToken := token
+	originalTenantID := tenantID
+	originalClientID := clientID
+	originalClientSecret := clientSecret
+	originalFormat := format
+	originalColorFlag := colorFlag
+	originalThemeFlag := themeFlag
+	originalNoUpdateCheck := noUpdateCheck
+	originalNoProgress := noProgress
+	originalVEXOutput := vexOutput
+
+	t.Cleanup(func() {
+		token = originalToken
+		tenantID = originalTenantID
+		clientID = originalClientID
+		clientSecret = originalClientSecret
+		format = originalFormat
+		colorFlag = originalColorFlag
+		themeFlag = originalThemeFlag
+		noUpdateCheck = originalNoUpdateCheck
+		noProgress = originalNoProgress
+		vexOutput = originalVEXOutput
+		_ = os.Unsetenv("ARMIS_API_URL")
+	})
+
+	_ = os.Setenv("ARMIS_API_URL", serverURL)
+	t.Setenv("ARMIS_CLIENT_ID", "")
+	t.Setenv("ARMIS_CLIENT_SECRET", "")
+	token = testToken
+	tenantID = testTenantID
+	clientID = ""
+	clientSecret = ""
+	format = agentFormatJSON
+	colorFlag = testColorNever
+	themeFlag = themeAuto
+	noUpdateCheck = true
+	noProgress = true
+	vexOutput = vexOut
+
+	if err := scanSBOMCmd.RunE(scanSBOMCmd, []string{sbomPath}); err != nil {
+		t.Fatalf("expected successful sbom scan, got error: %v", err)
+	}
+
+	if _, err := os.Stat(vexOut); err != nil {
+		t.Errorf("expected VEX written to %s: %v", vexOut, err)
+	}
+}
+
+func TestScanSBOMCmd_Registered(t *testing.T) {
+	if scanSBOMCmd == nil {
+		t.Fatal("scanSBOMCmd should not be nil")
+	}
+	found := false
+	for _, c := range scanCmd.Commands() {
+		if c.Name() == "sbom" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("scan sbom subcommand not registered under scan")
+	}
+}
+
+func TestScanSBOMRunE_InvalidPath(t *testing.T) {
+	originalToken := token
+	originalTenantID := tenantID
+	originalClientID := clientID
+	originalClientSecret := clientSecret
+	originalColorFlag := colorFlag
+	originalThemeFlag := themeFlag
+	originalNoUpdateCheck := noUpdateCheck
+
+	t.Cleanup(func() {
+		token = originalToken
+		tenantID = originalTenantID
+		clientID = originalClientID
+		clientSecret = originalClientSecret
+		colorFlag = originalColorFlag
+		themeFlag = originalThemeFlag
+		noUpdateCheck = originalNoUpdateCheck
+		_ = os.Unsetenv("ARMIS_API_URL")
+	})
+
+	_ = os.Setenv("ARMIS_API_URL", "http://localhost:8080")
+	t.Setenv("ARMIS_CLIENT_ID", "")
+	t.Setenv("ARMIS_CLIENT_SECRET", "")
+	token = testToken
+	tenantID = testTenantID
+	clientID = ""
+	clientSecret = ""
+	colorFlag = testColorNever
+	themeFlag = themeAuto
+	noUpdateCheck = true
+
+	if err := scanSBOMCmd.RunE(scanSBOMCmd, []string{"/nonexistent/sbom.json"}); err == nil {
+		t.Error("expected error for non-existent path")
+	}
+}

--- a/internal/scan/sbom/sbom.go
+++ b/internal/scan/sbom/sbom.go
@@ -1,0 +1,361 @@
+// Package sbom provides SBOM-to-VEX scanning functionality: it uploads a
+// pre-existing SBOM artifact and downloads the OpenVEX document the backend
+// generates from it (artifact_type=sbom, vex_generate=true).
+package sbom
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ArmisSecurity/armis-cli/internal/api"
+	"github.com/ArmisSecurity/armis-cli/internal/cli"
+	"github.com/ArmisSecurity/armis-cli/internal/model"
+	"github.com/ArmisSecurity/armis-cli/internal/output"
+	"github.com/ArmisSecurity/armis-cli/internal/progress"
+	"github.com/ArmisSecurity/armis-cli/internal/scan"
+	"github.com/ArmisSecurity/armis-cli/internal/util"
+)
+
+// MaxSBOMSize is the maximum allowed size for the SBOM upload body. SBOMs are
+// small relative to repos/images, but we keep a generous cap so multi-project
+// bundles still fit.
+const MaxSBOMSize = 512 * 1024 * 1024
+
+// Scanner uploads an SBOM artifact and retrieves the generated OpenVEX document.
+type Scanner struct {
+	client       *api.Client
+	noProgress   bool
+	tenantID     string
+	timeout      time.Duration
+	pollInterval time.Duration
+	vexOutput    string // Output path for VEX file (empty = default .armis/<artifact>-vex.json)
+}
+
+// NewScanner creates a new SBOM scanner.
+func NewScanner(client *api.Client, noProgress bool, tenantID string, timeout time.Duration) *Scanner {
+	return &Scanner{
+		client:       client,
+		noProgress:   noProgress,
+		tenantID:     tenantID,
+		timeout:      timeout,
+		pollInterval: 5 * time.Second,
+	}
+}
+
+// WithPollInterval sets a custom poll interval (used for testing).
+func (s *Scanner) WithPollInterval(d time.Duration) *Scanner {
+	s.pollInterval = d
+	return s
+}
+
+// WithVEXOutput sets a custom output path for the VEX document.
+func (s *Scanner) WithVEXOutput(path string) *Scanner {
+	s.vexOutput = path
+	return s
+}
+
+// Scan uploads the SBOM artifact at path and downloads the generated VEX
+// document. path may be a single SBOM file (.json/.xml), a directory of SBOMs,
+// or an already-built .tar/.tar.gz/.tgz. Returns a ScanResult (with no
+// findings — an SBOM scan produces a VEX document, not findings).
+func (s *Scanner) Scan(ctx context.Context, path string) (*model.ScanResult, error) {
+	// armis:ignore cwe:22 reason:SanitizePath IS the path traversal prevention; rejects invalid paths before use
+	sanitizedPath, err := util.SanitizePath(path)
+	if err != nil {
+		return nil, fmt.Errorf("invalid SBOM path: %w", err)
+	}
+	path = sanitizedPath
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	// armis:ignore cwe:22 reason:absPath resolved from sanitized CLI arg; read-only stat
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat path: %w", err)
+	}
+
+	spinner := progress.NewSpinnerWithContext(ctx, "Preparing SBOM for upload...", s.noProgress)
+	spinner.Start()
+	defer spinner.Stop()
+
+	// Determine the upload body. A pre-built tarball is uploaded as-is; a file
+	// or directory is packed into a tar.gz the backend walks for SBOMs.
+	var uploadFile *os.File
+	var uploadSize int64
+	var filename string
+	var cleanup func()
+
+	if !info.IsDir() && scan.HasAllowedTarExtension(filepath.Base(absPath)) {
+		// Pre-built tarball: validate format and upload directly.
+		if err := scan.ValidateTarballFormat(absPath); err != nil {
+			return nil, fmt.Errorf("invalid tarball: %w", err)
+		}
+		if info.Size() > MaxSBOMSize {
+			return nil, fmt.Errorf("SBOM tarball size (%d bytes) exceeds maximum allowed size (%d bytes)", info.Size(), MaxSBOMSize)
+		}
+		// armis:ignore cwe:22 reason:absPath sanitized by util.SanitizePath above; opened read-only for upload
+		f, openErr := os.Open(absPath) //nolint:gosec // G304: path sanitized above
+		if openErr != nil {
+			return nil, fmt.Errorf("failed to open tarball: %w", openErr)
+		}
+		uploadFile = f
+		uploadSize = info.Size()
+		filename = filepath.Base(absPath)
+		cleanup = func() { _ = f.Close() }
+	} else {
+		// File or directory: pack into a temp tar.gz, then upload from disk so
+		// the HTTP client can set Content-Length (real S3 requires it on POST).
+		tmpFile, tmpErr := os.CreateTemp("", "armis-sbom-*.tar.gz")
+		if tmpErr != nil {
+			return nil, fmt.Errorf("failed to create temp tarball: %w", tmpErr)
+		}
+		tmpPath := tmpFile.Name()
+		cleanup = func() {
+			_ = tmpFile.Close()
+			_ = os.Remove(tmpPath)
+		}
+
+		select {
+		case <-ctx.Done():
+			cleanup()
+			return nil, ctx.Err()
+		default:
+		}
+
+		if tarErr := tarGzPath(absPath, info, tmpFile); tarErr != nil {
+			cleanup()
+			return nil, fmt.Errorf("failed to package SBOM: %w", tarErr)
+		}
+		if err := tmpFile.Sync(); err != nil {
+			cleanup()
+			return nil, fmt.Errorf("failed to flush tarball: %w", err)
+		}
+		tarInfo, statErr := tmpFile.Stat()
+		if statErr != nil {
+			cleanup()
+			return nil, fmt.Errorf("failed to stat tarball: %w", statErr)
+		}
+		if tarInfo.Size() > MaxSBOMSize {
+			cleanup()
+			return nil, fmt.Errorf("SBOM archive size (%d bytes) exceeds maximum allowed size (%d bytes)", tarInfo.Size(), MaxSBOMSize)
+		}
+		if _, err := tmpFile.Seek(0, io.SeekStart); err != nil {
+			cleanup()
+			return nil, fmt.Errorf("failed to rewind tarball: %w", err)
+		}
+		uploadFile = tmpFile
+		uploadSize = tarInfo.Size()
+		filename = artifactName(absPath) + ".tar.gz"
+	}
+	defer cleanup()
+
+	spinner.Update("Uploading to Armis Cloud...")
+
+	ingestOpts := api.IngestOptions{
+		TenantID:     s.tenantID,
+		ArtifactType: "sbom",
+		Filename:     filename,
+		Data:         uploadFile,
+		Size:         uploadSize,
+		GenerateVEX:  true, // --vex is implied for `scan sbom`
+	}
+
+	scanID, err := s.client.StartIngest(ctx, ingestOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to upload SBOM: %w", err)
+	}
+
+	spinner.Stop()
+	styles := output.GetStyles()
+	fmt.Fprintf(os.Stderr, "%s %s\n\n",
+		styles.MutedText.Render("Scan initiated with ID:"),
+		styles.ScanID.Render(scanID))
+
+	analysisSpinner := progress.NewSpinnerWithContext(ctx, "Generating VEX from SBOM...", s.noProgress)
+	analysisSpinner.Start()
+	defer analysisSpinner.Stop()
+
+	_, err = s.client.WaitForIngest(ctx, s.tenantID, scanID, s.pollInterval, s.timeout,
+		func(status model.IngestStatusData) {
+			analysisSpinner.Update(scan.FormatScanStatus(status.ScanStatus, "Generating VEX from SBOM..."))
+		})
+	elapsed := analysisSpinner.GetElapsed()
+	analysisSpinner.Stop()
+	if err != nil {
+		return nil, fmt.Errorf("failed to wait for scan: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "%s %s\n\n",
+		styles.MutedText.Render("Scan completed in"),
+		styles.Duration.Render(scan.FormatElapsed(elapsed)))
+
+	// Download the generated VEX document. An SBOM scan produces no normalized
+	// findings, so we go straight to the VEX artifact.
+	art := artifactName(absPath)
+	vexPath := s.resolveVEXPath(art)
+
+	opts := &scan.SBOMVEXOptions{GenerateVEX: true, VEXOutput: s.vexOutput}
+	downloader := scan.NewSBOMVEXDownloader(s.client, s.tenantID, opts)
+	if err := downloader.Download(ctx, scanID, art); err != nil {
+		return nil, fmt.Errorf("failed to download VEX: %w", err)
+	}
+
+	// Best-effort statement count for a friendlier summary line. A read failure
+	// here is non-fatal: the file is already on disk and the downloader printed
+	// its own "VEX saved to" line.
+	if n, ok := countVEXStatements(vexPath); ok {
+		fmt.Fprintf(os.Stderr, "%s %s\n",
+			styles.SuccessText.Render("VEX generated →"),
+			styles.Bold.Render(fmt.Sprintf("%s (%d statement%s)", vexPath, n, plural(n))))
+	} else {
+		fmt.Fprintf(os.Stderr, "%s %s\n",
+			styles.SuccessText.Render("VEX generated →"),
+			styles.Bold.Render(vexPath))
+	}
+
+	// An SBOM scan yields no findings; return an empty completed result so
+	// --fail-on / summary / findings-table logic degrades gracefully.
+	return &model.ScanResult{
+		ScanID:   scanID,
+		Status:   "completed",
+		Findings: nil,
+		Summary: model.Summary{
+			BySeverity: make(map[model.Severity]int),
+			ByType:     make(map[model.FindingType]int),
+			ByCategory: make(map[string]int),
+		},
+	}, nil
+}
+
+// resolveVEXPath mirrors the SBOMVEXDownloader's default-path logic so the
+// summary line points at the same file the downloader wrote.
+func (s *Scanner) resolveVEXPath(art string) string {
+	if s.vexOutput != "" {
+		return s.vexOutput
+	}
+	return filepath.Join(".armis", filepath.Base(art)+"-vex.json")
+}
+
+// artifactName derives a friendly artifact name from a path, stripping tar and
+// SBOM extensions so "sbom.json" / "image.tar.gz" both yield a clean stem.
+func artifactName(path string) string {
+	base := filepath.Base(path)
+	for _, ext := range []string{".tar.gz", ".tgz", ".tar"} {
+		if strings.HasSuffix(strings.ToLower(base), ext) {
+			return base[:len(base)-len(ext)]
+		}
+	}
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// openVEXDoc is the minimal shape we parse to count statements. We only read
+// the statements array; the full document is written to disk verbatim.
+type openVEXDoc struct {
+	Statements []json.RawMessage `json:"statements"`
+}
+
+// countVEXStatements reads the VEX file and returns the number of statements.
+// ok is false if the file cannot be read or parsed.
+func countVEXStatements(path string) (int, bool) {
+	// armis:ignore cwe:22 reason:path is the CLI-controlled VEX output path (flag or .armis default), already sanitized by SanitizePath in downloadAndSave
+	data, err := os.ReadFile(path) //nolint:gosec // G304: path is the sanitized VEX output path
+	if err != nil {
+		return 0, false
+	}
+	var doc openVEXDoc
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return 0, false
+	}
+	return len(doc.Statements), true
+}
+
+// tarGzPath packs a single file or a directory tree at absPath into a gzip'd
+// tar written to w. Symlinks are skipped for safety (mirrors the repo scanner).
+func tarGzPath(absPath string, info os.FileInfo, w io.Writer) (err error) {
+	gzWriter := gzip.NewWriter(w)
+	defer func() {
+		if closeErr := gzWriter.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	tarWriter := tar.NewWriter(gzWriter)
+	defer func() {
+		if closeErr := tarWriter.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	if !info.IsDir() {
+		return writeTarFile(tarWriter, absPath, info, filepath.Base(absPath))
+	}
+
+	return filepath.Walk(absPath, func(path string, fi os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relPath, relErr := filepath.Rel(absPath, path)
+		if relErr != nil {
+			return relErr
+		}
+		if relPath == "." {
+			return nil
+		}
+		// Skip symlinks to avoid escaping the input directory.
+		if fi.Mode()&os.ModeSymlink != 0 {
+			cli.PrintWarningf("skipping symlink %s", relPath)
+			if fi.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if fi.IsDir() {
+			header, hErr := tar.FileInfoHeader(fi, "")
+			if hErr != nil {
+				return hErr
+			}
+			header.Name = filepath.ToSlash(relPath)
+			return tarWriter.WriteHeader(header)
+		}
+		return writeTarFile(tarWriter, path, fi, filepath.ToSlash(relPath))
+	})
+}
+
+// writeTarFile writes a single regular file into the tar writer under tarName.
+func writeTarFile(tarWriter *tar.Writer, path string, info os.FileInfo, tarName string) error {
+	header, err := tar.FileInfoHeader(info, "")
+	if err != nil {
+		return err
+	}
+	header.Name = tarName
+	if err := tarWriter.WriteHeader(header); err != nil {
+		return err
+	}
+	// armis:ignore cwe:22 reason:path is yielded by filepath.Walk within the sanitized input dir, or the single sanitized file; symlinks skipped above
+	file, err := os.Open(path) //nolint:gosec // G304: path within sanitized input; symlinks skipped
+	if err != nil {
+		return err
+	}
+	// armis:ignore cwe:253 reason:Close error on read-only file is non-actionable; io.Copy catches read failures
+	defer file.Close() //nolint:errcheck
+	_, err = io.Copy(tarWriter, file)
+	return err
+}

--- a/internal/scan/sbom/sbom_test.go
+++ b/internal/scan/sbom/sbom_test.go
@@ -1,0 +1,155 @@
+package sbom
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ArmisSecurity/armis-cli/internal/api"
+	"github.com/ArmisSecurity/armis-cli/internal/httpclient"
+	"github.com/ArmisSecurity/armis-cli/internal/testutil"
+)
+
+const testVEX = `{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/vex-abc",
+  "author": "Armis AppSec",
+  "version": 1,
+  "statements": [
+    {"vulnerability": {"name": "GHSA-1"}, "products": [{"@id": "pkg:pypi/requests@2.19.0"}], "status": "affected"},
+    {"vulnerability": {"name": "GHSA-2"}, "products": [{"@id": "pkg:pypi/flask@1.0"}], "status": "affected"}
+  ]
+}`
+
+// newSBOMClient wires an API client at the mock server with local URLs allowed
+// (the mock serves both the API and the fake presigned VEX download).
+func newSBOMClient(t *testing.T, serverURL string) *api.Client {
+	t.Helper()
+	httpClient := httpclient.NewClient(httpclient.Config{Timeout: 5 * time.Second})
+	uploadClient := httpclient.NewClient(httpclient.Config{Timeout: 5 * time.Second, DisableRetry: true})
+	client, err := api.NewClient(serverURL, testutil.NewTestAuthProvider("token123"), false, time.Minute,
+		api.WithHTTPClient(httpClient), api.WithUploadHTTPClient(uploadClient), api.WithAllowLocalURLs(true))
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+	return client
+}
+
+func TestScan_SingleSBOMFile(t *testing.T) {
+	serverURL := testutil.GetMockServerURLWithConfig(t, testutil.MockAPIConfig{
+		ScanID:     "sbom-scan-1",
+		VEXContent: testVEX,
+	})
+
+	tmpDir := t.TempDir()
+	sbomPath := filepath.Join(tmpDir, "sbom.json")
+	if err := os.WriteFile(sbomPath, []byte(`{"bomFormat":"CycloneDX"}`), 0600); err != nil {
+		t.Fatalf("write sbom: %v", err)
+	}
+	vexOut := filepath.Join(tmpDir, "out-vex.json")
+
+	scanner := NewScanner(newSBOMClient(t, serverURL), true, "test-tenant", time.Minute).
+		WithPollInterval(10 * time.Millisecond).
+		WithVEXOutput(vexOut)
+
+	result, err := scanner.Scan(context.Background(), sbomPath)
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+
+	if result.ScanID != "sbom-scan-1" {
+		t.Errorf("ScanID = %q, want sbom-scan-1", result.ScanID)
+	}
+	if len(result.Findings) != 0 {
+		t.Errorf("Findings = %d, want 0 (sbom scan produces no findings)", len(result.Findings))
+	}
+
+	data, err := os.ReadFile(vexOut) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("VEX not written to %s: %v", vexOut, err)
+	}
+	if string(data) != testVEX {
+		t.Errorf("VEX content mismatch:\n got %s\nwant %s", data, testVEX)
+	}
+}
+
+func TestScan_Directory(t *testing.T) {
+	serverURL := testutil.GetMockServerURLWithConfig(t, testutil.MockAPIConfig{
+		ScanID:     "sbom-scan-dir",
+		VEXContent: testVEX,
+	})
+
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "a.json"), []byte(`{"bomFormat":"CycloneDX"}`), 0600); err != nil {
+		t.Fatalf("write a.json: %v", err)
+	}
+	sub := filepath.Join(srcDir, "nested")
+	if err := os.MkdirAll(sub, 0750); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "b.xml"), []byte(`<bom/>`), 0600); err != nil {
+		t.Fatalf("write b.xml: %v", err)
+	}
+
+	vexOut := filepath.Join(t.TempDir(), "vex.json")
+	scanner := NewScanner(newSBOMClient(t, serverURL), true, "test-tenant", time.Minute).
+		WithPollInterval(10 * time.Millisecond).
+		WithVEXOutput(vexOut)
+
+	result, err := scanner.Scan(context.Background(), srcDir)
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	if len(result.Findings) != 0 {
+		t.Errorf("Findings = %d, want 0", len(result.Findings))
+	}
+	if _, err := os.Stat(vexOut); err != nil {
+		t.Errorf("VEX not written: %v", err)
+	}
+}
+
+func TestScan_NonExistentPath(t *testing.T) {
+	client := newSBOMClient(t, "https://localhost")
+	scanner := NewScanner(client, true, "test-tenant", time.Minute).WithPollInterval(10 * time.Millisecond)
+
+	_, err := scanner.Scan(context.Background(), "/no/such/sbom.json")
+	if err == nil {
+		t.Fatal("expected error for non-existent path")
+	}
+}
+
+func TestArtifactName(t *testing.T) {
+	cases := map[string]string{
+		"sbom.json":           "sbom",
+		"/tmp/project.tar.gz": "project",
+		"bundle.tgz":          "bundle",
+		"image.tar":           "image",
+		"/a/b/sboms":          "sboms",
+		"cyclonedx.bom.xml":   "cyclonedx.bom",
+	}
+	for in, want := range cases {
+		if got := artifactName(in); got != want {
+			t.Errorf("artifactName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCountVEXStatements(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "vex.json")
+	if err := os.WriteFile(tmp, []byte(testVEX), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	n, ok := countVEXStatements(tmp)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if n != 2 {
+		t.Errorf("statements = %d, want 2", n)
+	}
+
+	if _, ok := countVEXStatements(filepath.Join(t.TempDir(), "missing.json")); ok {
+		t.Error("expected ok=false for missing file")
+	}
+}

--- a/internal/testutil/mockapi.go
+++ b/internal/testutil/mockapi.go
@@ -25,6 +25,9 @@ type MockAPIConfig struct {
 	FinalStatus string
 	// LastError is set when FinalStatus is "FAILED"
 	LastError string
+	// VEXContent, when non-empty, makes GET /api/v1/ingest/results return a
+	// vex_results presigned URL that serves this content (used by `scan sbom`).
+	VEXContent string
 }
 
 // NewMockScanServer creates a mock Armis API server for integration testing.
@@ -163,6 +166,29 @@ func createMockHandler(t *testing.T, config MockAPIConfig) http.HandlerFunc {
 					},
 				},
 			})
+			return
+		}
+
+		// GET /api/v1/ingest/results - artifact results (SBOM/VEX presigned URLs).
+		// Returns a vex_results URL pointing back at this same server's /_vex path
+		// when VEXContent is configured (used by `scan sbom`).
+		if strings.Contains(r.URL.Path, "/api/v1/ingest/results") && r.Method == http.MethodGet {
+			AssertHasAuthorization(t, r)
+			results := map[string]string{}
+			if config.VEXContent != "" {
+				results["vex_results"] = SchemeFromRequest(r) + "://" + r.Host + "/_vex/" + config.ScanID
+			}
+			JSONResponse(t, w, http.StatusOK, map[string]interface{}{
+				"scan_status": "COMPLETED",
+				"results":     results,
+			})
+			return
+		}
+
+		// Fake presigned-URL download endpoint for the VEX document.
+		if strings.HasPrefix(r.URL.Path, "/_vex/") && r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(config.VEXContent))
 			return
 		}
 


### PR DESCRIPTION
## Summary

Adds `armis-cli scan sbom <path>` — uploads a pre-existing SBOM artifact (`artifact_type=sbom`, `vex_generate=true`) and downloads the OpenVEX v0.2.0 document the backend generates from it.

Backend side: Moose branch `feat/PPSC-971-generate-vex-api` (PR #2402) adds the `sbom` artifact type and the `GrypeVexGenerator`. No API request-shape changes — only a new `artifact_type` enum value.

## What's included

- **`internal/scan/sbom/sbom.go`** — scan driver mirroring the repo scanner. `<path>` may be a single SBOM file (`.json`/`.xml`), a directory of SBOMs, or a pre-built `.tar`/`.tar.gz`/`.tgz`. File/dir inputs are packed into a `tar.gz` (symlinks skipped) and uploaded from disk so `Content-Length` is set for S3. Runs `StartIngest → WaitForIngest → SBOMVEXDownloader.Download`, then prints `VEX generated → <path> (N statements)`.
- **`internal/cmd/scan_sbom.go`** — cobra command registered under `scan`. `--vex` is implied (always `GenerateVEX: true`); warns on `--sbom`/`--sbom-output` (can't generate an SBOM from an SBOM), matching `scan.go`'s warning style. Honors `--vex-output` (default `.armis/<artifact>-vex.json`).
- **No-findings UX** — an SBOM scan produces no findings, so the driver returns an empty completed `ScanResult`; `--fail-on`/summary/findings-table all degrade gracefully and the success line points at the written VEX file.
- **`internal/testutil/mockapi.go`** — mock `/api/v1/ingest/results` + fake presigned VEX download endpoint, gated on a new `VEXContent` config field.

## Testing

- `go build ./...`, `go vet ./...` clean
- `go test ./...` passes, including new tests: single file, directory, non-existent path, artifact-name derivation, VEX statement counting, and end-to-end command flow.
- `make lint` (golangci-lint) not run locally — not installed on this machine; relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)