### PR TITLE
[PPSC-1141] fix(ci): pin PR scan logo URL to main

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -204,10 +204,12 @@ jobs:
                            counts.HIGH > 0 ? '🟠 HIGH issues found' :
                            total > 0 ? '🟡 Issues found' : '✅ No issues';
 
-            const workflowRef = process.env.GITHUB_WORKFLOW_REF || '';
-            const ref = workflowRef.split('@')[1] || 'main';
-            const logoLight = `https://raw.githubusercontent.com/ArmisSecurity/armis-cli/${ref}/docs/assets/appsec-logo-light.png`;
-            const logoDark = `https://raw.githubusercontent.com/ArmisSecurity/armis-cli/${ref}/docs/assets/appsec-logo-dark.png`;
+            // Pinned to main rather than derived from GITHUB_WORKFLOW_REF: on
+            // pull_request-triggered runs that resolves to the ephemeral
+            // refs/pull/<N>/merge pseudo-ref, which raw.githubusercontent.com
+            // can never fetch, breaking the logo image in every PR comment.
+            const logoLight = `https://raw.githubusercontent.com/ArmisSecurity/armis-cli/main/docs/assets/appsec-logo-light.png`;
+            const logoDark = `https://raw.githubusercontent.com/ArmisSecurity/armis-cli/main/docs/assets/appsec-logo-dark.png`;
             // GitHub theme-aware images with height constraint (24px to match heading text)
             const logo = `<img alt="Armis AppSec" src="${logoLight}#gh-dark-mode-only" height="24"><img alt="Armis AppSec" src="${logoDark}#gh-light-mode-only" height="24">`;
 

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -205,9 +205,10 @@ jobs:
                            total > 0 ? '🟡 Issues found' : '✅ No issues';
 
             // Pinned to main rather than derived from GITHUB_WORKFLOW_REF: on
-            // pull_request-triggered runs that resolves to the ephemeral
-            // refs/pull/<N>/merge pseudo-ref, which raw.githubusercontent.com
-            // can never fetch, breaking the logo image in every PR comment.
+            // pull_request-triggered runs, that variable resolves to the
+            // ephemeral refs/pull/<N>/merge pseudo-ref, which
+            // raw.githubusercontent.com can never fetch, breaking the logo
+            // image in every PR comment.
             const logoLight = `https://raw.githubusercontent.com/ArmisSecurity/armis-cli/main/docs/assets/appsec-logo-light.png`;
             const logoDark = `https://raw.githubusercontent.com/ArmisSecurity/armis-cli/main/docs/assets/appsec-logo-dark.png`;
             // GitHub theme-aware images with height constraint (24px to match heading text)


### PR DESCRIPTION
## Related Issue

* [PPSC-1141](https://armis-security.atlassian.net/browse/PPSC-1141)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Problem

The Armis AppSec logo in every PR security-scan comment renders as a broken image. The logo URL was built from `GITHUB_WORKFLOW_REF`, which on `pull_request`-triggered runs resolves to the ephemeral `refs/pull/<N>/merge` pseudo-ref — a path `raw.githubusercontent.com` can never fetch, so both logo `<img>` requests 404.

## Solution

The logo is a static asset, so the dynamic ref derivation was dropped entirely and the URL pinned directly to `main`. This removes the untrusted-input-to-URL pattern altogether rather than trying to sanitize it.

## Testing

### Automated Tests

* [x] All tests passing locally (3215 passed, 3 skipped as expected/environmental, 72.1% coverage)

### Manual Testing

Confirmed `raw.githubusercontent.com/ArmisSecurity/armis-cli/main/docs/assets/appsec-logo-light.png` resolves (200, valid PNG), whereas the previous `refs/pull/N/merge` path 404s. Ran `make lint`, `make build`, and the security scanner (`scan_diff` + `scan_file`) against the change — clean.

## Reviewer Notes

Also ran the security scanner and confirmed no new findings are introduced by this change; two pre-existing findings elsewhere in the same file (unrelated to this diff) were spotted and left untouched since they're out of scope here.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed

[PPSC-1141]: https://armis-security.atlassian.net/browse/PPSC-1141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ