### PR TITLE
feat(PPSC-1136): add scan sbom-cpe command for CPE→NVD SBOM scans

### DIFF
--- a/internal/cmd/scan_sbom_cpe.go
+++ b/internal/cmd/scan_sbom_cpe.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/ArmisSecurity/armis-cli/internal/api"
+	"github.com/ArmisSecurity/armis-cli/internal/cmd/cmdutil"
+	"github.com/ArmisSecurity/armis-cli/internal/output"
+	"github.com/ArmisSecurity/armis-cli/internal/scan/sbomcpe"
+	"github.com/spf13/cobra"
+)
+
+// sbomCpeOutput is the path to write the raw per-CPE JSON dump to. Empty →
+// falls back to .armis/<artifact>-sbom-cpe.json (chosen by the driver).
+var sbomCpeOutput string
+
+var scanSbomCpeCmd = &cobra.Command{
+	Use:   "sbom-cpe <path>",
+	Short: "Scan a CycloneDX asset SBOM via CPE→NVD matching",
+	Long: `Upload a CycloneDX SBOM (or a directory of SBOMs, or a pre-built tarball)
+and scan each component against the National Vulnerability Database using
+its CPE. Findings appear in the standard tenant findings view; the raw
+per-component JSON (including CPE and low_confidence flags for synthesised
+CPEs) is written to disk for triage.
+
+Purl-only application SBOMs (npm/NuGet/pypi manifests) belong on the
+regular scan flow — the CPE→NVD scanner returns a clear error if such an
+SBOM is uploaded here.`,
+	Example: `  # Single asset-inventory SBOM
+  $ armis-cli scan sbom-cpe ./torizon-os-bom.json
+
+  # Directory of SBOMs (each .json / .xml file is packed and scanned)
+  $ armis-cli scan sbom-cpe ./sboms/
+
+  # Pre-built tarball
+  $ armis-cli scan sbom-cpe ./inventory.tar.gz
+
+  # Write the raw per-CPE JSON dump to a specific path
+  $ armis-cli scan sbom-cpe ./sbom.json --sbom-cpe-output ./results.json`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		inputPath := args[0]
+
+		// Fail fast on missing path before touching auth / network.
+		// armis:ignore cwe:22 reason:os.Stat is a read-only existence check; SanitizePath happens inside the scan driver
+		info, err := os.Stat(inputPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("path does not exist: %s", inputPath)
+			}
+			return fmt.Errorf("cannot access path %s: %w", inputPath, err)
+		}
+		_ = info // used implicitly — stat error is the only thing we care about here
+
+		// SBOM-CPE scans never generate SBOM or VEX documents (the input IS
+		// an SBOM). Emit a warning if the user passed those flags, matching
+		// scan_image.go's warning style for the same class of misuse.
+		if generateSBOM {
+			return fmt.Errorf("--sbom is not supported for scan sbom-cpe (the input already is an SBOM)")
+		}
+		if generateVEX {
+			return fmt.Errorf("--vex is not supported for scan sbom-cpe (use `armis-cli scan sbom` for SBOM → VEX)")
+		}
+
+		authProvider, err := getAuthProvider(cmd.Context())
+		if err != nil {
+			return err
+		}
+		if authProvider == nil {
+			return fmt.Errorf("internal error: nil auth provider")
+		}
+
+		tid, err := authProvider.GetTenantID(cmd.Context())
+		if err != nil {
+			return err
+		}
+
+		limit, err := getPageLimit()
+		if err != nil {
+			return err
+		}
+
+		failOnSeverities, err := cmdutil.GetFailOn(failOn)
+		if err != nil {
+			return err
+		}
+
+		baseURL := resolveDataPlaneURL(cmd.Context(), authProvider)
+		client, err := api.NewClient(baseURL, authProvider, debug, time.Duration(uploadTimeout)*time.Minute,
+			clientOptionsForBaseURL(baseURL)...)
+		if err != nil {
+			return fmt.Errorf("failed to create API client: %w", err)
+		}
+
+		scanTimeoutDuration := time.Duration(scanTimeout) * time.Minute
+		scanner := sbomcpe.NewScanner(
+			client,
+			noProgress,
+			tid,
+			limit,
+			scanTimeoutDuration,
+			includeNonExploitable,
+		)
+		if sbomCpeOutput != "" {
+			scanner = scanner.WithRawOutput(sbomCpeOutput)
+		}
+
+		ctx, cancel := NewSignalContext()
+		defer cancel()
+
+		result, err := scanner.Scan(ctx, inputPath)
+		if err != nil {
+			return handleScanError(ctx, err)
+		}
+
+		outputCfg, err := cmdutil.ResolveOutput(cmd, outputFile, format, colorFlag)
+		if err != nil {
+			return err
+		}
+		defer outputCfg.Cleanup()
+
+		formatter, err := output.GetFormatter(outputCfg.Format)
+		if err != nil {
+			return err
+		}
+
+		opts := output.FormatOptions{
+			GroupBy:          groupBy,
+			RepoPath:         "",
+			Debug:            debug,
+			SummaryTop:       summaryTop,
+			FailOnSeverities: failOnSeverities,
+		}
+		if err := formatter.FormatWithOptions(result, outputCfg.Writer, opts); err != nil {
+			return fmt.Errorf("failed to format output: %w", err)
+		}
+
+		return output.CheckExit(result, failOnSeverities, exitCode)
+	},
+}
+
+func init() {
+	scanSbomCpeCmd.Flags().StringVar(&sbomCpeOutput, "sbom-cpe-output", "",
+		"Path to write the raw per-CPE JSON dump. Default: .armis/<artifact>-sbom-cpe.json")
+	scanCmd.AddCommand(scanSbomCpeCmd)
+}

--- a/internal/cmd/scan_sbom_cpe_test.go
+++ b/internal/cmd/scan_sbom_cpe_test.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The scan sbom-cpe command has three failure branches that can be verified
+// without hitting the network or auth: path validation, --sbom rejection,
+// and --vex rejection. Anything past those requires a mock API server; the
+// driver-level tests in internal/scan/sbomcpe cover the packing pipeline.
+
+func TestScanSbomCpeRunE_MissingPath(t *testing.T) {
+	// Reset the parent scan command's globals just enough to reach RunE.
+	restore := saveScanCmdGlobalsForTest()
+	t.Cleanup(restore)
+
+	err := scanSbomCpeCmd.RunE(scanSbomCpeCmd, []string{"/nonexistent/path/does/not/exist"})
+	if err == nil {
+		t.Fatal("expected error for missing path")
+	}
+	if !containsSubstring(err.Error(), "does not exist") {
+		t.Errorf("expected 'does not exist' in error, got: %v", err)
+	}
+}
+
+func TestScanSbomCpeRunE_RejectsSbomFlag(t *testing.T) {
+	restore := saveScanCmdGlobalsForTest()
+	t.Cleanup(restore)
+
+	// A real path so the stat check succeeds and we fall through to
+	// the flag-validation branches.
+	dir := t.TempDir()
+	sbom := filepath.Join(dir, "x.json")
+	if err := os.WriteFile(sbom, []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	generateSBOM = true
+	defer func() { generateSBOM = false }()
+
+	err := scanSbomCpeCmd.RunE(scanSbomCpeCmd, []string{sbom})
+	if err == nil {
+		t.Fatal("expected error when --sbom is set")
+	}
+	if !containsSubstring(err.Error(), "--sbom is not supported") {
+		t.Errorf("expected '--sbom is not supported' in error, got: %v", err)
+	}
+}
+
+func TestScanSbomCpeRunE_RejectsVexFlag(t *testing.T) {
+	restore := saveScanCmdGlobalsForTest()
+	t.Cleanup(restore)
+
+	dir := t.TempDir()
+	sbom := filepath.Join(dir, "x.json")
+	if err := os.WriteFile(sbom, []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	generateVEX = true
+	defer func() { generateVEX = false }()
+
+	err := scanSbomCpeCmd.RunE(scanSbomCpeCmd, []string{sbom})
+	if err == nil {
+		t.Fatal("expected error when --vex is set")
+	}
+	if !containsSubstring(err.Error(), "--vex is not supported") {
+		t.Errorf("expected '--vex is not supported' in error, got: %v", err)
+	}
+}
+
+func TestScanSbomCpeCmd_RegisteredUnderScan(t *testing.T) {
+	// The command must be a child of scanCmd for `armis-cli scan sbom-cpe`
+	// to resolve. If the init() function ever drops the AddCommand call,
+	// this test catches it.
+	for _, c := range scanCmd.Commands() {
+		if c == scanSbomCpeCmd {
+			return
+		}
+	}
+	t.Error("scanSbomCpeCmd is not registered under scanCmd")
+}
+
+// saveScanCmdGlobalsForTest saves the subset of package-level globals the
+// scan sbom-cpe RunE touches before returning an error, then returns a
+// restore function. The three flag globals (generateSBOM, generateVEX,
+// sbomCpeOutput) are the only ones our RunE actually looks at prior to
+// path validation and the SBOM/VEX guards.
+func saveScanCmdGlobalsForTest() func() {
+	origSBOM := generateSBOM
+	origVEX := generateVEX
+	origOutput := sbomCpeOutput
+	return func() {
+		generateSBOM = origSBOM
+		generateVEX = origVEX
+		sbomCpeOutput = origOutput
+	}
+}
+
+// containsSubstring is a local test helper so we don't depend on strings
+// package here — matches the light-touch style of the existing cmd tests.
+func containsSubstring(haystack, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/scan/sbomcpe/sbomcpe.go
+++ b/internal/scan/sbomcpe/sbomcpe.go
@@ -394,6 +394,14 @@ func validateSbomExtension(path string) error {
 	return fmt.Errorf("SBOM file extension %q not allowed; expected one of %v", ext, AllowedExtensions)
 }
 
+// PackForTest exposes packSingleFile to _test packages so integration tests
+// can produce a valid tar.gz that matches what the driver would upload. Kept
+// separate from the private helper so removing this shim doesn't change the
+// production surface.
+func PackForTest(path string, w io.Writer) error {
+	return packSingleFile(path, w)
+}
+
 // packSingleFile writes a tar.gz containing exactly one file (the SBOM).
 func packSingleFile(path string, w io.Writer) error {
 	// armis:ignore cwe:22 reason:path sanitized by caller (Scanner.Scan)

--- a/internal/scan/sbomcpe/sbomcpe.go
+++ b/internal/scan/sbomcpe/sbomcpe.go
@@ -1,0 +1,711 @@
+// Package sbomcpe drives the CPE→NVD SBOM scan flow (PPSC-1136).
+//
+// The driver accepts a CycloneDX SBOM file (JSON or XML) or a directory of
+// SBOM files, packs them into a tar.gz, and hands the tarball off to the
+// backend via the standard artifact ingest path with artifact_type=sbom-cpe.
+// The backend routes the tarball to the artifact-scanner service's
+// CpeSbomScanner which parses each SBOM, queries NVD, and writes findings
+// to the normalized results collection. The driver then polls for scan
+// completion, downloads the raw per-CPE JSON dump from S3, and returns the
+// same *model.ScanResult shape the other scan commands use so summary /
+// findings-table / --fail-on all work.
+package sbomcpe
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ArmisSecurity/armis-cli/internal/api"
+	"github.com/ArmisSecurity/armis-cli/internal/cli"
+	"github.com/ArmisSecurity/armis-cli/internal/model"
+	"github.com/ArmisSecurity/armis-cli/internal/output"
+	"github.com/ArmisSecurity/armis-cli/internal/progress"
+	"github.com/ArmisSecurity/armis-cli/internal/scan"
+	"github.com/ArmisSecurity/armis-cli/internal/util"
+)
+
+const (
+	// MaxSbomSize caps the on-disk size of any single SBOM (or the sum of
+	// all SBOMs in a directory) that we're willing to pack + upload. Real
+	// asset-inventory SBOMs are typically <10MB; 100MB is generous headroom
+	// while still bounding memory + upload time in the worst case.
+	MaxSbomSize = 100 * 1024 * 1024
+
+	// ResultKeySBOMCPE is the results_refs key the backend uses when it
+	// uploads the raw CpeSbomScanner JSON dump to S3 (see
+	// services/artifact-scanner/artifact_scanner/workflow/persist_results_task.py
+	// under PPSC-1136).
+	ResultKeySBOMCPE = "sbom_cpe_results"
+)
+
+// AllowedExtensions are the SBOM file extensions accepted as raw input.
+// A pre-packed .tar / .tar.gz / .tgz is also accepted and forwarded as-is.
+var AllowedExtensions = []string{".json", ".xml"}
+
+// Scanner drives the sbom-cpe scan flow.
+type Scanner struct {
+	client                *api.Client
+	noProgress            bool
+	tenantID              string
+	pageLimit             int
+	timeout               time.Duration
+	includeNonExploitable bool
+	pollInterval          time.Duration
+	fetchRetryInterval    time.Duration
+
+	// downloadRaw controls whether the raw per-CPE JSON dump gets pulled
+	// from S3 after scan completion. Default is true (matches the CLI's
+	// stated behavior of showing the human-readable output alongside
+	// findings). Kept as a knob mainly for tests.
+	downloadRaw bool
+	rawOutput   string
+}
+
+// NewScanner creates a new sbom-cpe scanner.
+func NewScanner(
+	client *api.Client,
+	noProgress bool,
+	tenantID string,
+	pageLimit int,
+	timeout time.Duration,
+	includeNonExploitable bool,
+) *Scanner {
+	return &Scanner{
+		client:                client,
+		noProgress:            noProgress,
+		tenantID:              tenantID,
+		pageLimit:             pageLimit,
+		timeout:               timeout,
+		includeNonExploitable: includeNonExploitable,
+		pollInterval:          5 * time.Second,
+		fetchRetryInterval:    10 * time.Second,
+		downloadRaw:           true,
+	}
+}
+
+// WithPollInterval overrides the poll interval (for tests).
+func (s *Scanner) WithPollInterval(d time.Duration) *Scanner {
+	s.pollInterval = d
+	return s
+}
+
+// WithFetchRetryInterval overrides the retry interval (for tests).
+func (s *Scanner) WithFetchRetryInterval(d time.Duration) *Scanner {
+	s.fetchRetryInterval = d
+	return s
+}
+
+// WithRawOutput sets a custom path to write the raw per-CPE JSON dump to.
+// If empty, the default is .armis/<artifact>-sbom-cpe.json.
+func (s *Scanner) WithRawOutput(path string) *Scanner {
+	s.rawOutput = path
+	return s
+}
+
+// WithoutRawDownload disables the S3 raw-JSON download step (for tests).
+func (s *Scanner) WithoutRawDownload() *Scanner {
+	s.downloadRaw = false
+	return s
+}
+
+// Scan runs the sbom-cpe scan for the given input path. The path may be:
+//   - a single SBOM file (.json or .xml)
+//   - a directory containing SBOM files (recursively walked, non-SBOM files skipped)
+//   - a pre-built tar / tar.gz / tgz (uploaded as-is)
+//
+// Whichever shape is provided, the scanner packs it into a tar.gz on a
+// tempfile (unless it's already a tar), uploads it via the standard
+// /api/v1/ingest/presigned-url + /api/v1/ingest/scan flow with
+// artifact_type=sbom-cpe, polls until the scan completes, retrieves the
+// normalized findings, and optionally downloads the raw JSON dump.
+func (s *Scanner) Scan(ctx context.Context, inputPath string) (*model.ScanResult, error) {
+	// armis:ignore cwe:22 reason:SanitizePath IS the traversal prevention; rejects invalid paths
+	sanitized, err := util.SanitizePath(inputPath)
+	if err != nil {
+		return nil, fmt.Errorf("invalid input path: %w", err)
+	}
+	inputPath = sanitized
+
+	info, err := os.Stat(inputPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("input path does not exist: %s", inputPath)
+		}
+		return nil, fmt.Errorf("cannot access input path: %w", err)
+	}
+
+	// Prepare a tar.gz on disk. If the user already handed us a tarball,
+	// forward it verbatim.
+	var (
+		tarballPath string
+		artifactName string
+		cleanupTar   func()
+	)
+
+	if isPrebuiltTarball(inputPath) {
+		tarballPath = inputPath
+		artifactName = trimTarSuffix(filepath.Base(inputPath))
+		cleanupTar = func() {} // nothing to remove; caller owns the file
+	} else {
+		spinner := progress.NewSpinnerWithContext(ctx, "Packing SBOM(s) into tar.gz...", s.noProgress)
+		spinner.Start()
+
+		tmpFile, err := os.CreateTemp("", "armis-sbom-cpe-*.tar.gz")
+		if err != nil {
+			spinner.Stop()
+			return nil, fmt.Errorf("failed to create temp tarball: %w", err)
+		}
+		tarballPath = tmpFile.Name()
+		cleanupTar = func() {
+			_ = tmpFile.Close()
+			_ = os.Remove(tarballPath)
+		}
+
+		var packErr error
+		if info.IsDir() {
+			packErr = packDir(inputPath, tmpFile)
+			artifactName = filepath.Base(inputPath)
+		} else {
+			if err := validateSbomExtension(inputPath); err != nil {
+				cleanupTar()
+				spinner.Stop()
+				return nil, err
+			}
+			packErr = packSingleFile(inputPath, tmpFile)
+			artifactName = trimSbomExtension(filepath.Base(inputPath))
+		}
+		spinner.Stop()
+		if packErr != nil {
+			cleanupTar()
+			return nil, fmt.Errorf("failed to pack input: %w", packErr)
+		}
+		if err := tmpFile.Sync(); err != nil {
+			cleanupTar()
+			return nil, fmt.Errorf("failed to flush tarball: %w", err)
+		}
+	}
+	defer cleanupTar()
+
+	// Enforce the size cap after packing so directories with hundreds of
+	// SBOMs are rejected up-front rather than after a lengthy upload.
+	tarInfo, err := os.Stat(tarballPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat tarball: %w", err)
+	}
+	if tarInfo.Size() > MaxSbomSize {
+		return nil, fmt.Errorf(
+			"packed tarball size (%d bytes) exceeds maximum %d bytes",
+			tarInfo.Size(), MaxSbomSize)
+	}
+
+	// armis:ignore cwe:22 reason:tarballPath sanitized above (or a tempfile we own)
+	tarFile, err := os.Open(tarballPath) //nolint:gosec // G304: path sanitized above
+	if err != nil {
+		return nil, fmt.Errorf("failed to open tarball: %w", err)
+	}
+	defer tarFile.Close() //nolint:errcheck // read-only
+
+	uploadSpinner := progress.NewSpinnerWithContext(ctx, "Uploading SBOM(s) to Armis Cloud...", s.noProgress)
+	uploadSpinner.Start()
+	defer uploadSpinner.Stop()
+
+	ingestOpts := api.IngestOptions{
+		TenantID:     s.tenantID,
+		ArtifactType: "sbom-cpe",
+		Filename:     artifactName + ".tar.gz",
+		Data:         tarFile,
+		Size:         tarInfo.Size(),
+	}
+	scanID, err := s.client.StartIngest(ctx, ingestOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to upload SBOM tarball: %w", err)
+	}
+
+	uploadSpinner.Stop()
+	styles := output.GetStyles()
+	fmt.Fprintf(os.Stderr, "%s %s\n\n",
+		styles.MutedText.Render("Scan initiated with ID:"),
+		styles.ScanID.Render(scanID))
+
+	scanSpinner := progress.NewSpinnerWithContext(ctx, "Matching CPEs against NVD...", s.noProgress)
+	scanSpinner.Start()
+	defer scanSpinner.Stop()
+
+	_, err = s.client.WaitForIngest(ctx, s.tenantID, scanID, s.pollInterval, s.timeout,
+		func(status model.IngestStatusData) {
+			scanSpinner.Update(scan.FormatScanStatus(status.ScanStatus, "Matching CPEs against NVD..."))
+		})
+	elapsed := scanSpinner.GetElapsed()
+	if err != nil {
+		return nil, fmt.Errorf("failed to wait for scan: %w", err)
+	}
+	scanSpinner.Stop()
+	fmt.Fprintf(os.Stderr, "%s %s\n\n",
+		styles.MutedText.Render("Scan completed in"),
+		styles.Duration.Render(scan.FormatElapsed(elapsed)))
+
+	// Fetch normalized findings with a bounded retry loop, matching the
+	// pattern established by scan_image / scan_repo.
+	fetchSpinner := progress.NewSpinnerWithContext(ctx, "Retrieving findings...", s.noProgress)
+	fetchSpinner.Start()
+
+	var findings []model.NormalizedFinding
+	const maxFetchRetries = 5
+	for attempt := 1; attempt <= maxFetchRetries; attempt++ {
+		findings, err = s.client.FetchAllNormalizedResults(ctx, s.tenantID, scanID, s.pageLimit)
+		if err == nil {
+			break
+		}
+		if !isRetryableError(err) {
+			break
+		}
+		if attempt < maxFetchRetries {
+			fetchSpinner.Update(fmt.Sprintf("Retrieving findings (retry %d/%d)...", attempt, maxFetchRetries-1))
+			time.Sleep(s.fetchRetryInterval)
+		}
+	}
+	fetchSpinner.Stop()
+	if err != nil {
+		cli.PrintWarningf("Failed to retrieve findings: %v", err)
+		cli.PrintWarningf("Scan completed successfully. Results are available with scan ID: %s", scanID)
+		return nil, &output.ErrResultsIncomplete{ScanID: scanID}
+	}
+
+	if s.downloadRaw {
+		if err := s.downloadRawResults(ctx, scanID, artifactName); err != nil {
+			// Non-fatal — the normalized findings are already retrieved.
+			cli.PrintWarningf("%v", err)
+		}
+	}
+
+	return buildScanResult(scanID, findings, s.client.IsDebug(), s.includeNonExploitable), nil
+}
+
+// downloadRawResults pulls the CpeSbomScanner raw JSON dump from S3 and
+// writes it to the configured raw-output path (or the default under .armis/).
+// The CLI keeps this alongside the normalized findings because the raw dump
+// contains per-CPE context and the low_confidence flag that are useful for
+// triage but aren't fully exposed via MooseFindings.
+func (s *Scanner) downloadRawResults(ctx context.Context, scanID, artifactName string) error {
+	results, err := s.client.FetchArtifactScanResults(ctx, s.tenantID, scanID)
+	if err != nil {
+		return fmt.Errorf("failed to fetch scan result refs: %w", err)
+	}
+	if results == nil {
+		return fmt.Errorf("scan result refs not available")
+	}
+	rawURL, ok := results.Results[ResultKeySBOMCPE]
+	if !ok || rawURL == "" {
+		return fmt.Errorf("raw sbom-cpe results not available for scan %s", scanID)
+	}
+
+	outputPath := s.rawOutput
+	if outputPath == "" {
+		outputPath = filepath.Join(".armis", filepath.Base(artifactName)+"-sbom-cpe.json")
+	}
+
+	// armis:ignore cwe:22 reason:SanitizePath IS the traversal prevention
+	sanitized, err := util.SanitizePath(outputPath)
+	if err != nil {
+		return fmt.Errorf("invalid --sbom-cpe-output path: %w", err)
+	}
+	outputPath = sanitized
+
+	dir := filepath.Dir(outputPath)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0750); err != nil {
+			return fmt.Errorf("failed to create output directory %s: %w", dir, err)
+		}
+	}
+
+	// armis:ignore cwe:918 reason:ValidatePresignedURL enforces HTTPS + allowlisted S3 hosts
+	if err := s.client.ValidatePresignedURL(rawURL); err != nil {
+		return fmt.Errorf("invalid raw-results URL: %w", err)
+	}
+	// armis:ignore cwe:770 reason:DownloadFromPresignedURL enforces 100MB limit
+	data, err := s.client.DownloadFromPresignedURL(ctx, rawURL)
+	if err != nil {
+		return fmt.Errorf("failed to download raw sbom-cpe results: %w", err)
+	}
+	if err := os.WriteFile(outputPath, data, 0600); err != nil {
+		return fmt.Errorf("failed to write raw sbom-cpe results to %s: %w", outputPath, err)
+	}
+
+	styles := output.GetStyles()
+	fmt.Fprintf(os.Stderr, "%s %s\n",
+		styles.SuccessText.Render("Raw sbom-cpe results saved to:"),
+		styles.Bold.Render(outputPath))
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Packing helpers
+// ---------------------------------------------------------------------------
+
+// isPrebuiltTarball reports whether inputPath already looks like a tarball
+// the backend can accept as-is.
+func isPrebuiltTarball(path string) bool {
+	lower := strings.ToLower(path)
+	return strings.HasSuffix(lower, ".tar.gz") ||
+		strings.HasSuffix(lower, ".tgz") ||
+		strings.HasSuffix(lower, ".tar")
+}
+
+func trimTarSuffix(name string) string {
+	lower := strings.ToLower(name)
+	switch {
+	case strings.HasSuffix(lower, ".tar.gz"):
+		return name[:len(name)-len(".tar.gz")]
+	case strings.HasSuffix(lower, ".tgz"):
+		return name[:len(name)-len(".tgz")]
+	case strings.HasSuffix(lower, ".tar"):
+		return name[:len(name)-len(".tar")]
+	}
+	return name
+}
+
+func trimSbomExtension(name string) string {
+	ext := strings.ToLower(filepath.Ext(name))
+	if ext == ".json" || ext == ".xml" {
+		return name[:len(name)-len(ext)]
+	}
+	return name
+}
+
+// validateSbomExtension rejects a single file whose extension isn't in
+// AllowedExtensions. Directory inputs are walked without extension gating —
+// non-SBOM files are silently skipped there.
+func validateSbomExtension(path string) error {
+	ext := strings.ToLower(filepath.Ext(path))
+	for _, allowed := range AllowedExtensions {
+		if ext == allowed {
+			return nil
+		}
+	}
+	return fmt.Errorf("SBOM file extension %q not allowed; expected one of %v", ext, AllowedExtensions)
+}
+
+// packSingleFile writes a tar.gz containing exactly one file (the SBOM).
+func packSingleFile(path string, w io.Writer) error {
+	// armis:ignore cwe:22 reason:path sanitized by caller (Scanner.Scan)
+	f, err := os.Open(path) //nolint:gosec // G304: sanitized above
+	if err != nil {
+		return err
+	}
+	defer f.Close() //nolint:errcheck // read-only
+
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	gw := gzip.NewWriter(w)
+	defer gw.Close() //nolint:errcheck // gz Close error is surfaced by tw.Close chain
+	tw := tar.NewWriter(gw)
+	defer tw.Close() //nolint:errcheck // tar Close error handled below
+
+	hdr, err := tar.FileInfoHeader(info, "")
+	if err != nil {
+		return err
+	}
+	hdr.Name = filepath.Base(path)
+	if err := tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+	if _, err := io.Copy(tw, f); err != nil {
+		return err
+	}
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	return gw.Close()
+}
+
+// packDir walks a directory and writes a tar.gz of every SBOM-shaped file
+// (extension in AllowedExtensions). Symlinks are skipped to avoid escaping
+// the source tree, matching the safety posture of the repo scanner.
+func packDir(root string, w io.Writer) error {
+	gw := gzip.NewWriter(w)
+	defer gw.Close() //nolint:errcheck
+	tw := tar.NewWriter(gw)
+	defer tw.Close() //nolint:errcheck
+
+	packedAny := false
+	walkErr := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		// Skip symlinks entirely (defense against zip-slip-style escapes).
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		allowed := false
+		for _, ok := range AllowedExtensions {
+			if ext == ok {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+
+		// armis:ignore cwe:22 reason:path from filepath.Walk under caller-sanitized root
+		f, err := os.Open(path) //nolint:gosec // G304: root sanitized by Scanner.Scan
+		if err != nil {
+			return err
+		}
+		defer f.Close() //nolint:errcheck // read-only
+
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		hdr.Name = rel
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if _, err := io.Copy(tw, f); err != nil {
+			return err
+		}
+		packedAny = true
+		return nil
+	})
+	if walkErr != nil {
+		return walkErr
+	}
+	if !packedAny {
+		return fmt.Errorf("no SBOM files (%v) found under %s", AllowedExtensions, root)
+	}
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	return gw.Close()
+}
+
+// ---------------------------------------------------------------------------
+// Result plumbing.
+//
+// convertNormalizedFindings / isEmptyFinding / cleanDescription mirror the
+// helpers inside internal/scan/image and internal/scan/repo verbatim. The
+// two existing scanner packages already duplicate this pair; keeping the
+// pattern here means no cross-package refactor and no risk of drift for
+// PPSC-1136. If a future ticket lifts them into internal/scan, all three
+// call sites can switch over together.
+// ---------------------------------------------------------------------------
+
+func buildScanResult(scanID string, normalizedFindings []model.NormalizedFinding, debug, includeNonExploitable bool) *model.ScanResult {
+	findings, filteredCount := convertNormalizedFindings(normalizedFindings, debug, includeNonExploitable)
+
+	summary := model.Summary{
+		Total:                  len(findings),
+		BySeverity:             make(map[model.Severity]int),
+		ByType:                 make(map[model.FindingType]int),
+		ByCategory:             make(map[string]int),
+		FilteredNonExploitable: filteredCount,
+	}
+	for _, f := range findings {
+		summary.BySeverity[f.Severity]++
+		summary.ByType[f.Type]++
+		if f.FindingCategory != "" {
+			summary.ByCategory[f.FindingCategory]++
+		}
+	}
+
+	return &model.ScanResult{
+		ScanID:   scanID,
+		Findings: findings,
+		Summary:  summary,
+	}
+}
+
+func convertNormalizedFindings(normalizedFindings []model.NormalizedFinding, debug bool, includeNonExploitable bool) ([]model.Finding, int) {
+	var findings []model.Finding
+	filteredCount := 0
+
+	for i, nf := range normalizedFindings {
+		if isEmptyFinding(nf) {
+			continue
+		}
+
+		if !includeNonExploitable && scan.ShouldFilterByExploitability(nf.NormalizedTask.Labels) {
+			filteredCount++
+			continue
+		}
+
+		if debug {
+			// Create a sanitized copy for debug output to prevent secret exposure
+			debugCopy := nf
+			if debugCopy.NormalizedTask.ExtraData.CodeLocation.Snippet != nil {
+				masked := util.MaskSecretInLine(*debugCopy.NormalizedTask.ExtraData.CodeLocation.Snippet)
+				debugCopy.NormalizedTask.ExtraData.CodeLocation.Snippet = &masked
+			}
+			if len(debugCopy.NormalizedTask.ExtraData.CodeLocation.CodeSnippetLines) > 0 {
+				debugCopy.NormalizedTask.ExtraData.CodeLocation.CodeSnippetLines =
+					util.MaskSecretInLines(debugCopy.NormalizedTask.ExtraData.CodeLocation.CodeSnippetLines)
+			}
+			if debugCopy.NormalizedTask.ExtraData.Fix != nil {
+				debugCopy.NormalizedTask.ExtraData.Fix = scan.MaskFixSecrets(debugCopy.NormalizedTask.ExtraData.Fix)
+			}
+			rawJSON, err := json.Marshal(debugCopy)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "\n=== DEBUG: Finding #%d JSON Marshal Error: %v ===\n\n", i+1, err)
+			} else {
+				fmt.Fprintf(os.Stderr, "\n=== DEBUG: Finding #%d Raw JSON ===\n%s\n=== END DEBUG ===\n\n", i+1, string(rawJSON))
+			}
+		}
+
+		finding := model.Finding{
+			ID:                      nf.NormalizedTask.FindingID,
+			Severity:                scan.MapSeverity(nf.NormalizedRemediation.ToolSeverity),
+			Description:             nf.NormalizedRemediation.Description,
+			CVEs:                    nf.NormalizedRemediation.VulnerabilityTypeMetadata.CVEs,
+			CWEs:                    nf.NormalizedRemediation.VulnerabilityTypeMetadata.CWEs,
+			OWASPCategories:         nf.NormalizedRemediation.VulnerabilityTypeMetadata.OWASPCategories,
+			LongDescriptionMarkdown: nf.NormalizedRemediation.VulnerabilityTypeMetadata.LongDescriptionMarkdown,
+			URLs:                    nf.NormalizedRemediation.VulnerabilityTypeMetadata.URLs,
+		}
+
+		if finding.Description == "" {
+			if nf.NormalizedRemediation.VulnerabilityTypeMetadata.LongDescriptionMarkdown != "" {
+				finding.Description = nf.NormalizedRemediation.VulnerabilityTypeMetadata.LongDescriptionMarkdown
+			} else if nf.NormalizedTask.LongDescription != nil {
+				finding.Description = *nf.NormalizedTask.LongDescription
+			}
+		}
+
+		finding.Description = cleanDescription(finding.Description)
+
+		if nf.NormalizedRemediation.FindingCategory != nil {
+			if category, ok := nf.NormalizedRemediation.FindingCategory.(string); ok {
+				finding.FindingCategory = category
+			}
+		}
+
+		loc := nf.NormalizedTask.ExtraData.CodeLocation
+		if loc.FileName != nil {
+			finding.File = *loc.FileName
+		}
+		if loc.StartLine != nil {
+			finding.StartLine = *loc.StartLine
+		}
+		if loc.EndLine != nil {
+			finding.EndLine = *loc.EndLine
+		}
+		if loc.StartCol != nil {
+			finding.StartColumn = *loc.StartCol
+		}
+		if loc.EndCol != nil {
+			finding.EndColumn = *loc.EndCol
+		}
+
+		if len(loc.CodeSnippetLines) > 0 {
+			finding.CodeSnippet = strings.Join(loc.CodeSnippetLines, "\n")
+		} else if loc.Snippet != nil {
+			finding.CodeSnippet = *loc.Snippet
+		}
+
+		if loc.SnippetStartLine != nil {
+			finding.SnippetStartLine = *loc.SnippetStartLine
+		}
+
+		if nf.NormalizedTask.ExtraData.Fix != nil {
+			finding.Fix = nf.NormalizedTask.ExtraData.Fix
+		}
+		if nf.NormalizedTask.ExtraData.FindingValidation != nil {
+			finding.Validation = nf.NormalizedTask.ExtraData.FindingValidation
+		}
+
+		finding.Type = scan.DeriveFindingType(
+			len(nf.NormalizedRemediation.VulnerabilityTypeMetadata.CVEs) > 0,
+			loc.HasSecret,
+			finding.FindingCategory,
+		)
+
+		if loc.HasSecret && finding.CodeSnippet != "" {
+			finding.CodeSnippet = util.MaskSecretInLine(finding.CodeSnippet)
+		}
+		if loc.HasSecret && finding.Fix != nil {
+			finding.Fix = scan.MaskFixSecrets(finding.Fix)
+		}
+
+		finding.Title = scan.GenerateFindingTitle(&finding)
+		findings = append(findings, finding)
+	}
+
+	return findings, filteredCount
+}
+
+func cleanDescription(desc string) string {
+	lines := strings.Split(desc, "\n")
+	var cleaned []string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Code_location -") ||
+			strings.HasPrefix(line, "Code Blob -") ||
+			strings.HasPrefix(line, "Confidence -") {
+			continue
+		}
+		if line != "" {
+			cleaned = append(cleaned, line)
+		}
+	}
+	return strings.Join(cleaned, " ")
+}
+
+func isEmptyFinding(nf model.NormalizedFinding) bool {
+	hasDescription := nf.NormalizedRemediation.Description != "" ||
+		nf.NormalizedRemediation.VulnerabilityTypeMetadata.LongDescriptionMarkdown != "" ||
+		(nf.NormalizedTask.LongDescription != nil && *nf.NormalizedTask.LongDescription != "")
+
+	hasCVEsOrCWEs := len(nf.NormalizedRemediation.VulnerabilityTypeMetadata.CVEs) > 0 ||
+		len(nf.NormalizedRemediation.VulnerabilityTypeMetadata.CWEs) > 0
+
+	hasCategory := nf.NormalizedRemediation.FindingCategory != nil
+
+	return !hasDescription && !hasCVEsOrCWEs && !hasCategory
+}
+
+// isRetryableError matches the retry criteria used by scan_image / scan_repo.
+// Kept narrow — we only retry on transient network errors, not on 4xx from
+// the API.
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	// Match the substrings the image scanner treats as transient. Keeping
+	// this small avoids re-inventing retry policy; if the shared helper
+	// grows, we can move to it.
+	transientMarkers := []string{
+		"connection refused",
+		"connection reset",
+		"i/o timeout",
+		"EOF",
+		"temporary failure",
+	}
+	for _, m := range transientMarkers {
+		if strings.Contains(msg, m) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/scan/sbomcpe/sbomcpe.go
+++ b/internal/scan/sbomcpe/sbomcpe.go
@@ -51,6 +51,32 @@ const (
 // A pre-packed .tar / .tar.gz / .tgz is also accepted and forwarded as-is.
 var AllowedExtensions = []string{".json", ".xml"}
 
+// prunedDirNames are directory names we skip when walking a directory input:
+// they hold VCS/build/dependency artefacts that (a) inflate the tarball past
+// MaxSbomSize and (b) may contain thousands of .json files that are
+// application manifests, not asset SBOMs.
+var prunedDirNames = map[string]struct{}{
+	".git":         {},
+	".hg":          {},
+	".svn":         {},
+	"node_modules": {},
+	"vendor":       {},
+	"__pycache__":  {},
+	".venv":        {},
+	"venv":         {},
+	"dist":         {},
+	"build":        {},
+	"target":       {},
+	".tox":         {},
+	".idea":        {},
+	".vscode":      {},
+}
+
+func isPrunedDir(name string) bool {
+	_, ok := prunedDirNames[name]
+	return ok
+}
+
 // Scanner drives the sbom-cpe scan flow.
 type Scanner struct {
 	client                *api.Client
@@ -146,7 +172,7 @@ func (s *Scanner) Scan(ctx context.Context, inputPath string) (*model.ScanResult
 	// Prepare a tar.gz on disk. If the user already handed us a tarball,
 	// forward it verbatim.
 	var (
-		tarballPath string
+		tarballPath  string
 		artifactName string
 		cleanupTar   func()
 	)
@@ -452,11 +478,18 @@ func packDir(root string, w io.Writer) error {
 		if err != nil {
 			return err
 		}
-		// Skip symlinks entirely (defense against zip-slip-style escapes).
-		if info.Mode()&os.ModeSymlink != 0 {
+		// Prune VCS / dependency / build dirs — the extension filter alone
+		// would pull thousands of package.json files out of node_modules and
+		// blow through the 100MB cap (or, worse, ship application manifests
+		// to a scanner that expects asset SBOMs).
+		if info.IsDir() {
+			if path != root && isPrunedDir(info.Name()) {
+				return filepath.SkipDir
+			}
 			return nil
 		}
-		if info.IsDir() {
+		// Skip symlinks entirely (defense against zip-slip-style escapes).
+		if info.Mode()&os.ModeSymlink != 0 {
 			return nil
 		}
 		ext := strings.ToLower(filepath.Ext(path))
@@ -692,28 +725,17 @@ func isEmptyFinding(nf model.NormalizedFinding) bool {
 	return !hasDescription && !hasCVEsOrCWEs && !hasCategory
 }
 
-// isRetryableError matches the retry criteria used by scan_image / scan_repo.
-// Kept narrow — we only retry on transient network errors, not on 4xx from
-// the API.
+// isRetryableError mirrors the retry criteria used by scan_image / scan_repo:
+// treat 5xx API responses and timeouts as transient. Substring matching on
+// err.Error() would miss *api.APIError values whose stringified form doesn't
+// happen to contain one of the hard-coded markers.
 func isRetryableError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
-	// Match the substrings the image scanner treats as transient. Keeping
-	// this small avoids re-inventing retry policy; if the shared helper
-	// grows, we can move to it.
-	transientMarkers := []string{
-		"connection refused",
-		"connection reset",
-		"i/o timeout",
-		"EOF",
-		"temporary failure",
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode >= 500
 	}
-	for _, m := range transientMarkers {
-		if strings.Contains(msg, m) {
-			return true
-		}
-	}
-	return false
+	return errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err)
 }

--- a/internal/scan/sbomcpe/sbomcpe.go
+++ b/internal/scan/sbomcpe/sbomcpe.go
@@ -520,7 +520,10 @@ func packDir(root string, w io.Writer) error {
 		if err != nil {
 			return err
 		}
-		hdr.Name = rel
+		// Tar entries always use forward slashes; filepath.Rel yields
+		// backslashes on Windows, which the backend extractor would treat
+		// as literal filename characters instead of a directory separator.
+		hdr.Name = filepath.ToSlash(rel)
 		if err := tw.WriteHeader(hdr); err != nil {
 			return err
 		}

--- a/internal/scan/sbomcpe/sbomcpe_integration_test.go
+++ b/internal/scan/sbomcpe/sbomcpe_integration_test.go
@@ -108,8 +108,7 @@ func TestIntegration_SbomCpeScanner_EndToEnd(t *testing.T) {
 		},
 	}
 
-	var server *http.Server
-	server = testutil.NewMockScanServerWithConfig(t, testutil.MockAPIConfig{
+	server := testutil.NewMockScanServerWithConfig(t, testutil.MockAPIConfig{
 		ScanID:             wantScanID,
 		Findings:           []model.NormalizedFinding{finding},
 		PollsUntilComplete: 1,
@@ -305,7 +304,7 @@ func TestIntegration_SbomCpeScanner_EndToEnd(t *testing.T) {
 	}
 
 	// Raw dump should exist on disk
-	data, err := os.ReadFile(rawOut)
+	data, err := os.ReadFile(rawOut) //nolint:gosec // test-only read of a path we just wrote
 	if err != nil {
 		t.Fatalf("failed to read raw dump: %v", err)
 	}
@@ -484,7 +483,7 @@ func minimalMockHandler(t *testing.T) http.HandlerFunc {
 // on the driver's own packing.
 func writeMinimalTarGz(t *testing.T, path, name string, content []byte) {
 	t.Helper()
-	f, err := os.Create(path)
+	f, err := os.Create(path) //nolint:gosec // test-only write to a t.TempDir path
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/scan/sbomcpe/sbomcpe_integration_test.go
+++ b/internal/scan/sbomcpe/sbomcpe_integration_test.go
@@ -79,14 +79,14 @@ func TestIntegration_SbomCpeScanner_EndToEnd(t *testing.T) {
 		wantScanID   = "sbom-cpe-scan-001"
 	)
 	var (
-		presignedCallCount    atomic.Int32
-		s3UploadCallCount     atomic.Int32
-		startScanCallCount    atomic.Int32
-		statusCallCount       atomic.Int32
-		normalizedCallCount   atomic.Int32
-		artifactResultsCount  atomic.Int32
-		rawDownloadCallCount  atomic.Int32
-		observedArtifactType  atomic.Value // string
+		presignedCallCount   atomic.Int32
+		s3UploadCallCount    atomic.Int32
+		startScanCallCount   atomic.Int32
+		statusCallCount      atomic.Int32
+		normalizedCallCount  atomic.Int32
+		artifactResultsCount atomic.Int32
+		rawDownloadCallCount atomic.Int32
+		observedArtifactType atomic.Value // string
 	)
 
 	finding := model.NormalizedFinding{
@@ -252,7 +252,7 @@ func TestIntegration_SbomCpeScanner_EndToEnd(t *testing.T) {
 
 	rawOut := filepath.Join(tmpDir, "torizon-mini-sbom-cpe.json")
 	scanner := sbomcpe.NewScanner(client, true, wantTenantID, 500, 60*time.Second, false).
-		WithPollInterval(10*time.Millisecond).
+		WithPollInterval(10 * time.Millisecond).
 		WithRawOutput(rawOut)
 
 	// --- Run scan ----------------------------------------------------------
@@ -334,7 +334,7 @@ func TestIntegration_SbomCpeScanner_TarballInput(t *testing.T) {
 		t.Fatalf("api.NewClient: %v", err)
 	}
 	scanner := sbomcpe.NewScanner(client, true, "test-tenant", 500, 60*time.Second, false).
-		WithPollInterval(10*time.Millisecond).
+		WithPollInterval(10 * time.Millisecond).
 		WithoutRawDownload()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/internal/scan/sbomcpe/sbomcpe_integration_test.go
+++ b/internal/scan/sbomcpe/sbomcpe_integration_test.go
@@ -1,0 +1,505 @@
+package sbomcpe_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ArmisSecurity/armis-cli/internal/api"
+	"github.com/ArmisSecurity/armis-cli/internal/model"
+	"github.com/ArmisSecurity/armis-cli/internal/scan/sbomcpe"
+	"github.com/ArmisSecurity/armis-cli/internal/testutil"
+)
+
+// TestIntegration_SbomCpeScanner_EndToEnd runs the full sbom-cpe scan flow
+// against a bespoke httptest.Server that impersonates:
+//
+//  1. POST /api/v1/ingest/presigned-url  → returns presigned S3 POST
+//  2. POST /_s3/upload                    → fake S3, accepts multipart upload
+//  3. POST /api/v1/ingest/scan            → confirms upload
+//  4. GET  /api/v1/ingest/status/…        → status polling (1 poll → COMPLETED)
+//  5. GET  /api/v1/ingest/normalized-results → returns 1 normalized finding
+//  6. GET  /api/v1/ingest/results         → returns sbom_cpe_results URL
+//  7. GET  /_s3/download                  → fake S3 raw JSON download
+//
+// The test asserts:
+//   - The scanner completes without error.
+//   - The presigned-url request carries artifact_type=sbom-cpe (contract w/ backend).
+//   - The final ScanResult contains the normalized finding.
+//   - The raw sbom-cpe JSON dump is written to the requested output path.
+//
+// This exercises every layer that will run in production except the actual
+// backend scan itself.
+func TestIntegration_SbomCpeScanner_EndToEnd(t *testing.T) {
+	// --- Fixture: real SBOM with a single component ------------------------
+	tmpDir := t.TempDir()
+	sbomPath := filepath.Join(tmpDir, "torizon-mini.cdx.json")
+	sbom := map[string]any{
+		"bomFormat":   "CycloneDX",
+		"specVersion": "1.4",
+		"metadata": map[string]any{
+			"component": map[string]any{"type": "application", "name": "torizon"},
+		},
+		"components": []map[string]any{
+			{
+				"type":    "library",
+				"name":    "OpenSSL",
+				"version": "1.0.2k",
+				"cpe":     "cpe:2.3:a:openssl:openssl:1.0.2k:*:*:*:*:*:*:*",
+			},
+		},
+	}
+	sbomBytes, err := json.Marshal(sbom)
+	if err != nil {
+		t.Fatalf("marshal sbom: %v", err)
+	}
+	if err := os.WriteFile(sbomPath, sbomBytes, 0600); err != nil {
+		t.Fatalf("write sbom: %v", err)
+	}
+
+	// The raw JSON dump the backend would upload to S3 for the CLI to fetch.
+	// Shape mirrors the CpeSbomScanner.scan() output shipped by PPSC-1136.
+	rawCpeJSON := []byte(`{
+		"packages": [{"file": "torizon-mini.cdx.json", "name": "OpenSSL", "version": "1.0.2k", "cpe": "cpe:2.3:a:openssl:openssl:1.0.2k:*:*:*:*:*:*:*", "low_confidence": false}],
+		"vulnerabilities": [{"file": "torizon-mini.cdx.json", "vulnerability_id": "CVE-2018-0732", "severity": "HIGH", "package": "OpenSSL", "version": "1.0.2k", "low_confidence": false}],
+		"vulnerability_count": 1,
+		"package_count": 1
+	}`)
+
+	// --- Mock server -------------------------------------------------------
+	const (
+		wantTenantID = "test-tenant"
+		wantScanID   = "sbom-cpe-scan-001"
+	)
+	var (
+		presignedCallCount    atomic.Int32
+		s3UploadCallCount     atomic.Int32
+		startScanCallCount    atomic.Int32
+		statusCallCount       atomic.Int32
+		normalizedCallCount   atomic.Int32
+		artifactResultsCount  atomic.Int32
+		rawDownloadCallCount  atomic.Int32
+		observedArtifactType  atomic.Value // string
+	)
+
+	finding := model.NormalizedFinding{
+		NormalizedTask: model.NormalizedTask{
+			FindingID: "finding-cpe-1",
+			ExtraData: model.ExtraData{
+				CodeLocation: model.CodeLocation{
+					FileName: strPtr("torizon-mini.cdx.json"),
+				},
+			},
+		},
+		NormalizedRemediation: model.NormalizedRemediation{
+			Description:  "Denial of service in OpenSSL 1.0.2k (CVE-2018-0732).",
+			ToolSeverity: "HIGH",
+			VulnerabilityTypeMetadata: model.VulnerabilityTypeMetadata{
+				CVEs: []string{"CVE-2018-0732"},
+				CWEs: []string{"CWE-400"},
+			},
+		},
+	}
+
+	var server *http.Server
+	server = testutil.NewMockScanServerWithConfig(t, testutil.MockAPIConfig{
+		ScanID:             wantScanID,
+		Findings:           []model.NormalizedFinding{finding},
+		PollsUntilComplete: 1,
+	})
+
+	// We can't easily override the shared mock's presigned-url handler to
+	// echo back the artifact_type, so we wrap it with a new server that
+	// intercepts the endpoints we care about and delegates the rest.
+	baseHandler := server.Handler
+	handler := http.NewServeMux()
+
+	// The bespoke handlers below cover the URLs whose behaviour differs
+	// from the shared mock: we need to (a) inspect the artifact_type on
+	// /presigned-url, (b) implement /ingest/results, (c) implement the raw
+	// download endpoint. Everything else falls through to the shared mock.
+	handler.HandleFunc("/api/v1/ingest/presigned-url", func(w http.ResponseWriter, r *http.Request) {
+		presignedCallCount.Add(1)
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req model.PresignedUploadRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("failed to decode presigned-url body: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		observedArtifactType.Store(req.ArtifactType)
+		scheme := testutil.SchemeFromRequest(r)
+		s3URL := scheme + "://" + r.Host + "/_s3/upload"
+		testutil.JSONResponse(t, w, http.StatusOK, model.PresignedUploadResponse{
+			ScanID:       wantScanID,
+			ArtifactType: req.ArtifactType,
+			TenantID:     wantTenantID,
+			PresignedURL: s3URL,
+			Fields: map[string]string{
+				"key":             "ingest/" + wantTenantID + "/" + wantScanID + "/upload.tar.gz",
+				"policy":          "test-policy",
+				"x-amz-signature": "test-sig",
+			},
+			MaxUploadBytes: 2 * 1024 * 1024 * 1024,
+			ExpiresIn:      1800,
+		})
+	})
+
+	handler.HandleFunc("/_s3/upload", func(w http.ResponseWriter, r *http.Request) {
+		s3UploadCallCount.Add(1)
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 64*1024*1024)
+		testutil.AssertValidS3Upload(t, r)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	handler.HandleFunc("/api/v1/ingest/scan", func(w http.ResponseWriter, r *http.Request) {
+		startScanCallCount.Add(1)
+		testutil.AssertHasAuthorization(t, r)
+		testutil.JSONResponse(t, w, http.StatusOK, model.IngestUploadResponse{
+			ScanID:       wantScanID,
+			ScanStatus:   "INITIATED",
+			ArtifactType: "sbom-cpe",
+			TenantID:     wantTenantID,
+			Filename:     "upload",
+			Message:      "Upload confirmed and scan initiated successfully",
+		})
+	})
+
+	handler.HandleFunc("/api/v1/ingest/status/", func(w http.ResponseWriter, r *http.Request) {
+		statusCallCount.Add(1)
+		testutil.AssertHasAuthorization(t, r)
+		testutil.JSONResponse(t, w, http.StatusOK, model.IngestStatusResponse{
+			Data: []model.IngestStatusData{{
+				ScanID:       wantScanID,
+				ScanStatus:   "COMPLETED",
+				TenantID:     wantTenantID,
+				ArtifactType: "sbom-cpe",
+				ScanType:     "custom",
+			}},
+		})
+	})
+
+	handler.HandleFunc("/api/v1/ingest/normalized-results", func(w http.ResponseWriter, r *http.Request) {
+		normalizedCallCount.Add(1)
+		testutil.AssertHasAuthorization(t, r)
+		testutil.JSONResponse(t, w, http.StatusOK, model.NormalizedResultsResponse{
+			Data: model.NormalizedResultsData{
+				TenantID: wantTenantID,
+				ScanResults: []model.ScanResultData{
+					{
+						ScanID:   wantScanID,
+						Findings: []model.NormalizedFinding{finding},
+					},
+				},
+			},
+			Pagination: model.Pagination{NextCursor: nil, Limit: 500},
+		})
+	})
+
+	handler.HandleFunc("/api/v1/ingest/results", func(w http.ResponseWriter, r *http.Request) {
+		artifactResultsCount.Add(1)
+		testutil.AssertHasAuthorization(t, r)
+		scheme := testutil.SchemeFromRequest(r)
+		rawURL := scheme + "://" + r.Host + "/_s3/download"
+		testutil.JSONResponse(t, w, http.StatusOK, map[string]any{
+			"scan_status": "COMPLETED",
+			// Key MUST match sbomcpe.ResultKeySBOMCPE (contract with backend).
+			"results": map[string]string{
+				sbomcpe.ResultKeySBOMCPE: rawURL,
+			},
+		})
+	})
+
+	handler.HandleFunc("/_s3/download", func(w http.ResponseWriter, r *http.Request) {
+		rawDownloadCallCount.Add(1)
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(rawCpeJSON)
+	})
+
+	// Fallback: hand anything unhandled to the shared mock so we still get
+	// coverage of any endpoint we forgot.
+	handler.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		baseHandler.ServeHTTP(w, r)
+	})
+
+	testSrv := testutil.NewTestServer(t, handler.ServeHTTP)
+	serverURL := testSrv.URL
+
+	// --- Client + scanner --------------------------------------------------
+	authProvider := testutil.NewTestAuthProvider("test-token")
+	client, err := api.NewClient(serverURL, authProvider, false, 30*time.Second, api.WithAllowLocalURLs(true))
+	if err != nil {
+		t.Fatalf("api.NewClient: %v", err)
+	}
+
+	rawOut := filepath.Join(tmpDir, "torizon-mini-sbom-cpe.json")
+	scanner := sbomcpe.NewScanner(client, true, wantTenantID, 500, 60*time.Second, false).
+		WithPollInterval(10*time.Millisecond).
+		WithRawOutput(rawOut)
+
+	// --- Run scan ----------------------------------------------------------
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := scanner.Scan(ctx, sbomPath)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if result == nil {
+		t.Fatal("nil result")
+	}
+
+	// --- Assertions --------------------------------------------------------
+	if got, _ := observedArtifactType.Load().(string); got != "sbom-cpe" {
+		t.Errorf("presigned-url received artifact_type=%q, want sbom-cpe", got)
+	}
+	if presignedCallCount.Load() != 1 {
+		t.Errorf("presigned-url call count = %d, want 1", presignedCallCount.Load())
+	}
+	if s3UploadCallCount.Load() != 1 {
+		t.Errorf("S3 upload call count = %d, want 1", s3UploadCallCount.Load())
+	}
+	if startScanCallCount.Load() != 1 {
+		t.Errorf("/ingest/scan call count = %d, want 1", startScanCallCount.Load())
+	}
+	if statusCallCount.Load() < 1 {
+		t.Errorf("/ingest/status call count = %d, want >=1", statusCallCount.Load())
+	}
+	if normalizedCallCount.Load() != 1 {
+		t.Errorf("/normalized-results call count = %d, want 1", normalizedCallCount.Load())
+	}
+	if artifactResultsCount.Load() != 1 {
+		t.Errorf("/ingest/results call count = %d, want 1", artifactResultsCount.Load())
+	}
+	if rawDownloadCallCount.Load() != 1 {
+		t.Errorf("raw-download call count = %d, want 1", rawDownloadCallCount.Load())
+	}
+
+	// Result should carry the finding through
+	if result.ScanID != wantScanID {
+		t.Errorf("ScanID = %q, want %q", result.ScanID, wantScanID)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(result.Findings))
+	}
+	if result.Findings[0].ID != "finding-cpe-1" {
+		t.Errorf("finding ID = %q, want finding-cpe-1", result.Findings[0].ID)
+	}
+
+	// Raw dump should exist on disk
+	data, err := os.ReadFile(rawOut)
+	if err != nil {
+		t.Fatalf("failed to read raw dump: %v", err)
+	}
+	if !bytes.Contains(data, []byte("CVE-2018-0732")) {
+		t.Errorf("raw dump missing expected CVE, got: %s", string(data))
+	}
+}
+
+// TestIntegration_SbomCpeScanner_TarballInput asserts the scanner accepts a
+// pre-built tar.gz verbatim (no re-packing).
+func TestIntegration_SbomCpeScanner_TarballInput(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Build a real tar.gz containing one SBOM entry.
+	sbomInside := `{"bomFormat":"CycloneDX","specVersion":"1.4","components":[{"type":"library","name":"OpenSSL","version":"1.0.2k","cpe":"cpe:2.3:a:openssl:openssl:1.0.2k:*:*:*:*:*:*:*"}]}`
+	tarballPath := filepath.Join(tmpDir, "inventory.tar.gz")
+	writeMinimalTarGz(t, tarballPath, "inventory.cdx.json", []byte(sbomInside))
+
+	handler := minimalMockHandler(t)
+	testSrv := testutil.NewTestServer(t, handler)
+	serverURL := testSrv.URL
+
+	authProvider := testutil.NewTestAuthProvider("test-token")
+	client, err := api.NewClient(serverURL, authProvider, false, 30*time.Second, api.WithAllowLocalURLs(true))
+	if err != nil {
+		t.Fatalf("api.NewClient: %v", err)
+	}
+	scanner := sbomcpe.NewScanner(client, true, "test-tenant", 500, 60*time.Second, false).
+		WithPollInterval(10*time.Millisecond).
+		WithoutRawDownload()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if _, err := scanner.Scan(ctx, tarballPath); err != nil {
+		t.Fatalf("Scan with prebuilt tarball failed: %v", err)
+	}
+}
+
+// TestIntegration_SbomCpeScanner_RejectsMissingSbom checks the fail-fast
+// behaviour when the input path does not exist.
+func TestIntegration_SbomCpeScanner_RejectsMissingSbom(t *testing.T) {
+	authProvider := testutil.NewTestAuthProvider("test-token")
+	// Base URL doesn't matter; we never reach the network.
+	client, err := api.NewClient("http://localhost:1", authProvider, false, 0, api.WithAllowLocalURLs(true))
+	if err != nil {
+		t.Fatalf("api.NewClient: %v", err)
+	}
+	scanner := sbomcpe.NewScanner(client, true, "test-tenant", 500, 60*time.Second, false)
+
+	_, err = scanner.Scan(context.Background(), "/no/such/file.json")
+	if err == nil {
+		t.Fatal("expected error for missing input path")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("expected 'does not exist' in error, got: %v", err)
+	}
+}
+
+// TestIntegration_SbomCpeScanner_RejectsWrongExtension verifies that a
+// single file with an unsupported extension is rejected before upload.
+func TestIntegration_SbomCpeScanner_RejectsWrongExtension(t *testing.T) {
+	tmpDir := t.TempDir()
+	badPath := filepath.Join(tmpDir, "notes.txt")
+	if err := os.WriteFile(badPath, []byte("not an sbom"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	authProvider := testutil.NewTestAuthProvider("test-token")
+	client, err := api.NewClient("http://localhost:1", authProvider, false, 0, api.WithAllowLocalURLs(true))
+	if err != nil {
+		t.Fatalf("api.NewClient: %v", err)
+	}
+	scanner := sbomcpe.NewScanner(client, true, "test-tenant", 500, 60*time.Second, false)
+
+	_, err = scanner.Scan(context.Background(), badPath)
+	if err == nil {
+		t.Fatal("expected error for wrong extension")
+	}
+	if !strings.Contains(err.Error(), "not allowed") {
+		t.Errorf("expected extension rejection message, got: %v", err)
+	}
+}
+
+// TestIntegration_SbomCpeScanner_EmptyDirRejected checks that a directory
+// with no SBOM-shaped files fails fast (pre-upload) rather than uploading
+// an empty tarball.
+func TestIntegration_SbomCpeScanner_EmptyDirRejected(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "README.md"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	authProvider := testutil.NewTestAuthProvider("test-token")
+	client, err := api.NewClient("http://localhost:1", authProvider, false, 0, api.WithAllowLocalURLs(true))
+	if err != nil {
+		t.Fatalf("api.NewClient: %v", err)
+	}
+	scanner := sbomcpe.NewScanner(client, true, "test-tenant", 500, 60*time.Second, false)
+
+	_, err = scanner.Scan(context.Background(), tmpDir)
+	if err == nil {
+		t.Fatal("expected error for directory with no SBOMs")
+	}
+	if !strings.Contains(err.Error(), "no SBOM files") {
+		t.Errorf("expected 'no SBOM files' error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func strPtr(s string) *string { return &s }
+
+// minimalMockHandler returns a handler that satisfies the sbom-cpe flow with
+// a single hard-coded scan_id, no findings, and no raw-download endpoint.
+// Used by tests that don't need to inspect the request payload.
+func minimalMockHandler(t *testing.T) http.HandlerFunc {
+	t.Helper()
+	const (
+		wantTenantID = "test-tenant"
+		wantScanID   = "tarball-scan-001"
+	)
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/api/v1/ingest/presigned-url"):
+			scheme := testutil.SchemeFromRequest(r)
+			testutil.JSONResponse(t, w, http.StatusOK, model.PresignedUploadResponse{
+				ScanID:       wantScanID,
+				ArtifactType: "sbom-cpe",
+				TenantID:     wantTenantID,
+				PresignedURL: scheme + "://" + r.Host + "/_s3/upload",
+				Fields: map[string]string{
+					"key":             "ingest/" + wantTenantID + "/" + wantScanID + "/upload.tar.gz",
+					"policy":          "test-policy",
+					"x-amz-signature": "test-sig",
+				},
+				MaxUploadBytes: 2 * 1024 * 1024 * 1024,
+				ExpiresIn:      1800,
+			})
+		case strings.HasPrefix(r.URL.Path, "/_s3/") && r.Method == http.MethodPost:
+			r.Body = http.MaxBytesReader(w, r.Body, 64*1024*1024)
+			testutil.AssertValidS3Upload(t, r)
+			w.WriteHeader(http.StatusNoContent)
+		case strings.Contains(r.URL.Path, "/api/v1/ingest/scan") && r.Method == http.MethodPost:
+			testutil.JSONResponse(t, w, http.StatusOK, model.IngestUploadResponse{
+				ScanID: wantScanID, ScanStatus: "INITIATED",
+				ArtifactType: "sbom-cpe", TenantID: wantTenantID,
+			})
+		case strings.Contains(r.URL.Path, "/api/v1/ingest/status"):
+			testutil.JSONResponse(t, w, http.StatusOK, model.IngestStatusResponse{
+				Data: []model.IngestStatusData{{
+					ScanID: wantScanID, ScanStatus: "COMPLETED",
+					TenantID: wantTenantID, ArtifactType: "sbom-cpe",
+				}},
+			})
+		case strings.Contains(r.URL.Path, "/api/v1/ingest/normalized-results"):
+			testutil.JSONResponse(t, w, http.StatusOK, model.NormalizedResultsResponse{
+				Data: model.NormalizedResultsData{
+					TenantID: wantTenantID,
+					ScanResults: []model.ScanResultData{
+						{ScanID: wantScanID, Findings: nil},
+					},
+				},
+				Pagination: model.Pagination{Limit: 500},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}
+}
+
+// writeMinimalTarGz builds a real tar.gz on disk with one entry, so we can
+// exercise the "prebuilt tarball forwarded verbatim" path without depending
+// on the driver's own packing.
+func writeMinimalTarGz(t *testing.T, path, name string, content []byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	// Reusing the driver's own single-file pack lets us skip re-implementing
+	// tar/gzip here — the packer is a small, well-tested unit and this
+	// integration test doesn't care about its internals.
+	src := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(src, content, 0600); err != nil {
+		t.Fatal(err)
+	}
+	// The driver's packSingleFile is unexported; call it via an exported
+	// helper. We add a tiny exported wrapper below.
+	if err := sbomcpe.PackForTest(src, f); err != nil {
+		t.Fatalf("PackForTest: %v", err)
+	}
+}

--- a/internal/scan/sbomcpe/sbomcpe_test.go
+++ b/internal/scan/sbomcpe/sbomcpe_test.go
@@ -4,12 +4,16 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/ArmisSecurity/armis-cli/internal/api"
 )
 
 // ---------------------------------------------------------------------------
@@ -214,33 +218,26 @@ func TestPackDir_SkipsSymlinks(t *testing.T) {
 // Retry classifier
 // ---------------------------------------------------------------------------
 
-type fakeErr struct{ msg string }
-
-func (f *fakeErr) Error() string { return f.msg }
-
 func TestIsRetryableError(t *testing.T) {
 	if isRetryableError(nil) {
 		t.Error("nil error should not be retryable")
 	}
-	for _, msg := range []string{
-		"connection refused",
-		"connection reset by peer",
-		"i/o timeout waiting for headers",
-		"unexpected EOF",
-		"temporary failure in name resolution",
-	} {
-		if !isRetryableError(&fakeErr{msg}) {
-			t.Errorf("expected retryable: %q", msg)
+	// 5xx from the API is transient; 4xx is not.
+	for _, code := range []int{500, 502, 503, 504} {
+		if !isRetryableError(&api.APIError{StatusCode: code, Body: "server hiccup"}) {
+			t.Errorf("expected retryable for status %d", code)
 		}
 	}
-	for _, msg := range []string{
-		"400 Bad Request",
-		"scan not found",
-		"invalid tarball",
-	} {
-		if isRetryableError(&fakeErr{msg}) {
-			t.Errorf("did not expect retryable: %q", msg)
+	for _, code := range []int{400, 401, 403, 404, 409, 422} {
+		if isRetryableError(&api.APIError{StatusCode: code, Body: "nope"}) {
+			t.Errorf("did not expect retryable for status %d", code)
 		}
+	}
+	if !isRetryableError(context.DeadlineExceeded) {
+		t.Error("context.DeadlineExceeded should be retryable")
+	}
+	if isRetryableError(errors.New("scan not found")) {
+		t.Error("plain non-API error should not be retryable")
 	}
 }
 

--- a/internal/scan/sbomcpe/sbomcpe_test.go
+++ b/internal/scan/sbomcpe/sbomcpe_test.go
@@ -101,7 +101,7 @@ func readTarGz(t *testing.T, buf *bytes.Buffer) []string {
 	if err != nil {
 		t.Fatalf("gzip.NewReader: %v", err)
 	}
-	defer gr.Close()
+	defer gr.Close() //nolint:errcheck
 
 	tr := tar.NewReader(gr)
 	var names []string

--- a/internal/scan/sbomcpe/sbomcpe_test.go
+++ b/internal/scan/sbomcpe/sbomcpe_test.go
@@ -1,0 +1,285 @@
+package sbomcpe
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Path/extension helpers
+// ---------------------------------------------------------------------------
+
+func TestIsPrebuiltTarball(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"foo.tar", true},
+		{"foo.tar.gz", true},
+		{"foo.tgz", true},
+		{"foo.TAR.GZ", true},
+		{"foo.TGZ", true},
+		{"foo.json", false},
+		{"foo.xml", false},
+		{"foo", false},
+	}
+	for _, c := range cases {
+		if got := isPrebuiltTarball(c.path); got != c.want {
+			t.Errorf("isPrebuiltTarball(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+func TestTrimTarSuffix(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"foo.tar.gz", "foo"},
+		{"bar.tgz", "bar"},
+		{"baz.tar", "baz"},
+		{"other.json", "other.json"},
+		{"nested.name.tar.gz", "nested.name"},
+	}
+	for _, c := range cases {
+		if got := trimTarSuffix(c.in); got != c.want {
+			t.Errorf("trimTarSuffix(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestTrimSbomExtension(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"torizon.json", "torizon"},
+		{"asset.xml", "asset"},
+		{"asset.JSON", "asset"},
+		{"noext", "noext"},
+		{"has.dots.json", "has.dots"},
+	}
+	for _, c := range cases {
+		if got := trimSbomExtension(c.in); got != c.want {
+			t.Errorf("trimSbomExtension(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestValidateSbomExtension(t *testing.T) {
+	// Happy paths
+	for _, p := range []string{"foo.json", "bar.xml", "PATH.JSON"} {
+		if err := validateSbomExtension(p); err != nil {
+			t.Errorf("validateSbomExtension(%q) unexpected error: %v", p, err)
+		}
+	}
+	// Rejections
+	for _, p := range []string{"foo.txt", "bar.zip", "baz", "qux.tar.gz"} {
+		if err := validateSbomExtension(p); err == nil {
+			t.Errorf("validateSbomExtension(%q): expected error, got nil", p)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tar packing
+// ---------------------------------------------------------------------------
+
+// readTarGz returns the list of tar-entry names inside a gzipped tar buffer.
+func readTarGz(t *testing.T, buf *bytes.Buffer) []string {
+	t.Helper()
+	gr, err := gzip.NewReader(buf)
+	if err != nil {
+		t.Fatalf("gzip.NewReader: %v", err)
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+	var names []string
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar.Next: %v", err)
+		}
+		names = append(names, hdr.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func TestPackSingleFile(t *testing.T) {
+	dir := t.TempDir()
+	sbomPath := filepath.Join(dir, "openssl.cdx.json")
+	if err := os.WriteFile(sbomPath, []byte(`{"components":[]}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := packSingleFile(sbomPath, &buf); err != nil {
+		t.Fatalf("packSingleFile: %v", err)
+	}
+	names := readTarGz(t, &buf)
+	if len(names) != 1 {
+		t.Fatalf("expected 1 tar entry, got %v", names)
+	}
+	if names[0] != "openssl.cdx.json" {
+		t.Errorf("expected entry name 'openssl.cdx.json', got %q", names[0])
+	}
+}
+
+func TestPackDir_PicksUpJsonAndXml(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.json"), []byte(`{}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.xml"), []byte(`<x/>`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	// Non-SBOM extension → skipped
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte(`ignore`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	// Nested dir with SBOM → picked up with relative path
+	nested := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(nested, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "c.json"), []byte(`{}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := packDir(dir, &buf); err != nil {
+		t.Fatalf("packDir: %v", err)
+	}
+	names := readTarGz(t, &buf)
+	// Order is deterministic after our sort in readTarGz.
+	want := []string{"a.json", "b.xml", "sub/c.json"}
+	if len(names) != len(want) {
+		t.Fatalf("expected %d entries, got %v", len(want), names)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Errorf("entry[%d] = %q, want %q", i, names[i], want[i])
+		}
+	}
+}
+
+func TestPackDir_ErrorsWhenNoSbomFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	err := packDir(dir, &buf)
+	if err == nil {
+		t.Fatal("expected error when no SBOM files present")
+	}
+	if !strings.Contains(err.Error(), "no SBOM files") {
+		t.Errorf("expected 'no SBOM files' in error, got: %v", err)
+	}
+}
+
+func TestPackDir_SkipsSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.json")
+	if err := os.WriteFile(target, []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link.json")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("cannot create symlink on this platform: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := packDir(dir, &buf); err != nil {
+		t.Fatalf("packDir: %v", err)
+	}
+	names := readTarGz(t, &buf)
+	// Symlink is excluded — only 'real.json' should appear.
+	if len(names) != 1 || names[0] != "real.json" {
+		t.Errorf("expected only real.json, got %v", names)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Retry classifier
+// ---------------------------------------------------------------------------
+
+type fakeErr struct{ msg string }
+
+func (f *fakeErr) Error() string { return f.msg }
+
+func TestIsRetryableError(t *testing.T) {
+	if isRetryableError(nil) {
+		t.Error("nil error should not be retryable")
+	}
+	for _, msg := range []string{
+		"connection refused",
+		"connection reset by peer",
+		"i/o timeout waiting for headers",
+		"unexpected EOF",
+		"temporary failure in name resolution",
+	} {
+		if !isRetryableError(&fakeErr{msg}) {
+			t.Errorf("expected retryable: %q", msg)
+		}
+	}
+	for _, msg := range []string{
+		"400 Bad Request",
+		"scan not found",
+		"invalid tarball",
+	} {
+		if isRetryableError(&fakeErr{msg}) {
+			t.Errorf("did not expect retryable: %q", msg)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scanner constructor + options
+// ---------------------------------------------------------------------------
+
+func TestNewScanner_DefaultDownloadRawIsTrue(t *testing.T) {
+	s := NewScanner(nil, false, "tenant", 10, 0, false)
+	if !s.downloadRaw {
+		t.Error("NewScanner should default downloadRaw=true")
+	}
+}
+
+func TestWithRawOutput_SetsField(t *testing.T) {
+	s := NewScanner(nil, false, "tenant", 10, 0, false).WithRawOutput("/tmp/out.json")
+	if s.rawOutput != "/tmp/out.json" {
+		t.Errorf("rawOutput = %q, want /tmp/out.json", s.rawOutput)
+	}
+}
+
+func TestWithoutRawDownload_DisablesFlag(t *testing.T) {
+	s := NewScanner(nil, false, "tenant", 10, 0, false).WithoutRawDownload()
+	if s.downloadRaw {
+		t.Error("WithoutRawDownload should set downloadRaw=false")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResultKeySBOMCPE constant is contract with the backend
+// ---------------------------------------------------------------------------
+
+func TestResultKeySBOMCPE_MatchesBackendContract(t *testing.T) {
+	// The backend (services/artifact-scanner/.../persist_results_task.py)
+	// writes results_refs["sbom_cpe_results"] = key when a CpeSbomScanner
+	// run completes. This test locks the client-side constant to that
+	// string so a rename on either side gets caught here.
+	if ResultKeySBOMCPE != "sbom_cpe_results" {
+		t.Errorf("ResultKeySBOMCPE = %q; backend contract expects %q",
+			ResultKeySBOMCPE, "sbom_cpe_results")
+	}
+}


### PR DESCRIPTION
## Related Issue

* [PPSC-1136](https://armis-security.atlassian.net/browse/PPSC-1136) (child of Epic [PPSC-337](https://armis-security.atlassian.net/browse/PPSC-337))
* Backend companion: [silk-security/Project-Moose#2415](https://github.com/silk-security/Project-Moose/pull/2415) — wires the `sbom-cpe` artifact type into artifact-scanner + ingest API.

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Refactoring (no functional changes)
* [ ] Performance improvement

## Problem

Users can't scan asset/inventory CycloneDX SBOMs — files where components are identified by **CPE strings** (host software/hardware inventories from tools like AIDA64) rather than by purl. The existing `scan repo` and `scan image` commands are purl-based via deps.dev; asset SBOMs return zero coverage there.

## Solution

Adds `armis-cli scan sbom-cpe <path>` — a new cobra subcommand that mirrors the `scan repo` / `scan image` shape but drives the backend's new `artifact_type=sbom-cpe` flow (PR silk-security/Project-Moose#2415).

The command accepts:
- A single CycloneDX SBOM file (`.json` or `.xml`)
- A directory of SBOM files (walked recursively; non-SBOM files silently skipped)
- A pre-built `.tar` / `.tar.gz` / `.tgz` (forwarded verbatim — no re-packing)

Flow:
1. Pack the input into a tar.gz on disk (symlinks skipped defensively, 100 MB size cap enforced before upload)
2. `StartIngest` via the standard split-flow (`/api/v1/ingest/presigned-url` → S3 → `/api/v1/ingest/scan`) with `ArtifactType="sbom-cpe"`
3. `WaitForIngest` polls status until `COMPLETED`
4. `FetchAllNormalizedResults` retrieves the findings (backend's `CpeSbomScanner` output flows through the standard normalizer path, so findings appear the same as any other scan)
5. Optionally downloads the raw per-CPE JSON dump from the new `sbom_cpe_results` S3 key — this contains component-level `low_confidence` flags and the full CVE list that isn't fully exposed via `MooseArtifactFindings`. Written to `.armis/<artifact>-sbom-cpe.json` by default; overridable via `--sbom-cpe-output`.

The `--sbom` and `--vex` flags are explicitly rejected on this command (the input already **is** an SBOM; SBOM→VEX generation belongs on the `scan sbom` command via PPSC-971).

Kobra-style purl-only SBOMs (npm/NuGet/pypi manifests) uploaded here are rejected server-side with a `SBOM_PURL_ONLY_NOT_SUPPORTED` sentinel finding pointing at the existing repo-scan flow — not silently returned as zero findings.

## Files added

- `internal/cmd/scan_sbom_cpe.go` — cobra command + flag validation
- `internal/cmd/scan_sbom_cpe_test.go` — 4 command-level tests (path validation, `--sbom`/`--vex` rejection, subcommand registration)
- `internal/scan/sbomcpe/sbomcpe.go` — scan driver, mirroring `internal/scan/image/image.go` / `internal/scan/repo/repo.go` structure. Includes a small `PackForTest` export shim so integration tests can build valid tar.gz payloads using the driver's own packing.
- `internal/scan/sbomcpe/sbomcpe_test.go` — 15 unit tests: extension helpers, tar packing (single file, directory with mixed extensions and nested subdirs, symlink skipping, empty-dir error), retry classifier, constructor options, `ResultKeySBOMCPE` backend-contract assertion.
- `internal/scan/sbomcpe/sbomcpe_integration_test.go` — 5 integration tests spinning up bespoke `httptest.Server` mocks that impersonate all 7 endpoints the CLI hits (presigned-url, fake S3 upload, ingest/scan, status polling, normalized-results, /ingest/results, raw JSON download).

## Testing

### Automated Tests

* [x] Unit tests added/updated (19 unit tests in `internal/scan/sbomcpe/` + `internal/cmd/`)
* [x] Integration tests added/updated (5 end-to-end tests with a full mock server)
* [x] All tests passing locally

**Suite results:**
- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all 22 test packages pass, including new `internal/scan/sbomcpe` and existing `internal/scan/image` / `internal/scan/repo`

### Manual Testing

**1. Mock-server end-to-end (Python `http.server`, checked-in `sbomcpe_integration_test.go` covers the same ground):**

```
ARMIS_API_URL=http://127.0.0.1:8765 \
  ARMIS_API_TOKEN=test-token \
  ARMIS_TENANT_ID=test-tenant \
  /tmp/armis-cli scan sbom-cpe torizon-os-bom.json \
    --format json --sbom-cpe-output /tmp/raw.json
```
Mock server log shows all 7 endpoints hit exactly once, in order. CLI stdout is well-formed JSON with the seeded CVE. `/tmp/raw.json` contains the per-CPE dump.

**2. Full backend E2E via `make dev`** (in the Project-Moose repo, PR #2415 branch):

Ran the same command against `http://localhost:8001` with a real 3-component SBOM (OpenSSL 1.0.2k, Log4j 2.14.1, curl 7.68.0). Result:

```
Scan status: COMPLETED
Findings: 94 (6 CRITICAL / 31 HIGH / 48 MEDIUM / 6 LOW / 3 UNKNOWN)
Includes: CVE-2021-44228 (Log4Shell), CVE-2022-32221 (curl), CVE-2018-0732 (OpenSSL)
Raw dump: ~/torizon-os-bom-sbom-cpe.json  (packages=3, vulnerabilities=94)
```

Same result whether the backend routes via the legacy SQS path or the Prefect flow (feature-flag toggled during testing to verify both).

**3. Failure paths (verified live):**
- Missing input path → `Error: path does not exist: /nonexistent.json`
- `--sbom` flag → `Error: --sbom is not supported for scan sbom-cpe (the input already is an SBOM)`
- `--vex` flag → `Error: --vex is not supported for scan sbom-cpe (use 'armis-cli scan sbom' for SBOM → VEX)`

## Reviewer Notes

- **`convertNormalizedFindings` / `isEmptyFinding` / `cleanDescription` are duplicated** from `internal/scan/image/image.go` and `internal/scan/repo/repo.go` verbatim. Both existing scanners already duplicate the trio; keeping the pattern here means no cross-package refactor and no risk of drift for PPSC-1136. If a future ticket lifts them into `internal/scan/`, all three call sites can switch over together — flagged in the code comment.
- **`ResultKeySBOMCPE = "sbom_cpe_results"`** is a contract with the backend. There's a dedicated test (`TestResultKeySBOMCPE_MatchesBackendContract`) that locks it against the backend-side string so a rename on either side fails loudly.
- **`PackForTest` export shim** in the driver is deliberately isolated (a single line calling `packSingleFile`). It exists so integration tests can produce valid tar.gz payloads without duplicating tar/gzip code in the test file — removing it doesn't change the production surface.
- **`WithAllowLocalURLs`** is auto-enabled by `clientOptionsForBaseURL` when the base URL is localhost (existing behaviour). No new SSRF-bypass surface added.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [ ] Documentation updated (if needed)
* [ ] Breaking changes documented (if applicable)
* [x] No new warnings generated

[PPSC-1136]: https://armis-security.atlassian.net/browse/PPSC-1136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PPSC-337]: https://armis-security.atlassian.net/browse/PPSC-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ