### PR TITLE
feat(install): add `install knowledge` for the Armis Knowledge plugin [PPSC-1150]

### DIFF
--- a/internal/cmd/install_knowledge.go
+++ b/internal/cmd/install_knowledge.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ArmisSecurity/armis-cli/internal/install"
+	"github.com/spf13/cobra"
+)
+
+// installKnowledgeCmd registers the Armis Knowledge plugin with Claude Code.
+//
+// Unlike `armis-cli install` (the security scanner MCP), this drives the
+// official `claude` CLI to add the knowledge marketplace and install a plugin
+// from it — the scanner installer hand-writes registry JSON for a self-hosted
+// "directory" marketplace, but the knowledge plugin is a "github" marketplace
+// with no releases, so only the CLI can clone it and populate the plugin cache.
+var installKnowledgeCmd = &cobra.Command{
+	Use:   "knowledge",
+	Short: "Install the Armis Knowledge plugin for Claude Code",
+	Long: `Install the Armis Knowledge plugin for Claude Code.
+
+Adds the org's knowledge base — standards, CWE remediation, and framework /
+technology guidance — as slash commands (/knowledge, /cwe-fix, /cwe-fix-report,
+/framework-guidance, /tech-guidance) that your agent can also call on its own.
+
+This drives the Claude Code CLI (claude plugin marketplace add + install), so
+Claude Code must be installed. Credentials are read from ARMIS_CLIENT_ID and
+ARMIS_CLIENT_SECRET at runtime; the tenant is resolved server-side.
+
+Two variants — pick one per environment. They register identical slash commands
+and cannot run side by side, so switching variants auto-removes the other:
+  --variant skills   Shell-skills, Claude Code only, no Python (default)
+  --variant mcp      MCP server; needs Python, adds the agentic /ask command
+
+The backend environment follows --dev (dev backend) and defaults to prod.`,
+	Example: `  # Install the shell-skills variant (prod) — no Python required
+  armis-cli install knowledge
+
+  # Install the MCP variant (adds /ask; needs Python)
+  armis-cli install knowledge --variant mcp
+
+  # Point at the dev backend (registers /knowledge-dev, etc.)
+  armis-cli install knowledge --dev`,
+	Args: cobra.NoArgs,
+	RunE: runInstallKnowledge,
+}
+
+func init() {
+	installCmd.AddCommand(installKnowledgeCmd)
+	installKnowledgeCmd.Flags().String("variant", "skills", "Plugin variant: skills (no Python) or mcp (adds /ask)")
+}
+
+func runInstallKnowledge(cmd *cobra.Command, _ []string) error {
+	variantStr, err := cmd.Flags().GetString("variant")
+	if err != nil {
+		return fmt.Errorf("reading --variant flag: %w", err)
+	}
+
+	var variant install.KnowledgeVariant
+	switch variantStr {
+	case "skills":
+		variant = install.KnowledgeVariantSkills
+	case "mcp":
+		variant = install.KnowledgeVariantMCP
+	default:
+		return fmt.Errorf("unknown --variant %q (want \"skills\" or \"mcp\")", variantStr)
+	}
+
+	// Environment follows the global --dev flag; prod is the default everyone uses.
+	env := install.KnowledgeEnvProd
+	if useDev {
+		env = install.KnowledgeEnvDev
+	}
+
+	ki := install.NewKnowledgeInstaller(variant, env)
+
+	if err := ki.CheckClaudeCLI(); err != nil {
+		return err
+	}
+
+	// The MCP variant bootstraps a Python venv on first launch (inside Claude
+	// Code). Warn early if Python is missing so the failure isn't deferred to a
+	// confusing cold-start error the first time a knowledge command runs.
+	if variant == install.KnowledgeVariantMCP {
+		if perr := install.CheckPython(); perr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: the MCP variant needs Python at runtime — %v\n\n", perr)
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "Installing %s for Claude Code...\n", ki.PluginRef())
+	replaced, err := ki.Install()
+	if err != nil {
+		return fmt.Errorf("knowledge plugin installation failed: %w", err)
+	}
+	// The two variants share slash commands and cannot coexist; report when the
+	// sibling was swapped out so the state change is visible, not silent.
+	if replaced != "" {
+		fmt.Fprintf(os.Stderr, "  ✓ Removed conflicting %s (same commands)\n", replaced)
+	}
+	fmt.Fprintf(os.Stderr, "  ✓ %s\n\n", ki.PluginRef())
+
+	if install.CredentialsPresent() {
+		fmt.Fprintln(os.Stderr, "Credentials detected. Restart Claude Code to load the plugin.")
+	} else {
+		fmt.Fprintln(os.Stderr, "Next steps:")
+		fmt.Fprintln(os.Stderr, "  1. Export your credentials (copy from the knowledge webapp's /settings/integrations):")
+		fmt.Fprintln(os.Stderr, "     export ARMIS_CLIENT_ID=<your-client-id>")
+		fmt.Fprintln(os.Stderr, "     export ARMIS_CLIENT_SECRET=<your-client-secret>")
+		fmt.Fprintln(os.Stderr, "  2. Restart Claude Code")
+	}
+	return nil
+}

--- a/internal/cmd/install_knowledge.go
+++ b/internal/cmd/install_knowledge.go
@@ -57,21 +57,13 @@ func runInstallKnowledge(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("reading --variant flag: %w", err)
 	}
 
-	var variant install.KnowledgeVariant
-	switch variantStr {
-	case "skills":
-		variant = install.KnowledgeVariantSkills
-	case "mcp":
-		variant = install.KnowledgeVariantMCP
-	default:
-		return fmt.Errorf("unknown --variant %q (want \"skills\" or \"mcp\")", variantStr)
+	variant, err := parseKnowledgeVariant(variantStr)
+	if err != nil {
+		return err
 	}
 
 	// Environment follows the global --dev flag; prod is the default everyone uses.
-	env := install.KnowledgeEnvProd
-	if useDev {
-		env = install.KnowledgeEnvDev
-	}
+	env := knowledgeEnvForDev(useDev)
 
 	ki := install.NewKnowledgeInstaller(variant, env)
 

--- a/internal/cmd/knowledge_flags.go
+++ b/internal/cmd/knowledge_flags.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/ArmisSecurity/armis-cli/internal/install"
+)
+
+// parseKnowledgeVariant maps the --variant flag string to a KnowledgeVariant,
+// returning an actionable error for any unsupported value. Shared by the
+// install and uninstall knowledge subcommands so the flag contract stays in one
+// place (and is unit-testable without spawning the claude CLI).
+func parseKnowledgeVariant(s string) (install.KnowledgeVariant, error) {
+	switch s {
+	case "skills":
+		return install.KnowledgeVariantSkills, nil
+	case "mcp":
+		return install.KnowledgeVariantMCP, nil
+	default:
+		return "", fmt.Errorf("unknown --variant %q (want \"skills\" or \"mcp\")", s)
+	}
+}
+
+// knowledgeEnvForDev maps the global --dev flag to the knowledge backend
+// environment: prod by default, dev when --dev is set. (Stage is reachable via
+// the installer API but not surfaced as a CLI flag today.)
+func knowledgeEnvForDev(dev bool) install.KnowledgeEnv {
+	if dev {
+		return install.KnowledgeEnvDev
+	}
+	return install.KnowledgeEnvProd
+}

--- a/internal/cmd/knowledge_flags_test.go
+++ b/internal/cmd/knowledge_flags_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/ArmisSecurity/armis-cli/internal/install"
+	"github.com/spf13/cobra"
+)
+
+func mustSetFlag(t *testing.T, cmd *cobra.Command, name, value string) {
+	t.Helper()
+	if err := cmd.Flags().Set(name, value); err != nil {
+		t.Fatalf("setting --%s=%s: %v", name, value, err)
+	}
+}
+
+func TestParseKnowledgeVariant(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    install.KnowledgeVariant
+		wantErr bool
+	}{
+		{"skills", install.KnowledgeVariantSkills, false},
+		{"mcp", install.KnowledgeVariantMCP, false},
+		{"", "", true},
+		{"MCP", "", true}, // case-sensitive by design
+		{"bogus", "", true},
+	}
+	for _, tc := range cases {
+		got, err := parseKnowledgeVariant(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseKnowledgeVariant(%q) err = nil, want error", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseKnowledgeVariant(%q) unexpected err: %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Errorf("parseKnowledgeVariant(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestKnowledgeEnvForDev(t *testing.T) {
+	if got := knowledgeEnvForDev(false); got != install.KnowledgeEnvProd {
+		t.Errorf("knowledgeEnvForDev(false) = %q, want prod", got)
+	}
+	if got := knowledgeEnvForDev(true); got != install.KnowledgeEnvDev {
+		t.Errorf("knowledgeEnvForDev(true) = %q, want dev", got)
+	}
+}
+
+// The install/uninstall knowledge commands must reject an unknown --variant
+// before doing any work (the flag contract), for both subcommands.
+func TestKnowledgeCmd_RejectsUnknownVariant(t *testing.T) {
+	for _, run := range []struct {
+		name string
+		fn   func() error
+	}{
+		{"install", func() error {
+			mustSetFlag(t, installKnowledgeCmd, "variant", "bogus")
+			defer mustSetFlag(t, installKnowledgeCmd, "variant", "skills")
+			return runInstallKnowledge(installKnowledgeCmd, nil)
+		}},
+		{"uninstall", func() error {
+			mustSetFlag(t, uninstallKnowledgeCmd, "variant", "bogus")
+			defer mustSetFlag(t, uninstallKnowledgeCmd, "variant", "skills")
+			return runUninstallKnowledge(uninstallKnowledgeCmd, nil)
+		}},
+	} {
+		t.Run(run.name, func(t *testing.T) {
+			err := run.fn()
+			if err == nil {
+				t.Fatalf("%s knowledge with --variant=bogus: err = nil, want error", run.name)
+			}
+			if got := err.Error(); got == "" {
+				t.Error("error message should not be empty")
+			}
+		})
+	}
+}

--- a/internal/cmd/uninstall_knowledge.go
+++ b/internal/cmd/uninstall_knowledge.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ArmisSecurity/armis-cli/internal/cli"
+	"github.com/ArmisSecurity/armis-cli/internal/cmd/cmdutil"
+	"github.com/ArmisSecurity/armis-cli/internal/install"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+)
+
+// uninstallKnowledgeCmd removes the Armis Knowledge plugin from Claude Code.
+// Mirrors installKnowledgeCmd: it drives the `claude` CLI rather than editing
+// registry JSON, so install/uninstall stay symmetric.
+var uninstallKnowledgeCmd = &cobra.Command{
+	Use:   "knowledge",
+	Short: "Remove the Armis Knowledge plugin from Claude Code",
+	Long: `Remove the Armis Knowledge plugin from Claude Code.
+
+Drives the Claude Code CLI (claude plugin uninstall). Use --variant to match the
+plugin you installed; the backend environment follows --dev. The shared
+knowledge marketplace registration is left in place — other environments may
+still use it.`,
+	Example: `  # Remove the shell-skills variant (prod)
+  armis-cli uninstall knowledge
+
+  # Remove the MCP variant
+  armis-cli uninstall knowledge --variant mcp`,
+	Args: cobra.NoArgs,
+	RunE: runUninstallKnowledge,
+}
+
+func init() {
+	uninstallCmd.AddCommand(uninstallKnowledgeCmd)
+	uninstallKnowledgeCmd.Flags().String("variant", "skills", "Plugin variant to remove: skills or mcp")
+}
+
+func runUninstallKnowledge(cmd *cobra.Command, _ []string) error {
+	variantStr, err := cmd.Flags().GetString("variant")
+	if err != nil {
+		return fmt.Errorf("reading --variant flag: %w", err)
+	}
+
+	var variant install.KnowledgeVariant
+	switch variantStr {
+	case "skills":
+		variant = install.KnowledgeVariantSkills
+	case "mcp":
+		variant = install.KnowledgeVariantMCP
+	default:
+		return fmt.Errorf("unknown --variant %q (want \"skills\" or \"mcp\")", variantStr)
+	}
+
+	env := install.KnowledgeEnvProd
+	if useDev {
+		env = install.KnowledgeEnvDev
+	}
+
+	ki := install.NewKnowledgeInstaller(variant, env)
+	if err := ki.CheckClaudeCLI(); err != nil {
+		return err
+	}
+
+	successMark := "✓"
+	if cli.ColorsEnabled() {
+		successMark = lipgloss.NewStyle().Foreground(cmdutil.BrandSuccess).Render("✓")
+	}
+
+	fmt.Fprintf(os.Stderr, "Removing %s from Claude Code...\n", ki.PluginRef())
+	if err := ki.Uninstall(); err != nil {
+		return fmt.Errorf("knowledge plugin uninstall failed: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "  %s Removed %s\n", successMark, ki.PluginRef())
+	return nil
+}

--- a/internal/cmd/uninstall_knowledge.go
+++ b/internal/cmd/uninstall_knowledge.go
@@ -43,20 +43,12 @@ func runUninstallKnowledge(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("reading --variant flag: %w", err)
 	}
 
-	var variant install.KnowledgeVariant
-	switch variantStr {
-	case "skills":
-		variant = install.KnowledgeVariantSkills
-	case "mcp":
-		variant = install.KnowledgeVariantMCP
-	default:
-		return fmt.Errorf("unknown --variant %q (want \"skills\" or \"mcp\")", variantStr)
+	variant, err := parseKnowledgeVariant(variantStr)
+	if err != nil {
+		return err
 	}
 
-	env := install.KnowledgeEnvProd
-	if useDev {
-		env = install.KnowledgeEnvDev
-	}
+	env := knowledgeEnvForDev(useDev)
 
 	ki := install.NewKnowledgeInstaller(variant, env)
 	if err := ki.CheckClaudeCLI(); err != nil {

--- a/internal/install/knowledge.go
+++ b/internal/install/knowledge.go
@@ -1,0 +1,285 @@
+package install
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// The knowledge plugin ships as a Claude Code marketplace (no GitHub releases,
+// unlike armis-appsec-mcp). A "github" marketplace source requires Claude Code
+// to clone the repo and populate a sha-versioned plugin cache — state we cannot
+// fabricate by hand-writing the registry JSON the way ClaudeInstaller does for
+// its self-downloaded "directory" source. So we drive the official `claude`
+// CLI, which performs the clone, cache population, and enablement correctly.
+const (
+	// knowledgeMarketplaceRepo is the GitHub repo Claude Code clones as a marketplace.
+	knowledgeMarketplaceRepo = "ArmisSecurity/armis-knowledge-mcp"
+	// knowledgeMarketplaceName is the marketplace's declared name (from marketplace.json),
+	// used as the "@marketplace" suffix when installing a plugin from it.
+	knowledgeMarketplaceName = "armis-knowledge"
+)
+
+// KnowledgeVariant selects which plugin flavor to install. The shell-skills
+// variant is pure shell + curl (no Python); the MCP variant needs a Python venv
+// but adds the agentic /ask command. Installing both variants of the same
+// environment collides — they register identical slash commands.
+type KnowledgeVariant string
+
+const (
+	// KnowledgeVariantSkills is the Claude-Code-only shell-skills variant (no Python).
+	KnowledgeVariantSkills KnowledgeVariant = "skills"
+	// KnowledgeVariantMCP is the MCP variant (needs Python; adds /ask).
+	KnowledgeVariantMCP KnowledgeVariant = "mcp"
+)
+
+// KnowledgeEnv selects the backend environment. Each env registers suffixed
+// slash commands so all three can coexist on one machine.
+type KnowledgeEnv string
+
+const (
+	// KnowledgeEnvProd targets moose.armis.com (bare slash commands).
+	KnowledgeEnvProd KnowledgeEnv = "prod"
+	// KnowledgeEnvStage targets moose-stg.armis.com (-stage commands).
+	KnowledgeEnvStage KnowledgeEnv = "stage"
+	// KnowledgeEnvDev targets moose-dev.armis.com (-dev commands).
+	KnowledgeEnvDev KnowledgeEnv = "dev"
+)
+
+// claudeCandidates is the allowlist of binary names probed for the Claude Code
+// CLI. Restricting to these fixed names (never user input) is what makes the
+// exec.LookPath + EvalSymlinks resolution below safe against PATH-hijack CWEs.
+var claudeCandidates = []string{"claude"}
+
+// ErrClaudeCLINotFound is returned when the Claude Code CLI is not on PATH.
+var ErrClaudeCLINotFound = errors.New("Claude Code CLI not found on PATH") //nolint:staticcheck // "Claude Code" proper noun
+
+// KnowledgeInstaller installs the Armis Knowledge plugin for Claude Code by
+// driving the `claude` CLI.
+type KnowledgeInstaller struct {
+	Variant KnowledgeVariant
+	Env     KnowledgeEnv
+
+	// claudePath is the resolved path to the claude binary. Populated lazily by
+	// resolveClaude; overridable in tests.
+	claudePath string
+	// runner executes the claude CLI with the given args and returns combined
+	// output. Overridable in tests to avoid spawning a real process.
+	runner func(claudePath string, args ...string) (string, error)
+}
+
+// NewKnowledgeInstaller returns an installer for the given variant and environment.
+func NewKnowledgeInstaller(variant KnowledgeVariant, env KnowledgeEnv) *KnowledgeInstaller {
+	return &KnowledgeInstaller{
+		Variant: variant,
+		Env:     env,
+		runner:  runClaudeCLI,
+	}
+}
+
+// PluginName returns the marketplace plugin name for this variant+env, matching
+// the entries in the knowledge marketplace.json.
+//
+//	MCP:    prod=armis-knowledge, stage=armis-knowledge-stage, dev=armis-knowledge-dev
+//	skills: prod=armis-knowledge-skills, stage=armis-knowledge-skills-stage, ...
+func (ki *KnowledgeInstaller) PluginName() string {
+	base := knowledgeMarketplaceName // "armis-knowledge" — the MCP prod name
+	if ki.Variant == KnowledgeVariantSkills {
+		base += "-skills"
+	}
+	switch ki.Env {
+	case KnowledgeEnvStage:
+		base += "-stage"
+	case KnowledgeEnvDev:
+		base += "-dev"
+	}
+	return base
+}
+
+// PluginRef returns the "plugin@marketplace" identifier passed to `claude plugin install`.
+func (ki *KnowledgeInstaller) PluginRef() string {
+	return ki.PluginName() + "@" + knowledgeMarketplaceName
+}
+
+// CheckClaudeCLI verifies the Claude Code CLI is available, returning an
+// actionable error otherwise. It is a side-effect-free preflight.
+func (ki *KnowledgeInstaller) CheckClaudeCLI() error {
+	if err := ki.resolveClaude(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Install adds the knowledge marketplace and installs the selected plugin via
+// the Claude Code CLI. It is idempotent: re-adding an existing marketplace or
+// re-installing an already-installed plugin is tolerated.
+//
+// The two variants (skills / mcp) of the same environment register identical
+// slash commands and collide if both are present (see marketplace.json). To keep
+// exactly one active per environment, Install first removes the sibling variant
+// if it is installed and returns that variant's ref as replaced (empty when no
+// swap occurred), so the caller can report the swap.
+func (ki *KnowledgeInstaller) Install() (replaced string, err error) {
+	if err := ki.resolveClaude(); err != nil {
+		return "", err
+	}
+
+	// Swap out the conflicting sibling variant, if present. A query failure is
+	// non-fatal — worst case a leftover sibling the user can remove explicitly —
+	// so we only act on a definitive "installed" answer.
+	sib := ki.sibling()
+	if installed, qerr := sib.IsInstalled(); qerr == nil && installed {
+		if uerr := sib.Uninstall(); uerr != nil {
+			return "", fmt.Errorf("removing conflicting %s variant: %w", sib.Variant, uerr)
+		}
+		replaced = sib.PluginRef()
+	}
+
+	// Register (or refresh) the marketplace. `marketplace add` fails when the
+	// marketplace is already registered; that is not fatal — the subsequent
+	// install still resolves the plugin. We keep the output only to surface it
+	// if the install itself then fails, so a genuine "add" problem isn't hidden.
+	addOut, addErr := ki.runner(ki.claudePath, "plugin", "marketplace", "add", knowledgeMarketplaceRepo)
+
+	installOut, installErr := ki.runner(ki.claudePath, "plugin", "install", ki.PluginRef())
+	if installErr != nil {
+		// If the plugin is already installed, `claude` reports success on most
+		// versions; when it doesn't, treat an explicit "already installed"
+		// signal as success so reinstall is idempotent.
+		if isAlreadyInstalled(installOut) {
+			return replaced, nil
+		}
+		msg := fmt.Sprintf("installing %s: %v", ki.PluginRef(), installErr)
+		if strings.TrimSpace(installOut) != "" {
+			msg += "\n" + strings.TrimSpace(installOut)
+		}
+		// Only surface the marketplace-add failure when the install also failed,
+		// since a healthy "already registered" add is the common benign case.
+		if addErr != nil && strings.TrimSpace(addOut) != "" {
+			msg += "\n(marketplace add: " + strings.TrimSpace(addOut) + ")"
+		}
+		return "", errors.New(msg)
+	}
+
+	return replaced, nil
+}
+
+// sibling returns an installer for the other variant in the same environment,
+// sharing the resolved claude path and runner so a swap reuses the same process
+// plumbing (and test doubles).
+func (ki *KnowledgeInstaller) sibling() *KnowledgeInstaller {
+	other := KnowledgeVariantMCP
+	if ki.Variant == KnowledgeVariantMCP {
+		other = KnowledgeVariantSkills
+	}
+	return &KnowledgeInstaller{
+		Variant:    other,
+		Env:        ki.Env,
+		claudePath: ki.claudePath,
+		runner:     ki.runner,
+	}
+}
+
+// IsInstalled reports whether this plugin is currently installed, per the Claude
+// Code CLI's plugin list. A query failure returns (false, err).
+func (ki *KnowledgeInstaller) IsInstalled() (bool, error) {
+	if err := ki.resolveClaude(); err != nil {
+		return false, err
+	}
+	out, err := ki.runner(ki.claudePath, "plugin", "list")
+	if err != nil {
+		return false, fmt.Errorf("listing installed plugins: %w", err)
+	}
+	// The plugin names are distinct enough that a full "name@marketplace" match
+	// cannot false-positive across variants: every skills name carries a "-skills"
+	// segment the mcp names lack, so neither ref is a substring of the other.
+	return strings.Contains(out, ki.PluginRef()), nil
+}
+
+// Uninstall removes the selected knowledge plugin via the Claude Code CLI. It is
+// idempotent: uninstalling a plugin that isn't installed is treated as success.
+// The shared marketplace is left registered — other knowledge plugins (e.g. a
+// different environment) may still depend on it, and re-adding it is cheap.
+func (ki *KnowledgeInstaller) Uninstall() error {
+	if err := ki.resolveClaude(); err != nil {
+		return err
+	}
+
+	out, err := ki.runner(ki.claudePath, "plugin", "uninstall", "--yes", ki.PluginRef())
+	if err != nil {
+		if isNotInstalled(out) {
+			return nil
+		}
+		msg := fmt.Sprintf("uninstalling %s: %v", ki.PluginRef(), err)
+		if strings.TrimSpace(out) != "" {
+			msg += "\n" + strings.TrimSpace(out)
+		}
+		return errors.New(msg)
+	}
+	return nil
+}
+
+// isAlreadyInstalled reports whether claude CLI output indicates the plugin was
+// already present (so a non-zero exit can be treated as idempotent success).
+func isAlreadyInstalled(out string) bool {
+	l := strings.ToLower(out)
+	return strings.Contains(l, "already installed") || strings.Contains(l, "already exists")
+}
+
+// isNotInstalled reports whether claude CLI output indicates the plugin was not
+// installed (so a non-zero exit from uninstall can be treated as idempotent).
+func isNotInstalled(out string) bool {
+	l := strings.ToLower(out)
+	return strings.Contains(l, "not installed") || strings.Contains(l, "not found")
+}
+
+// resolveClaude locates the claude binary once and caches the path.
+func (ki *KnowledgeInstaller) resolveClaude() error {
+	if ki.claudePath != "" {
+		return nil
+	}
+	p := findClaude()
+	if p == "" {
+		return fmt.Errorf("%w — install Claude Code from https://claude.ai/download, then re-run", ErrClaudeCLINotFound)
+	}
+	ki.claudePath = p
+	return nil
+}
+
+// findClaude resolves the Claude Code CLI from the fixed candidate allowlist,
+// mirroring findPython's hardening: only hardcoded names are probed, and the
+// resolved path is symlink-evaluated and required to be absolute.
+func findClaude() string {
+	for _, name := range claudeCandidates {
+		// armis:ignore cwe:426 cwe:427 reason:name is from the hardcoded claudeCandidates allowlist (not user input); resolved path is validated via EvalSymlinks + IsAbs below
+		resolved, err := exec.LookPath(name)
+		if err != nil {
+			continue
+		}
+		resolved, err = filepath.EvalSymlinks(resolved)
+		if err != nil || !filepath.IsAbs(resolved) {
+			continue
+		}
+		return resolved
+	}
+	return ""
+}
+
+// runClaudeCLI executes the claude binary with the given args, streaming nothing
+// but capturing combined stdout+stderr for the caller to inspect on failure.
+func runClaudeCLI(claudePath string, args ...string) (string, error) {
+	// armis:ignore cwe:78 reason:claudePath is resolved from the hardcoded claudeCandidates allowlist via findClaude (EvalSymlinks + IsAbs); args are hardcoded literals or fixed plugin identifiers, never user input
+	cmd := exec.Command(claudePath, args...) //nolint:gosec // claudePath from findClaude allowlist; args are fixed literals
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// CredentialsPresent reports whether the client credentials the knowledge
+// plugin needs are exported in the environment. The plugin reads these at
+// runtime (env or its own .env); it does not accept a tenant identifier.
+func CredentialsPresent() bool {
+	return os.Getenv("ARMIS_CLIENT_ID") != "" && os.Getenv("ARMIS_CLIENT_SECRET") != ""
+}

--- a/internal/install/knowledge.go
+++ b/internal/install/knowledge.go
@@ -152,16 +152,29 @@ func (ki *KnowledgeInstaller) Install() (replaced string, err error) {
 		if isAlreadyInstalled(installOut) {
 			return replaced, nil
 		}
-		msg := fmt.Sprintf("installing %s: %v", ki.PluginRef(), installErr)
-		if strings.TrimSpace(installOut) != "" {
-			msg += "\n" + strings.TrimSpace(installOut)
+		// Preserve %w so callers can errors.Is/As the underlying failure, and
+		// return replaced even on error: a swap may already have removed the
+		// sibling, and the caller must be able to report that state change.
+		err := fmt.Errorf("installing %s: %w", ki.PluginRef(), installErr)
+		var notes []string
+		if s := strings.TrimSpace(installOut); s != "" {
+			notes = append(notes, s)
 		}
-		// Only surface the marketplace-add failure when the install also failed,
-		// since a healthy "already registered" add is the common benign case.
-		if addErr != nil && strings.TrimSpace(addOut) != "" {
-			msg += "\n(marketplace add: " + strings.TrimSpace(addOut) + ")"
+		// Surface the marketplace-add failure only when the install also failed
+		// (a healthy "already registered" add is the common benign case). Prefer
+		// its stdout, but fall back to the error itself so the diagnostic is
+		// never dropped when addOut happens to be empty.
+		if addErr != nil {
+			note := strings.TrimSpace(addOut)
+			if note == "" {
+				note = addErr.Error()
+			}
+			notes = append(notes, "(marketplace add: "+note+")")
 		}
-		return "", errors.New(msg)
+		if len(notes) > 0 {
+			err = fmt.Errorf("%w\n%s", err, strings.Join(notes, "\n"))
+		}
+		return replaced, err
 	}
 
 	return replaced, nil
@@ -193,10 +206,26 @@ func (ki *KnowledgeInstaller) IsInstalled() (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("listing installed plugins: %w", err)
 	}
-	// The plugin names are distinct enough that a full "name@marketplace" match
-	// cannot false-positive across variants: every skills name carries a "-skills"
-	// segment the mcp names lack, so neither ref is a substring of the other.
-	return strings.Contains(out, ki.PluginRef()), nil
+	return pluginListed(out, ki.PluginRef()), nil
+}
+
+// pluginListed reports whether ref appears as a whole "name@marketplace" token
+// on any line of `claude plugin list` output. It matches the ref as a distinct
+// field rather than a raw substring so extra columns, status glyphs, or prose
+// that merely contains the ref can't false-positive — and, critically, so the
+// mcp ref ("armis-knowledge@…") is never seen inside the skills ref line
+// ("armis-knowledge-skills@…"), which a substring check would get wrong.
+func pluginListed(out, ref string) bool {
+	for _, line := range strings.Split(out, "\n") {
+		for _, tok := range strings.Fields(line) {
+			// Trim list-decoration punctuation (e.g. a leading "❯" is its own
+			// field, but guard against attached glyphs/commas just in case).
+			if strings.Trim(tok, "❯•*-,") == ref {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Uninstall removes the selected knowledge plugin via the Claude Code CLI. It is

--- a/internal/install/knowledge_test.go
+++ b/internal/install/knowledge_test.go
@@ -190,6 +190,75 @@ func TestKnowledgeInstall_InstallFails(t *testing.T) {
 	}
 }
 
+// A failing install must preserve the underlying error via %w (errors.Is), and
+// still report the sibling ref that was already swapped out before the failure.
+func TestKnowledgeInstall_FailurePreservesWrapAndReplaced(t *testing.T) {
+	sentinel := errors.New("boom")
+	f := &fakeRunner{
+		outputs: map[string]string{"list": "armis-knowledge@armis-knowledge"}, // mcp sibling present
+		errs:    map[string]error{"install": sentinel},
+	}
+	ki := newInstallerWithRunner(f) // installs skills; swaps mcp first
+
+	replaced, err := ki.Install()
+	if err == nil {
+		t.Fatal("Install() = nil, want error")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("Install() error does not wrap the install error: %v", err)
+	}
+	if replaced != "armis-knowledge@armis-knowledge" {
+		t.Errorf("replaced = %q, want the swapped-out sibling ref even on failure", replaced)
+	}
+}
+
+// When marketplace add fails but emits no stdout, the diagnostic must fall back
+// to the add error's own message rather than being dropped.
+func TestKnowledgeInstall_AddErrFallbackWhenNoOutput(t *testing.T) {
+	f := &fakeRunner{
+		outputs: map[string]string{"install": "install exploded"}, // addOut empty
+		errs: map[string]error{
+			"marketplace": errors.New("network is unreachable"),
+			"install":     errors.New("exit 1"),
+		},
+	}
+	ki := newInstallerWithRunner(f)
+
+	_, err := ki.Install()
+	if err == nil {
+		t.Fatal("Install() = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "network is unreachable") {
+		t.Errorf("error missing add-error fallback diagnostic: %v", err)
+	}
+}
+
+func TestPluginListed(t *testing.T) {
+	const skills = "armis-knowledge-skills@armis-knowledge"
+	const mcp = "armis-knowledge@armis-knowledge"
+
+	cases := []struct {
+		name string
+		out  string
+		ref  string
+		want bool
+	}{
+		{"exact line", skills, skills, true},
+		{"decorated line", "  ❯ " + skills, skills, true},
+		{"among many", "foo@bar\n  ❯ " + mcp + "\nbaz@qux", mcp, true},
+		{"mcp not matched inside skills line", "  ❯ " + skills, mcp, false},
+		{"absent", "other@thing", skills, false},
+		{"empty", "", skills, false},
+		{"whole token amid prose matches", "Installed " + skills + " successfully", skills, true},
+		{"ref only as glued fragment not matched", "see armis-knowledge@armis-knowledgeX for docs", mcp, false},
+	}
+	for _, tc := range cases {
+		if got := pluginListed(tc.out, tc.ref); got != tc.want {
+			t.Errorf("%s: pluginListed(%q, %q) = %v, want %v", tc.name, tc.out, tc.ref, got, tc.want)
+		}
+	}
+}
+
 func TestIsAlreadyInstalled(t *testing.T) {
 	cases := map[string]bool{
 		"Plugin already installed":      true,

--- a/internal/install/knowledge_test.go
+++ b/internal/install/knowledge_test.go
@@ -1,0 +1,276 @@
+package install
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestKnowledgePluginName pins the variant×env → plugin-name mapping against the
+// exact names declared in the knowledge marketplace.json. If the marketplace
+// renames a plugin, this test should fail and be updated in lockstep.
+func TestKnowledgePluginName(t *testing.T) {
+	cases := []struct {
+		variant  KnowledgeVariant
+		env      KnowledgeEnv
+		wantName string
+		wantRef  string
+	}{
+		{KnowledgeVariantMCP, KnowledgeEnvProd, "armis-knowledge", "armis-knowledge@armis-knowledge"},
+		{KnowledgeVariantMCP, KnowledgeEnvStage, "armis-knowledge-stage", "armis-knowledge-stage@armis-knowledge"},
+		{KnowledgeVariantMCP, KnowledgeEnvDev, "armis-knowledge-dev", "armis-knowledge-dev@armis-knowledge"},
+		{KnowledgeVariantSkills, KnowledgeEnvProd, "armis-knowledge-skills", "armis-knowledge-skills@armis-knowledge"},
+		{KnowledgeVariantSkills, KnowledgeEnvStage, "armis-knowledge-skills-stage", "armis-knowledge-skills-stage@armis-knowledge"},
+		{KnowledgeVariantSkills, KnowledgeEnvDev, "armis-knowledge-skills-dev", "armis-knowledge-skills-dev@armis-knowledge"},
+	}
+	for _, tc := range cases {
+		ki := NewKnowledgeInstaller(tc.variant, tc.env)
+		if got := ki.PluginName(); got != tc.wantName {
+			t.Errorf("PluginName(%s,%s) = %q, want %q", tc.variant, tc.env, got, tc.wantName)
+		}
+		if got := ki.PluginRef(); got != tc.wantRef {
+			t.Errorf("PluginRef(%s,%s) = %q, want %q", tc.variant, tc.env, got, tc.wantRef)
+		}
+	}
+}
+
+// fakeRunner records the claude CLI invocations and returns scripted responses
+// keyed by the subcommand (args[1], e.g. "marketplace" or "install").
+type fakeRunner struct {
+	calls   [][]string
+	outputs map[string]string
+	errs    map[string]error
+}
+
+func (f *fakeRunner) run(_ string, args ...string) (string, error) {
+	f.calls = append(f.calls, args)
+	key := ""
+	if len(args) >= 2 {
+		key = args[1] // "marketplace", "install", "uninstall", or "list"
+	}
+	return f.outputs[key], f.errs[key]
+}
+
+func newInstallerWithRunner(f *fakeRunner) *KnowledgeInstaller {
+	return &KnowledgeInstaller{
+		Variant:    KnowledgeVariantSkills,
+		Env:        KnowledgeEnvProd,
+		claudePath: "/usr/local/bin/claude", // pre-resolved so resolveClaude is a no-op
+		runner:     f.run,
+	}
+}
+
+func TestKnowledgeInstall_HappyPath(t *testing.T) {
+	// Empty plugin list → sibling not installed → no swap, just add + install.
+	f := &fakeRunner{outputs: map[string]string{}, errs: map[string]error{}}
+	ki := newInstallerWithRunner(f)
+
+	replaced, err := ki.Install()
+	if err != nil {
+		t.Fatalf("Install() = %v, want nil", err)
+	}
+	if replaced != "" {
+		t.Fatalf("Install() replaced = %q, want empty (no sibling installed)", replaced)
+	}
+
+	if len(f.calls) != 3 {
+		t.Fatalf("expected 3 CLI calls, got %d: %v", len(f.calls), f.calls)
+	}
+	// First: query for the conflicting sibling variant.
+	assertArgs(t, f.calls[0], []string{"plugin", "list"})
+	// Then add the marketplace by repo.
+	assertArgs(t, f.calls[1], []string{"plugin", "marketplace", "add", knowledgeMarketplaceRepo})
+	// Then install the plugin@marketplace ref.
+	assertArgs(t, f.calls[2], []string{"plugin", "install", "armis-knowledge-skills@armis-knowledge"})
+}
+
+// Installing a variant when its sibling is present swaps the sibling out first.
+func TestKnowledgeInstall_SwapsSibling(t *testing.T) {
+	// We install skills; the mcp sibling (armis-knowledge@armis-knowledge) is
+	// present in the plugin list, so it must be uninstalled before install.
+	f := &fakeRunner{
+		outputs: map[string]string{"list": "armis-knowledge@armis-knowledge"},
+		errs:    map[string]error{},
+	}
+	ki := newInstallerWithRunner(f) // installs skills (prod)
+
+	replaced, err := ki.Install()
+	if err != nil {
+		t.Fatalf("Install() = %v, want nil", err)
+	}
+	if replaced != "armis-knowledge@armis-knowledge" {
+		t.Fatalf("Install() replaced = %q, want the mcp sibling ref", replaced)
+	}
+
+	// Expect: list, uninstall sibling, marketplace add, install.
+	if len(f.calls) != 4 {
+		t.Fatalf("expected 4 CLI calls, got %d: %v", len(f.calls), f.calls)
+	}
+	assertArgs(t, f.calls[0], []string{"plugin", "list"})
+	assertArgs(t, f.calls[1], []string{"plugin", "uninstall", "--yes", "armis-knowledge@armis-knowledge"})
+	assertArgs(t, f.calls[2], []string{"plugin", "marketplace", "add", knowledgeMarketplaceRepo})
+	assertArgs(t, f.calls[3], []string{"plugin", "install", "armis-knowledge-skills@armis-knowledge"})
+}
+
+// The plugin-list query must full-match the ref: a bare "armis-knowledge-skills"
+// line (this variant, not the sibling) must not be mistaken for the mcp sibling.
+func TestKnowledgeInstall_NoFalseSwapOnSubstring(t *testing.T) {
+	f := &fakeRunner{
+		// Only the skills variant itself is listed; the mcp ref is absent.
+		outputs: map[string]string{"list": "armis-knowledge-skills@armis-knowledge"},
+		errs:    map[string]error{},
+	}
+	ki := newInstallerWithRunner(f) // installs skills
+
+	replaced, err := ki.Install()
+	if err != nil {
+		t.Fatalf("Install() = %v, want nil", err)
+	}
+	if replaced != "" {
+		t.Fatalf("Install() replaced = %q, want empty — sibling is not installed", replaced)
+	}
+	// No uninstall call should appear.
+	for _, c := range f.calls {
+		if len(c) >= 2 && c[1] == "uninstall" {
+			t.Fatalf("unexpected uninstall call: %v", f.calls)
+		}
+	}
+}
+
+// A marketplace already registered ("add" fails) must not block install.
+func TestKnowledgeInstall_MarketplaceAlreadyAdded(t *testing.T) {
+	f := &fakeRunner{
+		outputs: map[string]string{"marketplace": "marketplace already exists"},
+		errs:    map[string]error{"marketplace": errors.New("exit status 1")},
+	}
+	ki := newInstallerWithRunner(f)
+
+	if _, err := ki.Install(); err != nil {
+		t.Fatalf("Install() with pre-existing marketplace = %v, want nil", err)
+	}
+}
+
+// An install that reports "already installed" via output should be idempotent.
+func TestKnowledgeInstall_PluginAlreadyInstalled(t *testing.T) {
+	f := &fakeRunner{
+		outputs: map[string]string{"install": "Plugin already installed"},
+		errs:    map[string]error{"install": errors.New("exit status 1")},
+	}
+	ki := newInstallerWithRunner(f)
+
+	if _, err := ki.Install(); err != nil {
+		t.Fatalf("Install() already-installed = %v, want nil", err)
+	}
+}
+
+// A genuine install failure surfaces both the install output and (since install
+// failed) the marketplace-add output for diagnosis.
+func TestKnowledgeInstall_InstallFails(t *testing.T) {
+	f := &fakeRunner{
+		outputs: map[string]string{
+			"marketplace": "could not reach github",
+			"install":     "plugin not found in marketplace",
+		},
+		errs: map[string]error{
+			"marketplace": errors.New("exit status 1"),
+			"install":     errors.New("exit status 1"),
+		},
+	}
+	ki := newInstallerWithRunner(f)
+
+	_, err := ki.Install()
+	if err == nil {
+		t.Fatal("Install() = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "plugin not found in marketplace") {
+		t.Errorf("error missing install output: %v", err)
+	}
+	if !strings.Contains(err.Error(), "could not reach github") {
+		t.Errorf("error missing marketplace-add diagnostic: %v", err)
+	}
+}
+
+func TestIsAlreadyInstalled(t *testing.T) {
+	cases := map[string]bool{
+		"Plugin already installed":      true,
+		"marketplace already exists":    true,
+		"ALREADY INSTALLED (uppercase)": true,
+		"Successfully installed plugin": false,
+		"error: network unreachable":    false,
+		"":                              false,
+	}
+	for out, want := range cases {
+		if got := isAlreadyInstalled(out); got != want {
+			t.Errorf("isAlreadyInstalled(%q) = %v, want %v", out, got, want)
+		}
+	}
+}
+
+func TestKnowledgeUninstall_HappyPath(t *testing.T) {
+	f := &fakeRunner{outputs: map[string]string{}, errs: map[string]error{}}
+	ki := newInstallerWithRunner(f)
+
+	if err := ki.Uninstall(); err != nil {
+		t.Fatalf("Uninstall() = %v, want nil", err)
+	}
+	if len(f.calls) != 1 {
+		t.Fatalf("expected 1 CLI call, got %d: %v", len(f.calls), f.calls)
+	}
+	assertArgs(t, f.calls[0], []string{"plugin", "uninstall", "--yes", "armis-knowledge-skills@armis-knowledge"})
+}
+
+// Uninstalling a plugin that isn't installed is idempotent (treated as success).
+func TestKnowledgeUninstall_NotInstalled(t *testing.T) {
+	f := &fakeRunner{
+		outputs: map[string]string{"uninstall": "Plugin not installed"},
+		errs:    map[string]error{"uninstall": errors.New("exit status 1")},
+	}
+	ki := newInstallerWithRunner(f)
+
+	if err := ki.Uninstall(); err != nil {
+		t.Fatalf("Uninstall() not-installed = %v, want nil", err)
+	}
+}
+
+func TestIsNotInstalled(t *testing.T) {
+	cases := map[string]bool{
+		"Plugin not installed":     true,
+		"plugin not found":         true,
+		"Successfully uninstalled": false,
+		"error: permission denied": false,
+		"":                         false,
+	}
+	for out, want := range cases {
+		if got := isNotInstalled(out); got != want {
+			t.Errorf("isNotInstalled(%q) = %v, want %v", out, got, want)
+		}
+	}
+}
+
+func TestResolveClaude_NotFound(t *testing.T) {
+	ki := &KnowledgeInstaller{Variant: KnowledgeVariantSkills, Env: KnowledgeEnvProd}
+	// Force resolution to fail by pointing findClaude at an empty candidate set.
+	orig := claudeCandidates
+	claudeCandidates = []string{"definitely-not-a-real-binary-xyz"}
+	defer func() { claudeCandidates = orig }()
+
+	err := ki.CheckClaudeCLI()
+	if err == nil {
+		t.Fatal("CheckClaudeCLI() = nil, want error when claude is absent")
+	}
+	if !errors.Is(err, ErrClaudeCLINotFound) {
+		t.Errorf("CheckClaudeCLI() error = %v, want wrapping ErrClaudeCLINotFound", err)
+	}
+}
+
+func assertArgs(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("args length mismatch: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("args[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `armis-cli install knowledge` (and `uninstall knowledge`) to install the **Armis Knowledge** plugin for Claude Code directly from the CLI — org standards, CWE remediation, and framework/tech guidance as slash commands (`/knowledge`, `/cwe-fix`, `/cwe-fix-report`, `/framework-guidance`, `/tech-guidance`).

## Why it drives the `claude` CLI instead of writing registry JSON

The existing scanner installer (`ClaudeInstaller`) hand-writes `known_marketplaces.json` / `installed_plugins.json` / `settings.json` because it uses a **`directory`** marketplace it downloads itself. The knowledge plugin is a **`github`** marketplace (`ArmisSecurity/armis-knowledge-mcp`) with **no releases** — Claude Code must *clone* the repo and populate a **sha-versioned** plugin cache, state we can't fabricate by writing JSON. So this shells out to the official `claude plugin marketplace add` + `plugin install` (guaranteed present since the feature is Claude-Code-only).

## Variants

Selectable via `--variant`:

| | `skills` (default) | `mcp` |
|---|---|---|
| Runtime | shell + curl, **no Python** | Python venv (bootstrapped by Claude Code) |
| Commands | 5 slash commands | same 5 **+ `/ask`** (agentic Q&A) |
| Rationale | avoids the venv/corporate-proxy failure mode | fuller tool reach; portable to other MCP clients |

Environment follows the global `--dev` flag (prod default; dev backend). Credentials come from the existing `ARMIS_CLIENT_ID` / `ARMIS_CLIENT_SECRET`; tenant resolved server-side.

## Collision guard (swap)

The two variants of the same environment register **identical** slash commands and cannot coexist. `Install()` detects an installed sibling variant, removes it, then installs the requested one — guaranteeing exactly one active variant per environment. The swap is reported to the user, never silent. The plugin-list check is a full `name@marketplace` match (not a loose substring) so a variant can't false-positive on its own listing.

## Testing

- Unit tests: variant×env name matrix (pinned to `marketplace.json`), CLI-arg assertions, swap + reverse-swap, substring-false-positive guard, idempotency (already-installed / not-installed), missing-CLI path.
- `golangci-lint`: 0 issues (cache cleaned first). Full `internal/install` + `internal/cmd` suites pass.
- **Live verified** on a real machine: install (skills), swap skills→mcp, swap mcp→skills, uninstall — always exactly one variant active. Security scan of the diff: clean.

## Scope / follow-ups (intentionally out)

- **Claude Code only** for now — the editor matrix (Cursor/VS Code/etc.) like the scanner installer is a fast-follow.
- **Not folded into the interactive install wizard** (`install_interactive.go`) — one-shot command for now.
- Same-variant **cross-environment** installs are allowed (they use `-dev`/`-stage`-suffixed commands by design and don't collide).

Refs PPSC-1150