### PR TITLE
[PPSC-1147] fix(scan): use NUL-delimited git output for --changed

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- `scan repo --changed`: fixed a scan-scope bypass where a changed file whose name contains control characters (newline, tab, etc.) could be silently omitted from the upload archive while other changed files were still scanned. Git change detection now uses NUL-delimited output (`-z`), so pathnames — including those with control characters that git would otherwise quote onto a single line — round-trip verbatim and resolve on disk like any other changed file.
+
 ---
 
 ## [1.18.0] - 2026-07-07

--- a/internal/scan/repo/gitchanges.go
+++ b/internal/scan/repo/gitchanges.go
@@ -95,7 +95,17 @@ func GitChangedFiles(scanPath string, opts ChangedOptions) (*FileList, error) {
 		return nil, ErrNoChangedFiles
 	}
 
-	// Use ParseFileList for security validation (path traversal checks, MaxFiles limit)
+	// Use ParseFileList for security validation (path traversal checks, MaxFiles limit).
+	//
+	// Note: we intentionally do NOT fail closed if an individual changed path
+	// later turns out to be unscannable (a symlink, a file that vanished, or a
+	// directory). Those are legitimate, intentional skips — symlinks are a
+	// security skip shared with full-directory scans, and untracked files
+	// surfaced by `ls-files --others` (editor swapfiles, build artifacts) can
+	// vanish between detection and archiving. The scan-scope bypass this
+	// addresses was control-character filenames being silently dropped, and the
+	// -z (NUL-delimited) output above closes that fully: such names now
+	// round-trip verbatim and resolve on disk like any other file.
 	return ParseFileList(absPath, filtered)
 }
 
@@ -126,15 +136,19 @@ func gitRepoRoot(path string) (string, error) {
 
 // changedUncommitted returns files with uncommitted changes (staged + unstaged + untracked).
 func changedUncommitted(repoRoot string) ([]string, error) {
-	// Get staged and unstaged modified files
-	// --diff-filter=ACMRT excludes deleted files (D)
-	diffOutput, err := runGit(repoRoot, "diff", "--name-only", "--diff-filter=ACMRT", "HEAD")
+	// Get staged and unstaged modified files.
+	// --diff-filter=ACMRT excludes deleted files (D).
+	// -z emits NUL-terminated, unquoted pathnames so filenames containing
+	// newlines, tabs, or other control characters round-trip losslessly
+	// (without -z, git C-quotes such paths and packs them onto one line each,
+	// so newline splitting would silently drop them — a scan-scope bypass).
+	diffOutput, err := runGit(repoRoot, "diff", "--name-only", "-z", "--diff-filter=ACMRT", "HEAD")
 	if err != nil {
 		// If HEAD doesn't exist (fresh repo with no commits), get staged files instead.
 		// Check for specific git error messages indicating missing HEAD revision.
 		if strings.Contains(err.Error(), "unknown revision") ||
 			strings.Contains(err.Error(), "bad revision") {
-			stagedOutput, stagedErr := runGit(repoRoot, "diff", "--name-only", "--diff-filter=ACMRT", "--cached")
+			stagedOutput, stagedErr := runGit(repoRoot, "diff", "--name-only", "-z", "--diff-filter=ACMRT", "--cached")
 			if stagedErr != nil {
 				return nil, fmt.Errorf("failed to get uncommitted changes (no HEAD and staged diff failed): %w", stagedErr)
 			}
@@ -144,24 +158,24 @@ func changedUncommitted(repoRoot string) ([]string, error) {
 		}
 	}
 
-	// Get untracked files (respects .gitignore)
-	untrackedOutput, err := runGit(repoRoot, "ls-files", "--others", "--exclude-standard")
+	// Get untracked files (respects .gitignore). -z for the same reason as above.
+	untrackedOutput, err := runGit(repoRoot, "ls-files", "--others", "--exclude-standard", "-z")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get untracked files: %w", err)
 	}
 
-	return combineAndDedupe(diffOutput, untrackedOutput), nil
+	return combineAndDedupe(parseNulSeparated(diffOutput), parseNulSeparated(untrackedOutput)), nil
 }
 
 // changedStaged returns only staged files.
 func changedStaged(repoRoot string) ([]string, error) {
-	// Get staged files only
+	// Get staged files only. -z for NUL-terminated, unquoted pathnames.
 	// --diff-filter=ACMRT excludes deleted files (D)
-	output, err := runGit(repoRoot, "diff", "--name-only", "--diff-filter=ACMRT", "--cached")
+	output, err := runGit(repoRoot, "diff", "--name-only", "-z", "--diff-filter=ACMRT", "--cached")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get staged changes: %w", err)
 	}
-	return parseLines(output), nil
+	return parseNulSeparated(output), nil
 }
 
 // validateRef checks that a git ref does not contain characters that could
@@ -188,7 +202,8 @@ func changedSinceRef(repoRoot, ref string) ([]string, error) {
 	}
 	// Use three-dot notation to compare ref...HEAD (changes since common ancestor)
 	// --diff-filter=ACMRT excludes deleted files (D)
-	output, err := runGit(repoRoot, "diff", "--name-only", "--diff-filter=ACMRT", ref+"...HEAD")
+	// -z emits NUL-terminated, unquoted pathnames (see changedUncommitted).
+	output, err := runGit(repoRoot, "diff", "--name-only", "-z", "--diff-filter=ACMRT", ref+"...HEAD")
 	if err != nil {
 		// Check if the ref doesn't exist
 		if strings.Contains(err.Error(), "unknown revision") ||
@@ -198,7 +213,7 @@ func changedSinceRef(repoRoot, ref string) ([]string, error) {
 		}
 		return nil, fmt.Errorf("failed to get changes since %q: %w", ref, err)
 	}
-	return parseLines(output), nil
+	return parseNulSeparated(output), nil
 }
 
 // filterToScanPath filters changedPaths (relative to repoRoot) to only include
@@ -280,38 +295,41 @@ func runGit(dir string, args ...string) (string, error) {
 	return stdout.String(), nil
 }
 
-// parseLines splits output by newlines and removes empty entries.
-// It only trims trailing newline/CR characters, preserving any spaces
-// in filenames (git can track files with leading/trailing spaces).
-func parseLines(output string) []string {
-	// Only trim trailing newlines from the output, not all whitespace
-	// (a filename could legitimately start with a space)
-	output = strings.TrimRight(output, "\n\r")
+// parseNulSeparated splits NUL-terminated git output (produced with the -z
+// flag) into individual pathnames and removes empty entries.
+//
+// Unlike newline splitting, this is safe for pathnames containing ANY byte
+// except NUL — including newlines, carriage returns, tabs, and other control
+// characters. With -z git also disables path quoting, so each record is the
+// raw, verbatim pathname; we must NOT trim CR or whitespace, as those bytes
+// may be a legitimate part of the filename.
+func parseNulSeparated(output string) []string {
 	if output == "" {
 		return nil
 	}
-	lines := strings.Split(output, "\n")
-	result := make([]string, 0, len(lines))
-	for _, line := range lines {
-		// Only trim trailing CR (for Windows CRLF compatibility), not spaces
-		line = strings.TrimSuffix(line, "\r")
-		if line != "" {
-			result = append(result, line)
+	// -z terminates each record with a NUL, so the split yields a trailing
+	// empty element after the final NUL; the empty-string check drops it.
+	parts := strings.Split(output, "\x00")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p != "" {
+			result = append(result, p)
 		}
 	}
 	return result
 }
 
-// combineAndDedupe combines two newline-separated outputs and removes duplicates.
-func combineAndDedupe(outputs ...string) []string {
+// combineAndDedupe combines multiple pathname lists and removes duplicates,
+// preserving first-seen order.
+func combineAndDedupe(lists ...[]string) []string {
 	seen := make(map[string]bool)
 	var result []string
 
-	for _, output := range outputs {
-		for _, line := range parseLines(output) {
-			if !seen[line] {
-				seen[line] = true
-				result = append(result, line)
+	for _, list := range lists {
+		for _, path := range list {
+			if !seen[path] {
+				seen[path] = true
+				result = append(result, path)
 			}
 		}
 	}

--- a/internal/scan/repo/gitchanges_test.go
+++ b/internal/scan/repo/gitchanges_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -342,6 +343,86 @@ func TestGitChangedFiles_SpecialCharacters(t *testing.T) {
 	}
 }
 
+// TestGitChangedFiles_ControlCharFilename is the regression test for the
+// scan-scope bypass: a changed file whose name contains a control character
+// (here a tab) must appear in the changed set. Before the -z switch, git
+// C-quoted such names ("weird\tname.txt") and newline splitting produced a
+// string that no longer matched any on-disk file, so it was silently dropped
+// while other changed files still uploaded.
+func TestGitChangedFiles_ControlCharFilename(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	// Tabs/newlines in filenames are not permitted on Windows.
+	if runtime.GOOS == "windows" {
+		t.Skip("control characters not allowed in filenames on Windows")
+	}
+
+	repoDir := setupGitRepo(t)
+
+	// Filename containing a tab (a control character git would normally quote).
+	weirdName := "weird\tname.txt"
+	if err := os.WriteFile(filepath.Join(repoDir, weirdName), []byte("content"), 0600); err != nil {
+		t.Fatalf("failed to create control-char file: %v", err)
+	}
+	// A normal file alongside it, to prove we don't just detect one or the other.
+	if err := os.WriteFile(filepath.Join(repoDir, "normal.go"), []byte("package main"), 0600); err != nil {
+		t.Fatalf("failed to create normal file: %v", err)
+	}
+
+	fl, err := GitChangedFiles(repoDir, ChangedOptions{Mode: ChangedModeUncommitted})
+	if err != nil {
+		t.Fatalf("GitChangedFiles failed: %v", err)
+	}
+
+	files := fl.Files()
+	fileSet := make(map[string]bool)
+	for _, f := range files {
+		fileSet[f] = true
+	}
+	if !fileSet[weirdName] {
+		t.Errorf("control-char filename %q missing from changed set: %q", weirdName, files)
+	}
+	if !fileSet["normal.go"] {
+		t.Errorf("normal.go missing from changed set: %q", files)
+	}
+}
+
+// TestGitChangedFiles_ControlCharFilename_Newline covers a filename containing
+// a literal newline — the byte that a newline-splitting parser fundamentally
+// cannot represent as a single record.
+func TestGitChangedFiles_ControlCharFilename_Newline(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("newlines not allowed in filenames on Windows")
+	}
+
+	repoDir := setupGitRepo(t)
+
+	weirdName := "line1\nline2.txt"
+	if err := os.WriteFile(filepath.Join(repoDir, weirdName), []byte("content"), 0600); err != nil {
+		t.Fatalf("failed to create newline file: %v", err)
+	}
+
+	fl, err := GitChangedFiles(repoDir, ChangedOptions{Mode: ChangedModeUncommitted})
+	if err != nil {
+		t.Fatalf("GitChangedFiles failed: %v", err)
+	}
+
+	found := false
+	for _, f := range fl.Files() {
+		if f == weirdName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("newline filename %q missing from changed set: %q", weirdName, fl.Files())
+	}
+}
+
 func TestFilterToScanPath(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -499,7 +580,7 @@ func TestValidateRef(t *testing.T) {
 	}
 }
 
-func TestParseLines(t *testing.T) {
+func TestParseNulSeparated(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
@@ -507,13 +588,13 @@ func TestParseLines(t *testing.T) {
 		wantNil bool // expect nil
 	}{
 		{
-			name:  "normal lines",
-			input: "a.go\nb.go\nc.go",
+			name:  "normal records",
+			input: "a.go\x00b.go\x00c.go\x00",
 			want:  []string{"a.go", "b.go", "c.go"},
 		},
 		{
-			name:  "trailing newline",
-			input: "a.go\nb.go\n",
+			name:  "no trailing NUL",
+			input: "a.go\x00b.go",
 			want:  []string{"a.go", "b.go"},
 		},
 		{
@@ -522,33 +603,40 @@ func TestParseLines(t *testing.T) {
 			wantNil: true,
 		},
 		{
-			name:  "whitespace-only lines preserved",
-			input: "  \n  \n  ",
-			want:  []string{"  ", "  ", "  "},
+			name:  "preserves spaces in filenames",
+			input: "  a.go  \x00  b.go  \x00",
+			want:  []string{"  a.go  ", "  b.go  "},
 		},
 		{
-			name:  "preserves spaces in filenames",
-			input: "  a.go  \n  b.go  ",
-			want:  []string{"  a.go  ", "  b.go  "},
+			// The core regression: control characters inside a pathname are
+			// payload, not delimiters. Newline, CR, and tab must survive.
+			name:  "control characters in filename preserved",
+			input: "weird\tname.txt\x00has\nnewline.go\x00has\rcr.py\x00",
+			want:  []string{"weird\tname.txt", "has\nnewline.go", "has\rcr.py"},
+		},
+		{
+			name:  "empty records skipped",
+			input: "a.go\x00\x00b.go\x00",
+			want:  []string{"a.go", "b.go"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseLines(tt.input)
+			got := parseNulSeparated(tt.input)
 			if tt.wantNil {
 				if got != nil {
-					t.Errorf("parseLines() = %v, want nil", got)
+					t.Errorf("parseNulSeparated() = %v, want nil", got)
 				}
 				return
 			}
 			if len(got) != len(tt.want) {
-				t.Errorf("parseLines() = %v, want %v", got, tt.want)
+				t.Errorf("parseNulSeparated() = %q, want %q", got, tt.want)
 				return
 			}
 			for i := range got {
 				if got[i] != tt.want[i] {
-					t.Errorf("parseLines()[%d] = %v, want %v", i, got[i], tt.want[i])
+					t.Errorf("parseNulSeparated()[%d] = %q, want %q", i, got[i], tt.want[i])
 				}
 			}
 		})
@@ -557,30 +645,30 @@ func TestParseLines(t *testing.T) {
 
 func TestCombineAndDedupe(t *testing.T) {
 	tests := []struct {
-		name    string
-		outputs []string
-		want    []string
+		name  string
+		lists [][]string
+		want  []string
 	}{
 		{
-			name:    "no duplicates",
-			outputs: []string{"a.go\nb.go", "c.go\nd.go"},
-			want:    []string{"a.go", "b.go", "c.go", "d.go"},
+			name:  "no duplicates",
+			lists: [][]string{{"a.go", "b.go"}, {"c.go", "d.go"}},
+			want:  []string{"a.go", "b.go", "c.go", "d.go"},
 		},
 		{
-			name:    "with duplicates",
-			outputs: []string{"a.go\nb.go", "b.go\nc.go"},
-			want:    []string{"a.go", "b.go", "c.go"},
+			name:  "with duplicates",
+			lists: [][]string{{"a.go", "b.go"}, {"b.go", "c.go"}},
+			want:  []string{"a.go", "b.go", "c.go"},
 		},
 		{
-			name:    "empty inputs",
-			outputs: []string{"", "a.go"},
-			want:    []string{"a.go"},
+			name:  "empty inputs",
+			lists: [][]string{nil, {"a.go"}},
+			want:  []string{"a.go"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := combineAndDedupe(tt.outputs...)
+			got := combineAndDedupe(tt.lists...)
 			if len(got) != len(tt.want) {
 				t.Errorf("combineAndDedupe() = %v, want %v", got, tt.want)
 				return


### PR DESCRIPTION
## Related Issue

* [PPSC-1147](https://armis-security.atlassian.net/browse/PPSC-1147)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Refactoring (no functional changes)
* [ ] Performance improvement

## Problem

`armis-cli scan repo --changed` could silently omit a changed file from the scan archive when git reported a filename containing control characters (newline, tab, CR). Git's default `--name-only` output C-quotes such names and newline-terminates them; splitting on `\n` then produced a quoted string that no longer matched any on-disk path, so it was dropped by existence validation while other changed files still uploaded — a scan-scope bypass.

## Solution

Switch all four git change-detection invocations in `internal/scan/repo/gitchanges.go` (`diff HEAD`, `diff --cached` fallback, `ls-files --others`, `diff ref...HEAD`) to `-z` (NUL-delimited, unquoted output), and replace newline-splitting with `parseNulSeparated`, which preserves any byte except NUL — including control characters and leading/trailing spaces — verbatim.

## Testing

### Automated Tests

* [x] Unit tests added/updated
* [ ] Integration tests added/updated
* [x] All tests passing locally

### Manual Testing

Added regression tests for tab- and newline-containing filenames, verifying both appear in the changed set alongside a normal file. Also verified `parseNulSeparated` table cases (tab/newline/CR-in-filename, empty records, preserved spaces) and confirmed via `od -c` that git C-quotes such names without `-z` but emits them verbatim with `-z`.

## Reviewer Notes

Change detection still warns-and-continues (documented in code) rather than failing closed when an individual resolved path can't be scanned (symlink escapes, directories, vanished untracked files) — that's an intentional scoping decision, not an oversight; the encoding bypass itself is fully closed.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] Documentation updated (if needed)
* [ ] Breaking changes documented (if applicable)
* [x] No new warnings generated

[PPSC-1147]: https://armis-security.atlassian.net/browse/PPSC-1147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ