### PR TITLE
Updated readme for scanning sboms

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Enterprise-grade CLI for static application security scanning with Armis Cloud. 
 
 ## Features
 
-- Scan repositories and container images
+- Scan repositories, container images, and pre-existing SBOMs
 - Multiple output formats: human, JSON, SARIF, JUnit XML
 - **SBOM generation**: Generate CycloneDX Software Bill of Materials
 - **VEX generation**: Generate Vulnerability Exploitability eXchange documents
@@ -475,7 +475,7 @@ Invoke-WebRequest -Uri "https://github.com/ArmisSecurity/armis-cli/releases/late
 --debug                 Enable debug mode for detailed API responses
 ```
 
-> The `--sbom`, `--vex`, `--sbom-output`, and `--vex-output` flags are specific to the `scan` commands — see [Scan Repository](#scan-repository).
+> The `--sbom`, `--vex`, `--sbom-output`, and `--vex-output` flags are specific to the `scan` commands — see [Scan Repository](#scan-repository). Their meaning differs on [Scan SBOM](#scan-sbom), which takes an SBOM as input rather than generating one.
 
 ### Scan Repository
 
@@ -556,6 +556,48 @@ armis-cli scan image nginx:latest --pull=always
 # Never pull, require local image (for air-gapped environments)
 armis-cli scan image nginx:latest --pull=never
 ```
+
+### Scan SBOM
+
+Scans a **pre-existing** CycloneDX SBOM you already have — instead of generating one from source — and reports the vulnerabilities it exposes. The input may be a single SBOM file (`.json`/`.xml`), a directory of SBOMs, or a pre-built `.tar`/`.tar.gz`/`.tgz`.
+
+```bash
+armis-cli scan sbom [path]
+```
+
+**Size Limit**: 512MB
+**Examples**:
+
+```bash
+# Single SBOM file
+armis-cli scan sbom ./sbom.json
+
+# Directory of SBOMs
+armis-cli scan sbom ./sboms/
+
+# Pre-built tarball
+armis-cli scan sbom ./inventory.tar.gz
+
+# Also download the generated OpenVEX document
+armis-cli scan sbom ./sbom.json --vex-output ./out/vex.json
+
+# Custom path for the raw-findings JSON dump
+armis-cli scan sbom ./sbom.json --sbom-output ./out/findings.json
+```
+
+The backend picks the right scanner automatically based on the SBOM's contents — no flags needed:
+
+- **CPE-based SBOMs** (asset/inventory SBOMs like Torizon, whose components carry explicit CPEs) are matched against NVD directly.
+- **purl-based SBOMs** (npm/NuGet/PyPI-style application manifests) are matched via Trivy → deps.dev.
+
+Either way, findings are printed as a table (same shape as `scan repo` / `scan image`) and gate on `--fail-on`.
+
+> **`--sbom-output` and `--vex-output` mean something different here.** On `scan repo` / `scan image` they name where a *generated* SBOM/VEX is written. On `scan sbom` the SBOM is the *input*, so:
+>
+> - `--sbom-output` sets the path for the raw-findings JSON dump (default: `.armis/<artifact>-sbom.json`).
+> - `--vex-output` opts into OpenVEX generation and sets its path (default: `.armis/<artifact>-vex.json`). Without it, no VEX is requested.
+>
+> `--sbom` is a no-op on `scan sbom` (you can't generate an SBOM from an SBOM) and prints a warning if passed.
 
 ### Other Commands
 


### PR DESCRIPTION
## Related Issue

* [PPSC-971](https://armis-security.atlassian.net/browse/PPSC-971)
* Documents the `scan sbom` command shipped in #269 and unified in #276.

## Type of Change

* [x] Documentation update

## Problem

The `armis-cli scan sbom <path>` command shipped (introduced in #269, then unified into its findings-first form in #276) but was never documented in the README. Users had no way to discover it, and — more importantly — no way to learn that `--sbom-output` / `--vex-output` mean something *different* on `scan sbom` than on `scan repo` / `scan image`:

* On `scan repo` / `scan image` those flags name where a **generated** SBOM/VEX is written.
* On `scan sbom` the SBOM is the **input**, so `--sbom-output` is repurposed as the raw-findings JSON dump path, `--vex-output` opts into VEX generation, and `--sbom` is a no-op.

Without docs, the divergent flag semantics were a silent trap.

## Solution

Documentation-only change to `README.md`:

1. **Features list** — updated to "Scan repositories, container images, **and pre-existing SBOMs**".
2. **Global-flags note** — the existing `--sbom`/`--vex`/`--sbom-output`/`--vex-output` callout now points at the new **Scan SBOM** section and flags that their meaning differs there.
3. **New "Scan SBOM" section** under Usage (after Scan Container Image), covering:
   * What it does — scans a **pre-existing** CycloneDX SBOM (single file, directory, or pre-built `.tar`/`.tar.gz`/`.tgz`) rather than generating one.
   * 512MB size limit (`sbom.MaxSBOMSize`) and worked examples.
   * Backend auto-routing — CPE-based SBOMs → NVD, purl-based SBOMs → Trivy → deps.dev — with findings printed as a table and gated by `--fail-on` (the findings-first behavior from #276).
   * A callout explaining the repurposed `--sbom-output` / `--vex-output` / `--sbom` semantics and their `.armis/<artifact>-*.json` defaults.

Content was verified against the current code (`internal/cmd/scan_sbom.go`, `internal/scan/sbom/sbom.go`), not just the source PR descriptions, so it reflects the shipped behavior.

## Testing

### Automated Tests

* [ ] Unit tests added/updated — n/a (docs only)
* [ ] Integration tests added/updated — n/a (docs only)
* [x] All tests passing locally — no code changed

### Manual Testing

* Reviewed the rendered Markdown; the new `[Scan SBOM](#scan-sbom)` anchor resolves and the section renders correctly.
* Cross-checked every documented flag, default path, and size limit against `internal/cmd/scan_sbom.go` and `internal/scan/sbom/sbom.go`.

## Reviewer Notes

* **Docs only** — no code, no behavior change.
* The Table of Contents lists only top-level `##` sections; the existing `### Scan Repository` / `### Scan Container Image` subsections are not in it, so `### Scan SBOM` is intentionally kept out of the ToC for consistency.
* No "breaking change" note was added for the ~one-week window where `scan sbom` users relied on implicit VEX download (VEX became opt-in in #276); happy to add one if reviewers want it called out.

## Checklist

* [x] Code follows project style guidelines
* [x] Pre-commit hooks pass
* [x] Self-review performed
* [x] Documentation updated (if needed)
* [x] Breaking changes documented (if applicable) — n/a
* [x] No new warnings generated


[PPSC-971]: https://armis-security.atlassian.net/browse/PPSC-971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ