### PR TITLE
PPSC-1177: fix SSO-SETUP scope list and Okta groups claim guidance

### DIFF
--- a/docs/SSO-SETUP.md
+++ b/docs/SSO-SETUP.md
@@ -47,7 +47,7 @@ Create a **confidential OIDC / OAuth2 web application** in your IdP and configur
 - **Redirect URI:** `<your-region-host>/oauth2/device/callback`
   (e.g. `https://moose.armis.com/oauth2/device/callback`, or the `eu.` host for EU).
 - **Grant type:** Authorization Code.
-- **Scopes:** `openid`, `email`, `profile`, `groups`.
+- **Scopes:** `openid`, `email`, `profile`.
 - **Groups claim:** include the user's group memberships in the token under a
   claim (commonly `groups`). Armis uses this to assign each user's role.
 
@@ -59,7 +59,7 @@ Provider-specific notes (follow your IdP's own docs for the current UI):
 
 - **Okta** — Applications → Create App Integration → OIDC / Web Application. Issuer
   is your org URL (`https://<org>.okta.com`). Add a `groups` claim to the ID token
-  and assign the relevant groups to the app.
+  set to emit **Always**, and assign the relevant groups to the app.
 - **Microsoft Entra ID** — App registrations → New registration (platform: Web).
   Issuer is `https://login.microsoftonline.com/<tenant-guid>/v2.0`. Add a groups
   claim under Token configuration — Entra emits **group object IDs**, so use those


### PR DESCRIPTION
## Related Issue

* [PPSC-1177](https://armis-security.atlassian.net/browse/PPSC-1177)

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] Documentation update
* [ ] Refactoring (no functional changes)
* [ ] Performance improvement

## Problem

The `docs/SSO-SETUP.md` guide listed `groups` as a requested OIDC scope (`openid`, `email`, `profile`, `groups`). `groups` is not a standard OIDC scope — group membership is delivered as an ID-token **claim** configured on the IdP, not requested via a scope. Requesting it caused Okta to reject the entire authorization with `invalid_scope`, breaking SSO login for Okta tenants.

The doc was also internally contradictory: it listed `groups` as a scope to request, while correctly instructing admins to configure `groups` as a token claim in Okta/Entra/Keycloak.

## Solution

- Removed `groups` from the listed OIDC scopes (now `openid`, `email`, `profile` only).
- Added a note to the Okta instructions clarifying that the `groups` claim must be set to emit **Always** (not gated on a specific scope), so it is included in the token even though `groups` is no longer a requested scope.

The API-controller fix (removing `groups` from `OIDC_DEFAULT_SCOPES` in `constants.py`) is handled in the Project-Moose repo.

## Testing

### Automated Tests

* [ ] Unit tests added/updated
* [ ] Integration tests added/updated
* [x] All tests passing locally

### Manual Testing

Documentation-only change. Verified by reading the updated `docs/SSO-SETUP.md` to confirm the scope list and Okta claim instructions are consistent and accurate.

## Reviewer Notes

No code changes — docs only. The Okta "Always" note is the key addition: without it, an admin who followed the old guide (claim gated on the `groups` scope) would silently stop receiving the claim after the API-controller fix removes `groups` from the requested scopes.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] Documentation updated (if needed)
* [ ] Breaking changes documented (if applicable)
* [x] No new warnings generated

[PPSC-1177]: https://armis-security.atlassian.net/browse/PPSC-1177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ