### PR TITLE
fix(scan): close temp tarball handle before docker/podman save [PPSC-1157]

### DIFF
--- a/internal/scan/image/helpers_test.go
+++ b/internal/scan/image/helpers_test.go
@@ -2,7 +2,9 @@ package image
 
 import (
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -327,4 +329,52 @@ func TestDeterminePullBehavior(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateExportedTarball(t *testing.T) {
+	t.Run("empty tarball is rejected with an actionable error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "empty.tar")
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatalf("failed to write empty test file: %v", err)
+		}
+
+		_, err := validateExportedTarball(path, "docker", "testapp:1.0")
+		if err == nil {
+			t.Fatal("expected an error for an empty tarball, got nil")
+		}
+		if !strings.Contains(err.Error(), "empty tarball") {
+			t.Errorf("expected error to mention empty tarball, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "testapp:1.0") {
+			t.Errorf("expected error to name the image, got: %v", err)
+		}
+	})
+
+	t.Run("non-empty tarball returns its size", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "nonempty.tar")
+		content := []byte("not a real tar, just needs bytes")
+		if err := os.WriteFile(path, content, 0o600); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+
+		size, err := validateExportedTarball(path, "docker", "testapp:1.0")
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if size != int64(len(content)) {
+			t.Errorf("expected size %d, got %d", len(content), size)
+		}
+	})
+
+	t.Run("missing file returns a stat error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "does-not-exist.tar")
+
+		_, err := validateExportedTarball(path, "docker", "testapp:1.0")
+		if err == nil {
+			t.Fatal("expected an error for a missing file, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to stat exported image") {
+			t.Errorf("expected stat error, got: %v", err)
+		}
+	})
 }

--- a/internal/scan/image/image.go
+++ b/internal/scan/image/image.go
@@ -106,10 +106,17 @@ func (s *Scanner) ScanImage(ctx context.Context, imageName string) (*model.ScanR
 		return nil, fmt.Errorf("failed to create temp file: %w", err)
 	}
 	tmpFileName := tmpFile.Name()
+	// Close immediately: we only need a unique path. Keeping our own handle
+	// open while the external `docker save`/`podman save` process writes to
+	// the same path is unnecessary and, on Windows, risks a sharing
+	// violation or a save that appears to succeed but writes nothing.
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpFileName)
+		return nil, fmt.Errorf("failed to create temp file: %w", err)
+	}
 
 	// Ensure cleanup always runs, even on context cancellation
 	defer func() {
-		_ = tmpFile.Close()
 		_ = os.Remove(tmpFileName)
 	}()
 
@@ -254,6 +261,12 @@ func (s *Scanner) exportImage(ctx context.Context, imageName, outputPath string)
 		return err
 	}
 
+	debug := s.client.IsDebug()
+	if debug {
+		fmt.Fprintf(os.Stderr, "\n=== DEBUG: exportImage runtime=%s image=%q pull_policy=%q output=%q ===\n",
+			dockerCmd, imageName, s.pullPolicy, outputPath)
+	}
+
 	styles := output.GetStyles()
 
 	// Determine pull behavior based on policy
@@ -261,6 +274,9 @@ func (s *Scanner) exportImage(ctx context.Context, imageName, outputPath string)
 	shouldPull, err := determinePullBehavior(s.pullPolicy, localExists)
 	if err != nil {
 		return fmt.Errorf("image %q: %w", imageName, err)
+	}
+	if debug {
+		fmt.Fprintf(os.Stderr, "=== DEBUG: local_exists=%t should_pull=%t ===\n", localExists, shouldPull)
 	}
 
 	if shouldPull {
@@ -282,6 +298,7 @@ func (s *Scanner) exportImage(ctx context.Context, imageName, outputPath string)
 			styles.Bold.Render(imageName))
 	}
 
+	saveStart := time.Now()
 	// armis:ignore cwe:94 reason:dockerCmd from getDockerCommand (hardcoded docker/podman); imageName validated by validateImageName()
 	// armis:ignore cwe:78 reason:dockerCmd validated by validateDockerCommand allowlist; imageName validated by validateImageName; outputPath is temp file
 	saveCmd := exec.CommandContext(ctx, dockerCmd, "save", "-o", outputPath, imageName) //nolint:gosec // G204: dockerCmd is validated, imageName is validated, outputPath is controlled
@@ -289,6 +306,27 @@ func (s *Scanner) exportImage(ctx context.Context, imageName, outputPath string)
 	saveCmd.Stderr = os.Stderr
 	if err := saveCmd.Run(); err != nil {
 		return fmt.Errorf("failed to save image: %w", err)
+	}
+	if debug {
+		fmt.Fprintf(os.Stderr, "=== DEBUG: %s save exited 0 after %s ===\n", dockerCmd, time.Since(saveStart).Round(time.Millisecond))
+	}
+
+	// `docker save`/`podman save` can exit 0 while writing nothing (observed
+	// on Windows). Catch it here with an actionable message instead of
+	// letting the generic tarball-format check fail later with no context
+	// about which command produced the empty file.
+	info, err := os.Stat(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to stat exported image: %w", err)
+	}
+	if debug {
+		fmt.Fprintf(os.Stderr, "=== DEBUG: exported tarball %q size=%d bytes ===\n", outputPath, info.Size())
+	}
+	if info.Size() == 0 {
+		return fmt.Errorf(
+			"%s save produced an empty tarball for %q; retry, or verify the %s daemon can access the image, or use --tarball with a pre-exported image",
+			dockerCmd, imageName, dockerCmd,
+		)
 	}
 
 	return nil

--- a/internal/scan/image/image.go
+++ b/internal/scan/image/image.go
@@ -112,7 +112,7 @@ func (s *Scanner) ScanImage(ctx context.Context, imageName string) (*model.ScanR
 	// violation or a save that appears to succeed but writes nothing.
 	if err := tmpFile.Close(); err != nil {
 		_ = os.Remove(tmpFileName)
-		return nil, fmt.Errorf("failed to create temp file: %w", err)
+		return nil, fmt.Errorf("failed to close temp file: %w", err)
 	}
 
 	// Ensure cleanup always runs, even on context cancellation
@@ -311,25 +311,35 @@ func (s *Scanner) exportImage(ctx context.Context, imageName, outputPath string)
 		fmt.Fprintf(os.Stderr, "=== DEBUG: %s save exited 0 after %s ===\n", dockerCmd, time.Since(saveStart).Round(time.Millisecond))
 	}
 
-	// `docker save`/`podman save` can exit 0 while writing nothing (observed
-	// on Windows). Catch it here with an actionable message instead of
-	// letting the generic tarball-format check fail later with no context
-	// about which command produced the empty file.
-	info, err := os.Stat(outputPath)
+	size, err := validateExportedTarball(outputPath, dockerCmd, imageName)
 	if err != nil {
-		return fmt.Errorf("failed to stat exported image: %w", err)
+		return err
 	}
 	if debug {
-		fmt.Fprintf(os.Stderr, "=== DEBUG: exported tarball %q size=%d bytes ===\n", outputPath, info.Size())
-	}
-	if info.Size() == 0 {
-		return fmt.Errorf(
-			"%s save produced an empty tarball for %q; retry, or verify the %s daemon can access the image, or use --tarball with a pre-exported image",
-			dockerCmd, imageName, dockerCmd,
-		)
+		fmt.Fprintf(os.Stderr, "=== DEBUG: exported tarball %q size=%d bytes ===\n", outputPath, size)
 	}
 
 	return nil
+}
+
+// validateExportedTarball stats the tarball produced by `docker save`/`podman
+// save` and rejects it if empty. `docker save`/`podman save` can exit 0 while
+// writing nothing (observed on Windows) — this catches that case with an
+// actionable message instead of letting the generic downstream
+// tarball-format check fail with no context about which command produced
+// the empty file.
+func validateExportedTarball(outputPath, dockerCmd, imageName string) (int64, error) {
+	info, err := os.Stat(outputPath)
+	if err != nil {
+		return 0, fmt.Errorf("failed to stat exported image: %w", err)
+	}
+	if info.Size() == 0 {
+		return 0, fmt.Errorf(
+			"%s save produced an empty tarball for %q; retry, or verify the %s runtime can access the image, or use --tarball with a pre-exported image",
+			dockerCmd, imageName, dockerCmd,
+		)
+	}
+	return info.Size(), nil
 }
 
 // IsDockerAvailable reports whether a container runtime (Docker or Podman) is

--- a/internal/scan/image/image.go
+++ b/internal/scan/image/image.go
@@ -298,7 +298,10 @@ func (s *Scanner) exportImage(ctx context.Context, imageName, outputPath string)
 			styles.Bold.Render(imageName))
 	}
 
-	saveStart := time.Now()
+	var saveStart time.Time
+	if debug {
+		saveStart = time.Now()
+	}
 	// armis:ignore cwe:94 reason:dockerCmd from getDockerCommand (hardcoded docker/podman); imageName validated by validateImageName()
 	// armis:ignore cwe:78 reason:dockerCmd validated by validateDockerCommand allowlist; imageName validated by validateImageName; outputPath is temp file
 	saveCmd := exec.CommandContext(ctx, dockerCmd, "save", "-o", outputPath, imageName) //nolint:gosec // G204: dockerCmd is validated, imageName is validated, outputPath is controlled
@@ -322,12 +325,11 @@ func (s *Scanner) exportImage(ctx context.Context, imageName, outputPath string)
 	return nil
 }
 
-// validateExportedTarball stats the tarball produced by `docker save`/`podman
-// save` and rejects it if empty. `docker save`/`podman save` can exit 0 while
-// writing nothing (observed on Windows) — this catches that case with an
-// actionable message instead of letting the generic downstream
-// tarball-format check fail with no context about which command produced
-// the empty file.
+// validateExportedTarball stats the tarball produced by the save command and
+// rejects it if empty. `docker save`/`podman save` can exit 0 while writing
+// nothing (observed on Windows) — this catches that case with an actionable
+// message instead of letting the generic downstream tarball-format check
+// fail with no context about which command produced the empty file.
 func validateExportedTarball(outputPath, dockerCmd, imageName string) (int64, error) {
 	info, err := os.Stat(outputPath)
 	if err != nil {


### PR DESCRIPTION
## Summary
- On Windows, `armis-cli scan image <name>:<tag>` failed with `invalid tarball: tarball "armis-image-*.tar" is empty` — `docker save`/`podman save` exited 0 but wrote nothing.
- Root cause: `ScanImage` kept its own handle on the temp tarball open (only closed in a deferred cleanup that ran after the entire scan) while `docker save`/`podman save`, a separate process, wrote to the same path. Unix tolerates concurrent opens to the same path; Windows does not, causing the save to silently write nothing.
- Confirmed independently by Sol Ben Zeev and Chris Hamill in Slack: `docker save` externally + `--tarball` worked fine, isolating the bug to the CLI's internal export step.

## Changes
- Close the temp file handle immediately after `os.CreateTemp` returns, before `exportImage` shells out to `docker save`/`podman save`.
- Add an explicit post-export empty-tarball check in `exportImage` with an actionable error naming the runtime and image, instead of relying on the generic downstream `ValidateTarballFormat` error.
- Add `--debug` instrumentation to the export step (runtime chosen, pull decision, save duration, exported tarball size) so a future regression is diagnosable without a live Windows repro.

Jira: PPSC-1157

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/scan/image/...` (all pass)
- [x] `golangci-lint run ./internal/scan/image/...` (0 issues)
- [ ] Verify on a real Windows machine per the original repro steps (`.\armis-cli.exe scan image <name>:<tag> --debug`)